### PR TITLE
Fix readthedocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - source activate testenv
   - conda install --yes $DEPS
 # TODO Remove these once setup.py handles dependencies correctly.
-  - pip install -e git+https://github.com/soft-matter/pims#egg=pims
   - pip install -e svn+http://pylibtiff.googlecode.com/svn/trunk/
   - python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ setup_parameters = dict(
     author = "Daniel Allan and Thomas Caswell",
     author_email = "dallan@pha.jhu.edu",
     url = "https://github.com/soft-matter/trackpy",
-    install_requires = ['numpy', 'scipy', 'six', 'pandas'],
+    install_requires = ['numpy', 'scipy', 'six', 'pandas',
+                        'pyyaml', 'matplotlib', 'pims'],
     packages = ['trackpy'],
     long_description = read('README.md'),
 )


### PR DESCRIPTION
Merging own changes to `setup.py` to fix the docs (#111). We are likely to get some traffic around the talk, so this needs to happen. The v0.1 docs build fine, and I never used `Mock`, so I don't think that should be necessary. Having `pims` on pip makes this easier....
