### PR TITLE
DOC: Add reminder to update version string in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -58,7 +58,7 @@ copyright = u'2010-2014, Trackpy Contributors'
 # built documents.
 #
 # The short X.Y version.
-release = '0.2.0'
+release = '0.2.1'
 version = ''
 # The full version, including alpha/beta/rc tags.
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ except ImportError:
     from numpy.distutils.core import setup
     _have_setuptools = False
 
+# Don't forget to update the "release =" line in doc/source/conf.py
 MAJOR = 0
 MINOR = 2
 MICRO = 1


### PR DESCRIPTION
Following up on #111, this updates the version in the sphinx docs to 0.2.1, and more importantly, adds a reminder to `setup.py` to further update it at release time.
