### PR TITLE
Restore limited numba functionality for numba >= 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ Optional Dependencies:
       HDF5 file. This is included with Anaconda.
   * [``numba``] for accelerated feature-finding and linking. This is
       included with Anaconda. Installing it any other way is difficult;
-      we recommend sticking with Anaconda. Currently we support v0.11
-      but not v0.12.
+      we recommend sticking with Anaconda. Note that `numba` v0.12.0
+      (included with Anaconda 1.8.0) has a bug and will not work at all;
+      if you have this version, you should update Anaconda.
 
 Pims has its own optional dependencies for reading various formats. You
 can read what you need for each format

--- a/trackpy/try_numba.py
+++ b/trackpy/try_numba.py
@@ -22,6 +22,7 @@ ENABLE_NUMBA_ON_IMPORT = False
 _registered_functions = list()  # functions that can be numba-compiled
 
 NUMBA_AVAILABLE = False
+
 try:
     import numba
 except ImportError:
@@ -30,13 +31,16 @@ except ImportError:
 else:
     v = numba.__version__
     major, minor, micro = v.split('.')
-    if major == '0' and minor == '11':
+    if major == '0' and minor == '12' and micro == '0':
+        # Importing numba code will take forever. Disable numba.
+        message = ("Trackpy does not support numba 0.12.0. "
+                   "Version {0} is currently installed. Trackpy will run "
+                   "with numba disabled. Please downgrade numba to version "
+                   "0.11, or update to latest version.".format(v))
+        warn(message)
+    else:
         NUMBA_AVAILABLE = True
         _hush_llvm()
-    else:
-        message = ("Trackpy currently supports numba 0.11* only. "
-                  "Version {0} is currently installed. Trackpy will run "
-                  "with numba disabled.".format(v))
 
 
 class RegisteredFunction(object):


### PR DESCRIPTION
try_numba now treats numba 0.12.0 as the exceptional case; merely issues a warning for 0.12.1+ that feature-finding will be slow.
