### PR TITLE
CLN/PERF: Do not import matplotlib at the module level.

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -1,4 +1,3 @@
-
 from __future__ import division
 import warnings
 import numpy as np
@@ -7,7 +6,6 @@ from scipy import ndimage
 from scipy import stats
 from scipy.spatial import cKDTree
 from pandas import DataFrame, Series
-import matplotlib.pyplot as plt  # for walkthrough
 
 from trackpy import uncertainty
 from trackpy.preprocessing import bandpass, scale_to_gamut
@@ -217,6 +215,7 @@ def _refine(raw_image, image, radius, coords, max_iterations,
         final_coords[feat] = cm_i[..., ::-1]
 
         if walkthrough:
+            import matplotlib.pyplot as plt
             plt.imshow(neighborhood)
 
         # Characterize the neighborhood of our final centroid.

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -4,8 +4,6 @@ from functools import wraps
 import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 import logging
 import motion
 
@@ -23,6 +21,8 @@ def make_axes(func):
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
+        import matplotlib as mpl
+        import matplotlib.pyplot as plt
         if kwargs.get('ax') is None:
             kwargs['ax'] = plt.gca()
             # Delete legend keyword so remaining ones can be passed to plot().
@@ -45,6 +45,8 @@ def make_axes(func):
 
 def make_fig(func):
     """See make_axes."""
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
     wraps(func)
     def wrapper(*args, **kwargs):
         if 'fig' not in kwargs:
@@ -57,7 +59,7 @@ def make_fig(func):
 
 @make_axes
 def plot_traj(traj, colorby='particle', mpp=1, label=False, superimpose=None,
-       cmap=mpl.cm.winter, ax=None):
+       cmap=None, ax=None):
     """Plot traces of trajectories for each particle.
     Optionally superimpose it on a frame from the video.
 
@@ -76,6 +78,12 @@ def plot_traj(traj, colorby='particle', mpp=1, label=False, superimpose=None,
     -------
     None
     """
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+
+    if cmap is None:
+        cmap = mpl.cmap.winter
+
     if (superimpose is not None) and (mpp != 1):
         raise NotImplementedError("When superimposing over an image, you " +
                                   "must plot in units of pixels. Leave " +
@@ -148,9 +156,11 @@ def annotate(centroids, image, circle_size=170, color='g',
     ------
     axes
     """
+    import matplotlib.pyplot as plt
+
     # The parameter image can be an image object or a filename.
     if isinstance(image, basestring):
-        image = plt.itpead(image)
+        image = plt.imread(image)
     if invert:
         ax.imshow(1-image, origin='upper', shape=image.shape, cmap=plt.cm.gray)
     else:
@@ -191,6 +201,8 @@ def subpx_bias(f, ax=None):
 @make_axes
 def fit(data, fits, inverted_model=False, logx=False, logy=False, ax=None,
         **kwargs):
+    import matplotlib.pyplot as plt
+
     data = data.dropna()
     x, y = data.index.values.astype('float64'), data.values
     datalines = plt.plot(x, y, 'o', label=data.name)
@@ -236,6 +248,8 @@ def plot_principal_axes(img, x_bar, y_bar, cov, ax=None):
     ax.imshow(img)
 
 def examine_jumps(data, jumps):
+    import matplotlib.pyplot as plt
+
     fig, axes = plt.subplots(len(jumps), 1)
     for i, jump in enumerate(jumps):
         roi = data.ix[jump-10:jump+10]


### PR DESCRIPTION
Closes #106.

Now, following best practice, matplotlib is never imported outside of a function. It will only be imported if one of the functions in `plots` is called, or if `locate` is used with `walkthrough=True` (which is not the default).

@RebeccaWPerry You will have to rebase #104 on this.
