### PR TITLE
FIX: Fix typo introduced in #112 mpl cleanup.

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -82,7 +82,7 @@ def plot_traj(traj, colorby='particle', mpp=1, label=False, superimpose=None,
     import matplotlib.pyplot as plt
 
     if cmap is None:
-        cmap = mpl.cmap.winter
+        cmap = plt.cm.winter
 
     if (superimpose is not None) and (mpp != 1):
         raise NotImplementedError("When superimposing over an image, you " +


### PR DESCRIPTION
This corrects a simple typo in #112 that broke tests locally. I am very confused by why it did not break Travis. Merging own -- this is trivial and important to keep tests alive.
