### PR TITLE
ENH: Explicitly check for black image and fail informatively.

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -41,6 +41,8 @@ def local_maxima(image, radius, separation, percentile=64):
 
     # Compute a threshold based on percentile.
     not_black = image[np.nonzero(image)]
+    if len(not_black) == 0:
+        raise ValueError("Image is completely black.")
     threshold = stats.scoreatpercentile(not_black, percentile)
     ndim = image.ndim
 


### PR DESCRIPTION
The problem in #56 was in pims, but trackpy made it confusing by failing inside `scipy.stats.scoreatpercentile`, like so:

```
In [1]: black_image = np.zeros((100, 100))

In [2]: import trackpy as tp

In [3]: tp.locate(black_image, 5)
ValueError: operands could not be broadcast together with shapes (0) (2) 
```

The problem was in pims, but clearly trackpy could be handling this error more nicely. With this PR, we get instead:

```
In [3]: tp.locate(black_image, 5)
ValueError: Image is completely black.
```
