### PR TITLE
Test 3D feature-finding

### DIFF
--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -22,25 +22,37 @@ def draw_gaussian_spot(image, pos, r, max_value=None, ecc=0):
     if image.shape[0] == image.shape[1]:
         raise ValueError("For stupid numpy broadcasting reasons, don't make" +
                          "the image square.")
-    # Transpose x and y of the image shape.
-    shape = np.asarray(image.shape)
-    if image.ndim > 1:
-        shape = shape[[1, 0] + range(2, image.ndim)]
-    x, y = np.meshgrid(*np.array(map(np.arange, shape)) - pos)
+    ndim = image.ndim
+    pos = maybe_permute_position(pos)
+    coords = np.meshgrid(*np.array(map(np.arange, image.shape)) - pos,
+                         indexing='ij')
     if max_value is None:
         max_value = np.iinfo(image.dtype).max - 3
-    spot = max_value*np.exp(-((x/(1 - ecc))**2 + (y*(1 - ecc))**2)/(2*r**2))
+    if ndim == 2:
+        # Special case for 2D: implement eccentricity.
+        y, x = coords
+        spot = max_value*np.exp(
+            -((x / (1 - ecc))**2 + (y * (1 - ecc))**2)/(2*r**2))
+    else:
+        if ecc != 0:
+            raise ValueError("Eccentricity must be 0 if image is not 2D.")
+        coords = np.asarray(coords)
+        spot = max_value*np.exp(-np.sum(coords**2, 0)/(ndim*r**2))
     image += spot.astype(image.dtype)
 
 
-def draw(image, pos, value):
-    "Set pixel values in an image by specifying a position as [x, y]."
-    pos = np.asarray(pos)
-    # Transpose x and y of the position, to match image shape.
-    if image.ndim > 1:
-        pos = pos[[1, 0] + range(2, image.ndim)]
-    image[tuple(pos)] = value
+def draw_point(image, pos, value):
+    image[tuple(maybe_permute_position(pos))] = value
 
+
+def maybe_permute_position(pos):
+    ndim = len(pos)
+    if ndim == 2:
+        pos = np.asarray(pos)[[1, 0]]
+    elif ndim == 3:
+        pos = np.asarray(pos)[[2, 1, 0]]
+    return pos
+     
 
 def gen_random_locations(shape, count):
     np.random.seed(0)
@@ -70,6 +82,9 @@ class CommonFeatureIdentificationTests(object):
     def check_skip(self):
         pass
 
+    def skip_numba(self):
+        pass
+
     def test_smoke_datatypes(self):
         self.check_skip()
         SHAPE = (300, 300)
@@ -93,14 +108,21 @@ class CommonFeatureIdentificationTests(object):
     def test_maxima_in_margin(self):
         self.check_skip()
         black_image = np.ones((21, 23)).astype(np.uint8)
-        draw(black_image, [1, 1], 100)
+        draw_point(black_image, [1, 1], 100)
+        with assert_produces_warning(UserWarning):
+            f = tp.locate(black_image, 5, engine=self.engine)
+
+    def test_maxima_in_margin_3D(self):
+        self.skip_numba()
+        black_image = np.ones((21, 23, 25)).astype(np.uint8)
+        draw_point(black_image, [1, 1, 1], 100)
         with assert_produces_warning(UserWarning):
             f = tp.locate(black_image, 5, engine=self.engine)
 
     def test_all_maxima_filtered(self):
         self.check_skip()
         black_image = np.ones((21, 23)).astype(np.uint8)
-        draw(black_image, [11, 13], 10)
+        draw_point(black_image, [11, 13], 10)
         with assert_produces_warning(UserWarning):
             f = tp.locate(black_image, 5, minmass=1000,
                           engine=self.engine, preprocess=False)
@@ -155,6 +177,20 @@ class CommonFeatureIdentificationTests(object):
                            engine=self.engine)[cols]
         assert_allclose(actual, expected, atol=0.1)
 
+    def test_one_centered_gaussian_3D(self):
+        self.skip_numba()
+        L = 21
+        dims = (L, L + 2, L + 4)  # avoid square images in tests
+        pos = [7, 13, 9]
+        cols = ['x', 'y', 'z']
+        expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
+
+        image = np.ones(dims, dtype='uint8')
+        draw_gaussian_spot(image, pos, 4)
+        actual = tp.locate(image, 9, 1, preprocess=False,
+                           engine=self.engine)[cols]
+        assert_allclose(actual, expected, atol=0.1)
+
     def test_subpx_precision(self): 
         self.check_skip()
         L = 21
@@ -165,7 +201,7 @@ class CommonFeatureIdentificationTests(object):
         # one bright pixel
         pos = [7, 13]
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos, 100)
+        draw_point(image, pos, 100)
         actual = tp.locate(image, 3, 1, preprocess=False,
                            engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
@@ -176,9 +212,10 @@ class CommonFeatureIdentificationTests(object):
         pos2 = np.array([8, 13])
         pos = [7.5, 13]  # center is between pixels
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 100)
-        draw(image, pos2, 100)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 100)
+        draw_point(image, pos2, 100)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
@@ -187,17 +224,19 @@ class CommonFeatureIdentificationTests(object):
         pos2 = np.array([8, 13])
         pos = [7.25, 13]  # center is between pixels, biased left
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 100)
-        draw(image, pos2, 50)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 100)
+        draw_point(image, pos2, 50)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         pos = [7.75, 13]  # center is between pixels, biased right 
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 50)
-        draw(image, pos2, 100)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 50)
+        draw_point(image, pos2, 100)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
@@ -205,17 +244,19 @@ class CommonFeatureIdentificationTests(object):
         pos2 = np.array([7, 13])
         pos = [7, 12.25]  # center is between pixels, biased down
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 100)
-        draw(image, pos2, 50)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 100)
+        draw_point(image, pos2, 50)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         pos = [7, 12.75]  # center is between pixels, biased up 
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 50)
-        draw(image, pos2, 100)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 50)
+        draw_point(image, pos2, 100)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
@@ -226,21 +267,23 @@ class CommonFeatureIdentificationTests(object):
         pos4 = np.array([8, 13])
         pos = [7.25, 13]  # center is between pixels, biased left
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 100)
-        draw(image, pos2, 50)
-        draw(image, pos3, 100)
-        draw(image, pos4, 50)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 100)
+        draw_point(image, pos2, 50)
+        draw_point(image, pos3, 100)
+        draw_point(image, pos4, 50)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         pos = [7.75, 13]  # center is between pixels, biased right 
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 50)
-        draw(image, pos2, 100)
-        draw(image, pos3, 50)
-        draw(image, pos4, 100)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 50)
+        draw_point(image, pos2, 100)
+        draw_point(image, pos3, 50)
+        draw_point(image, pos4, 100)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
@@ -250,17 +293,19 @@ class CommonFeatureIdentificationTests(object):
         pos4 = np.array([7, 13])
         pos = [7, 12.25]  # center is between pixels, biased down
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 100)
-        draw(image, pos2, 50)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 100)
+        draw_point(image, pos2, 50)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         pos = [7, 12.75]  # center is between pixels, biased up 
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 50)
-        draw(image, pos2, 100)
-        actual = tp.locate(image, 5, 1, preprocess=False, engine=self.engine)[cols]
+        draw_point(image, pos1, 50)
+        draw_point(image, pos2, 100)
+        actual = tp.locate(image, 5, 1, preprocess=False,
+                           engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
@@ -294,9 +339,9 @@ class CommonFeatureIdentificationTests(object):
         pos2 = np.array([14, 14])
         pos3 = np.array([7, 14])
         image = np.ones(dims, dtype='uint8')
-        draw(image, pos1, 100)
-        draw(image, pos2, 90)
-        draw(image, pos3, 80)
+        draw_point(image, pos1, 100)
+        draw_point(image, pos2, 90)
+        draw_point(image, pos3, 80)
         actual = tp.locate(image, 5, 1, topn=2, preprocess=False,
                            engine=self.engine)[cols]
         actual = actual.sort(['x', 'y'])  # sort for reliable comparison
@@ -327,28 +372,32 @@ class CommonFeatureIdentificationTests(object):
         SIZE = 2
         image = np.ones(dims, dtype='uint8')
         draw_gaussian_spot(image, pos, SIZE)
-        actual = tp.locate(image, 7, 1, preprocess=False, engine=self.engine)['size']
+        actual = tp.locate(image, 7, 1, preprocess=False,
+                           engine=self.engine)['size']
         expected = SIZE
         assert_allclose(actual, expected, rtol=0.1)
 
         SIZE = 3
         image = np.ones(dims, dtype='uint8')
         draw_gaussian_spot(image, pos, SIZE)
-        actual = tp.locate(image, 11, 1, preprocess=False, engine=self.engine)['size']
+        actual = tp.locate(image, 11, 1, preprocess=False,
+                           engine=self.engine)['size']
         expected = SIZE
         assert_allclose(actual, expected, rtol=0.1)
 
         SIZE = 5
         image = np.ones(dims, dtype='uint8')
         draw_gaussian_spot(image, pos, SIZE)
-        actual = tp.locate(image, 17, 1, preprocess=False, engine=self.engine)['size']
+        actual = tp.locate(image, 17, 1, preprocess=False,
+                           engine=self.engine)['size']
         expected = SIZE
         assert_allclose(actual, expected, rtol=0.1)
         
         SIZE = 7
         image = np.ones(dims, dtype='uint8')
         draw_gaussian_spot(image, pos, SIZE)
-        actual = tp.locate(image, 23, 1, preprocess=False, engine=self.engine)['size']
+        actual = tp.locate(image, 23, 1, preprocess=False,
+                           engine=self.engine)['size']
         expected = SIZE
         assert_allclose(actual, expected, rtol=0.1)
         
@@ -365,21 +414,24 @@ class CommonFeatureIdentificationTests(object):
         ECC = 0
         image = np.ones(dims, dtype='uint8')
         draw_gaussian_spot(image, pos, 4, ecc=ECC)
-        actual = tp.locate(image, 21, 1, preprocess=False, engine=self.engine)['ecc']
+        actual = tp.locate(image, 21, 1, preprocess=False,
+                           engine=self.engine)['ecc']
         expected = ECC
         assert_allclose(actual, expected, atol=0.02)
 
         ECC = 0.2
         image = np.ones(dims, dtype='uint8')
         draw_gaussian_spot(image, pos, 4, ecc=ECC)
-        actual = tp.locate(image, 21, 1, preprocess=False, engine=self.engine)['ecc']
+        actual = tp.locate(image, 21, 1, preprocess=False,
+                           engine=self.engine)['ecc']
         expected = ECC
         assert_allclose(actual, expected, atol=0.1)
 
         ECC = 0.5
         image = np.ones(dims, dtype='uint8')
         draw_gaussian_spot(image, pos, 4, ecc=ECC)
-        actual = tp.locate(image, 21, 1, preprocess=False, engine=self.engine)['ecc']
+        actual = tp.locate(image, 21, 1, preprocess=False,
+                           engine=self.engine)['ecc']
         expected = ECC
         assert_allclose(actual, expected, atol=0.1)
 
@@ -432,6 +484,10 @@ class TestFeatureIdentificationWithNumba(
     def check_skip(self):
         if not NUMBA_AVAILABLE:
             raise nose.SkipTest("Numba not installed. Skipping.")
+
+    def skip_numba(self):
+        raise nose.SkipTest("This feature is not "
+                            "supported by the numba variant. Skipping.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In response to an email gently pointing out that our N-dimensional capabilities are completely undocumented aside from "encouraging statements about how trackpy can be used for arbitrarily high dimensional data" (Ha! Guilty as charged!), I added two simple 3D tests and refactored all the feature-finding tests to make it easier to extend more tests in time. Happily, everything works as advertised: no changes to `feature.py` were necessary.

**Key Point:**
It will be up to the user to keep track of what x, y, and z mean for their data. Trackpy flips x and y internally because images are conventionally displayed column-major (as in `imshow` or any image viewer) but indexed row-major by numpy. But for higher-dimensional data, trackpy leaves ordering to the user. Different experiments would seem to call for different conventions here. By doing nothing, trackpy minimizes confusion.

 There should certainly be more tests, but this at least proves that trackpy can find a spot in a 3D image.
