### PR TITLE
ENH: Helpful error on plot_traj(empty_df)

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -95,6 +95,9 @@ def plot_traj(traj, colorby='particle', mpp=None, label=False,
     if t_column is None:
         t_column = 'frame'
 
+    if len(traj) == 0:
+        raise ValueError("DataFrame of trajectories is empty.")
+
     # Axes labels
     if mpp is None:
         ax.set_xlabel('x [px]')

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -21,6 +21,11 @@ class TestPlots(unittest.TestCase):
         suppress_plotting()
         plots.plot_traj(self.sparse, label=True)
 
+    def test_ptraj_empty(self):
+        suppress_plotting()
+        f = lambda: plots.plot_traj(DataFrame(columns=self.sparse.columns))
+        self.assertRaises(ValueError, f)
+
     def test_ptraj_unicode_labels(self):
         # smoke test
         plots.plot_traj(self.sparse, mpp=0.5)


### PR DESCRIPTION
A minor improvement:

`plot_traj(accidentally_empty_df)` used to raise the cryptic error:

```
AttributeError: 'DataFrame' object has no attribute 'find'
```

which has bitten my undergrads a couple times. Now, a more helpful `ValueError` is raised instead. Test included.
