### PR TITLE
FIX/ENH: Allow locate to invert float images by assuming normalization=1

### DIFF
--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -30,10 +30,28 @@ else:
     ifftn = lambda a: pyfftw.interfaces.numpy_fft.ifftn(_maybe_align(a))
 
 
-def bandpass(image, lshort, llong, threshold=1):
+def bandpass(image, lshort, llong, threshold=None):
     """Convolve with a Gaussian to remove short-wavelength noise,
     and subtract out long-wavelength variations,
-    retaining features of intermediate scale."""
+    retaining features of intermediate scale.
+
+    Parmeters
+    ---------
+    image : ndarray
+    lshort : small-scale cutoff (noise)
+    llong : large-scale cutoff
+    threshold : float or integer
+        By default, 1 for integer images and 1/256. for float images.
+
+    Returns
+    -------
+    ndarray, the bandpassed image
+    """
+    if threshold is None:
+        if np.issubdtype(image.dtype, np.integer):
+            threshold = 1
+        else:
+            threshold = 1/256.
     if not 2*lshort < llong:
         raise ValueError("The smoothing length scale must be more" +
                          "than twice the noise length scale.")


### PR DESCRIPTION
`trackpy.locate` expects integer-type images. If it is asked to invert a float-type image (`invert=True`) it will raise. This PR allows it to accept float-type images safely.

(For performance reasons, the floats are converted to 8-bit images for the core processing. If you have higher bit depth, your images are probably not floats to begin with. In any case, you can convert them yourself beforehand.)

Notably, scikit-image's `imread` can sometimes return floats. Their implementation of `imread` is more flexible and more powerful than implementations in other packages, and it becoming more widely used. Thus, in soft-matter/pims#65, PIMS adopts skimage as a preferred (but optional) dependency. This PR should be merged before before soft-matter/pims#65.

Then I propose we tag trackpy 0.2.1 for compatibility with the soon-to-be-christened release of pims.
