### PR TITLE
FIX: Minor unicode fix

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -105,8 +105,8 @@ def plot_traj(traj, colorby='particle', mpp=None, label=False,
             ax.set_xlabel(r'x [\textmu m]')
             ax.set_ylabel(r'y [\textmu m]')
         else:
-            ax.set_xlabel(u'x [\xb5m]')
-            ax.set_ylabel(u'y [\xb5m]')
+            ax.set_xlabel('x [\xb5m]')
+            ax.set_ylabel('y [\xb5m]')
     # Background image
     if superimpose is not None:
         ax.imshow(superimpose, cmap=plt.cm.gray,

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -21,6 +21,10 @@ class TestPlots(unittest.TestCase):
         suppress_plotting()
         plots.plot_traj(self.sparse, label=True)
 
+    def test_ptraj_unicode_labels(self):
+        # smoke test
+        plots.plot_traj(self.sparse, mpp=0.5)
+
     def test_ptraj_t_column(self):
         suppress_plotting()
         df = self.sparse.copy()


### PR DESCRIPTION
Re: @tacaswell's comment when merging #145, this makes the unicode strings safe for 3.2 and adds a smoke test. I'm not convinced we need to support 3.2, but I won't break it on purpose.

This is a minor edit to #145. I tested it manually, and Travis passed too. Merging own.
