### PR TITLE
BUG/PERF: Re-enabled numba usage by default.

### DIFF
--- a/trackpy/try_numba.py
+++ b/trackpy/try_numba.py
@@ -18,7 +18,7 @@ def _hush_llvm():
         pass
 
 
-ENABLE_NUMBA_ON_IMPORT = False
+ENABLE_NUMBA_ON_IMPORT = True
 _registered_functions = list()  # functions that can be numba-compiled
 
 NUMBA_AVAILABLE = False


### PR DESCRIPTION
Previously ( #88 ) forgot to re-enable default usage of numba. Tests were fine but benchmarks were terrible. We now have correct behavior for numba 0.11, 0.12.0, and 0.12.1.

For the record, the output of `benchmarks/numba_benchmarks.ipy` is, with numba 0.12.1,

```
10x: Locate using Python Engine with Fast Settings (Sloppy)
1 loops, best of 3: 2.47 s per loop
1x: Locate using Numba Engine with Default Settings (Accurate)
1 loops, best of 3: 289 ms per loop
10x: Locate using Numba Engine with Default Settings (Accurate)
1 loops, best of 3: 2.98 s per loop
10x: Locate using Numba Engine with Fast Settings (Sloppy)
1 loops, best of 3: 1.22 s per loop
```

Here is the same code on numba 0.11:

```
10x: Locate using Python Engine with Fast Settings (Sloppy)
1 loops, best of 3: 2.4 s per loop
1x: Locate using Numba Engine with Default Settings (Accurate)
1 loops, best of 3: 286 ms per loop
10x: Locate using Numba Engine with Default Settings (Accurate)
1 loops, best of 3: 3.05 s per loop
10x: Locate using Numba Engine with Fast Settings (Sloppy)
1 loops, best of 3: 1.19 s per loop
```

And here is an older version of the code (without short-circuiting added back in), commit 6a06806, on numba 0.11:

```
10x: Locate using Python Engine with Fast Settings (Sloppy)
1 loops, best of 3: 3.2 s per loop
1x: Locate using Numba Engine with Default Settings (Accurate)
1 loops, best of 3: 362 ms per loop
10x: Locate using Numba Engine with Default Settings (Accurate)
1 loops, best of 3: 3.77 s per loop
10x: Locate using Numba Engine with Fast Settings (Sloppy)
1 loops, best of 3: 1.89 s per loop
```
