### PR TITLE
BUG/TST: Points were not removed from memory.

### DIFF
--- a/trackpy/tests/test_more.py
+++ b/trackpy/tests/test_more.py
@@ -43,6 +43,19 @@ def test_memory():
     assert len(t5) == 2, len(t5)
 
 
+def test_memory_removal():
+    """BUG: A particle remains in memory after its Track is resumed, leaving two
+    copies that can independently pick up desinations, leaving two Points in the
+    same Track in a single level."""
+    levels  = []
+    levels.append([PointND(0, [1, 1]), PointND(0, [4, 1])])  # two points
+    levels.append([PointND(1, [1, 1])])  # one vanishes, but is remembered
+    levels.append([PointND(2, [1, 1]), PointND(2, [2, 1])]) # resume Track in memory
+    levels.append([PointND(3, [1, 1]), PointND(3, [2, 1]), PointND(3, [4, 1])])
+    t = link(levels, 5, hash_generator((10, 10), 1), memory=2)
+    assert len(t) == 3, len(t)
+
+
 def test_box_size():
     """No matter what the box size, there should be one track, and it should
     contain all the points."""


### PR DESCRIPTION
When a Track was put in memory and then "found" again, it remained in memory (mem_set). Therefore, two Points could link the same track in the same frame -- one via the point in memory, and one via the new point at which the Track was found again.

See test case for an example of the problem. The PointND(3, [4, 1]) _should_ start a new Track, but before this change it was attached to the same track, in the same level, as Point(3, [2, 1]). This is obviously not OK.

Also, some particles were not being added to memory that should have been. I believe this is the minimal change that treats memory correctly.
