### PR TITLE
BLD: Add min versions of required deps to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,9 @@ setup_parameters = dict(
     author = "Trackpy Contributors",
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
-    install_requires = ['numpy', 'scipy', 'six', 'pandas',
-                        'pyyaml', 'matplotlib', 'pims'],
+    install_requires = ['numpy>=1.7', 'scipy>=0.12', 'six>=1.8',
+	                'pandas>=0.12', 'pims>=0.2.2',
+                        'pyyaml', 'matplotlib'],
     packages = ['trackpy'],
     long_description = read('README.md'),
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup_parameters = dict(
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
     install_requires = ['numpy>=1.7', 'scipy>=0.12', 'six>=1.8',
-	                'pandas>=0.12', 'pims>=0.2.2',
+	                    'pandas>=0.12', 'pims',
                         'pyyaml', 'matplotlib'],
     packages = ['trackpy'],
     long_description = read('README.md'),


### PR DESCRIPTION
Closes #159. These same minimum versions were also specified in the recipes used to build the conda packages for 0.2.4.

Notes:
* scipy 0.12 added full-featured cKDTree
* pandas 0.12 added GroupBy.filter