### PR TITLE
BLD: Now compatible with Numba 0.12

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -338,7 +338,7 @@ def _numba_refine(raw_image, image, radius, coords, max_iterations,
                     if oc > SHIFT_THRESH:
                         new_coord[dim] += 1
                     elif oc < - SHIFT_THRESH:
-                        new_coord[dim] -= 1
+                        new_coord[dim] += -1
                     # Don't move outside the image!
                     if new_coord[dim] < radius:
                         new_coord[dim] = radius

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -1168,7 +1168,7 @@ def _numba_subnet_norecur(ncands, candsarray, dists2array, cur_assignments, cur_
                         delta = 1
         if delta == -1:
             if j > 0:
-                j -= 1
+                j += -1
                 tmp_assignments[j] += 1 # Try the next candidate at this higher level
                 continue
             else:

--- a/trackpy/try_numba.py
+++ b/trackpy/try_numba.py
@@ -7,11 +7,14 @@ import logging
 
 def _hush_llvm():
     # Necessary for current stable release 0.11.
-    # Not necessary in master, probably future release will fix.
+    # Not necessary (and unimplemented) in numba >= 0.12 (February 2014)
     # See http://stackoverflow.com/a/20663852/1221924
-    import numba.codegen.debug
-    llvmlogger = logging.getLogger('numba.codegen.debug')
-    llvmlogger.setLevel(logging.INFO)
+    try:
+        import numba.codegen.debug
+        llvmlogger = logging.getLogger('numba.codegen.debug')
+        llvmlogger.setLevel(logging.INFO)
+    except ImportError:
+        pass
 
 
 ENABLE_NUMBA_ON_IMPORT = True


### PR DESCRIPTION
Addresses #78. Now tests OK on old anaconda (numba 0.11) and new (numba 0.12).

There were major changes to the numba compiler, so that in-place subtraction (-=) is currently not supported. But in-place addition still is. Probably a temporary condition.

As predicted, silencing debug messages is no longer necessary, and in fact raises an error.
