### PR TITLE
ENH: Never return negative uncertainty; return NaN instead.

### DIFF
--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -8,7 +8,7 @@ from trackpy.try_numba import NUMBA_AVAILABLE
 
 import unittest
 import nose
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_almost_equal, assert_allclose, assert_equal
 from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_produces_warning)
@@ -391,6 +391,22 @@ class CommonFeatureIdentificationTests(object):
         actual = tp.feature.refine(image, image, 6, guess, characterize=False,
                                    engine=self.engine)[:, :2]
         assert_allclose(actual, expected, atol=0.1)
+
+    def test_uncertainty_failure(self):
+        self.check_skip()
+        L = 21
+        dims = (L, L + 2)  # avoid square images in tests
+        pos = np.array([7, 13])
+        cols = ['x', 'y']
+        expected = DataFrame(pos.reshape(1, -1), columns=cols)
+
+        image = 100*np.ones(dims, dtype='uint8')
+        image[:, [0, -1]] = 255
+        draw_gaussian_spot(image, pos[::-1], 4, max_value=150)
+        actual = tp.locate(image, 9, 1, preprocess=False, engine=self.engine)
+        print actual.signal, actual.ep
+        self.assertLess(np.asscalar(actual.signal), 0)
+        assert_equal(np.asscalar(actual.ep), np.nan)
 
 
 class TestFeatureIdentificationWithVanillaNumpy(

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -57,6 +57,10 @@ def static_error(features, noise, diameter, noise_size=1):
         N_S = features.join(noise, on='frame')['noise']/features['signal']
     s = 2*((diameter//2-1)/features['size'])**2
     ep = N_S*noise_size/(2*np.pi**0.5)*s/(1-np.exp(-s))
+    # It is possible for signal to be negative. In those cases, our scheme
+    # for estimating uncertainty is not workable. Instead of returning
+    # a negative value for uncertainty, return NaN.
+    ep = ep.where(ep > 0, np.nan)
     # ^ Savin & Doyle, Eq. 50
     ep.name = 'ep' # so it can be joined
     return ep


### PR DESCRIPTION
This is a work in progress.

The Savin-Doyle procedure for estimating uncertainty fails in dense systems or images with distinct background features. This often leads to 'signal' being negative. Instead of returning a negative value for the uncertainty 'ep', we should return NaN to make it clear that an uncertainty could not be estimated.

The tests for this need to be designed carefully, and this PR is not there yet.