### PR TITLE
Refine with optional numba

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -75,8 +75,8 @@ def make_fig(func):
 
 @make_axes
 def plot_traj(traj, colorby='particle', mpp=1, label=False, superimpose=None, 
-       cmap=mpl.cm.winter, ax=None):
-    """Plot traces of trajectories for each particle.
+       cmap=None, ax=None):
+    """Plot traces of trajectories for each probe.
     Optionally superimpose it on a frame from the video.
 
     Parameters


### PR DESCRIPTION
My numba refine branch is passing all tests with and without numba. It's ready for more eyes when you have a moment.

You can switch numba on and off in the same session by calling `tp.enable_numba()` and `tp.disable_numba()`. I imagine most users will want to rely on numba if they have it, so numba is enabled by default if numba can be imported. But being able to switch is handy for testing.

If the numba linker shows significant speedups even without numba, running in vanilla numpy, it wouldn't be hard to hook it into this same enable/disable system.

These are the final speedups on a noise image and image of colloids respectively:

Master:
    1 loops, best of 3: 1.37 s per loop
    1 loops, best of 3: 1.93 s per loop

Numba-ed:
    1 loops, best of 3: 830 ms per loop
    1 loops, best of 3: 1.13 s per loop

Notes:
- I'm finding array comparison to be buggy. I worked around this by defining `numba_less` and `numba_greater`, like `np.less` and `np.greater`. Do you know why those functions (and also < and > ) are giving me trouble?
- I gather I could get a larger speedup by unfolding some loops. But doing so would make everything slower when run without numba, so this seems like a reasonable compromise to start. If you we want to push numba as far as possible, we may need to maintain to different versions of _refine. That seems like a recipe for trouble, though. Any opinions/ideas?
