### PR TITLE
DOC/BLD: Need yaml for logging, but not yaml_serialize. Also, specify dep versions in README.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ python:
   - 2.7
 
 env:
-  - DEPS="numpy=1.7.1 scipy=0.13.0 nose matplotlib=1.3 pandas=0.13.0 PIL"
-  - DEPS="numpy=1.7.1 scipy=0.13.0 nose matplotlib=1.3 pandas=0.13.0 PIL numba=0.11"
+  - DEPS="numpy=1.7.1 scipy=0.13.0 nose matplotlib=1.3 pandas=0.13.0 PIL pyyaml"
+  - DEPS="numpy=1.7.1 scipy=0.13.0 nose matplotlib=1.3 pandas=0.13.0 PIL pyyaml numba=0.11"
 
 install:
   - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - conda install --yes $DEPS
 # TODO Remove these once setup.py handles dependencies correctly.
-  - pip install -e git+https://github.com/soft-matter/yaml-serialize#egg=yaml_serialize
   - pip install -e git+https://github.com/soft-matter/pims#egg=pims
   - pip install -e svn+http://pylibtiff.googlecode.com/svn/trunk/
   - python setup.py install

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Open a command prompt. That's "Terminal" on a Mac, and
 "Start > Applications > Command Prompt" on Windows. Type these
 lines:
 
+    conda install numpy=1.7.1 scipy=0.13.0 matplotlib=1.3 pandas=0.13.0 numba=0.11 PIL pyyaml
     conda install pip
     pip install http://github.com/soft-matter/pims/zipball/master
     pip install http://github.com/soft-matter/trackpy/zipball/master
@@ -111,6 +112,7 @@ Essential Dependencies:
   * [``scipy``](http://www.scipy.org/)
   * [``matplotlib``](http://matplotlib.org/)
   * [``pandas``](http://pandas.pydata.org/pandas-docs/stable/overview.html)
+  * [``pyyaml``](http://pyyaml.org/)
 
 
 You will also need the image- and video-reader pims, which is, like trackpy
@@ -143,7 +145,8 @@ Optional Dependencies:
       HDF5 file. This is included with Anaconda.
   * [``numba``] for accelerated feature-finding and linking. This is
       included with Anaconda. Installing it any other way is difficult;
-      we recommend sticking with Anaconda.
+      we recommend sticking with Anaconda. Currently we support v0.11
+      but not v0.12.
 
 Pims has its own optional dependencies for reading various formats. You
 can read what you need for each format


### PR DESCRIPTION
In the wake of the Travis mess, I think the default conda install will not work because of #78 . These new installation instructions give a `conda install ...` command with version numbers that work, same as those tested on Travis.

If #78 is fixed, default conda should work again, and we can revert to the simple instructions if we want. But it might be better to stay specific -- this could happen again on the next conda update.
