### PR TITLE
Add linker for an iterable of DataFrames

### DIFF
--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -59,7 +59,7 @@ class CommonTrackingTests(object):
         expected['particle'] = np.zeros(N)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f, 5)
+        actual_iter = self.link_df_iter(f, 5, hash_size=(10, 2))
         assert_frame_equal(actual_iter, expected)
 
     def test_two_isolated_steppers(self):
@@ -324,7 +324,7 @@ class CommonTrackingTests(object):
         expected['particle'] = np.zeros(N)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
-        actual = self.link_df_iter(f, 5)
+        actual = self.link_df_iter(f, 5, hash_size=(6, 2))
         assert_frame_equal(actual, expected)
 
     def test_blank_frame_no_memory(self):
@@ -336,7 +336,7 @@ class CommonTrackingTests(object):
         expected['particle'] = np.zeros(N)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
-        actual = self.link_df_iter(f, 5)
+        actual = self.link_df_iter(f, 5, hash_size=(10, 10))
         assert_frame_equal(actual, expected)
         # This doesn't error, but we might wish it would
         # give the particle a new ID after the gap. It just


### PR DESCRIPTION
It makes sense to combine 2 great features --- DataFrame support and linker-as-generator --- into one function. This also might help support link_on_disk. I had to make a few internal changes (and track down a bug in #55), but I think this is the right way to do it. I am very open to discussion, however!

The only major problem with this PR right now is testing. I added testing for link_df_iter() as another instance of the generic test class, but it really should be called from most of the individual test cases. This would solve the other problem: we can't set the hash size if we've only seen the first frame. So some of the tests of link_df_iter() with a BTree are skipped right now.

I'd like to drop the auto-hash_size code from link_df_iter(), since it is likely to fail and only invites confusion. I suspect that we'll be making KDTree the default pretty soon anyhow. So expect some incremental updates to this PR.
