### PR TITLE
FIX/TST: When an empty frame is put to FramewiseData, warn but continue.

### DIFF
--- a/trackpy/framewise_data.py
+++ b/trackpy/framewise_data.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
+import warnings
 
 import pandas as pd
 
@@ -118,6 +119,9 @@ class PandasHDFStore(FramewiseData):
         return max(self.frames)
 
     def put(self, df):
+        if len(df) == 0:
+            warnings.warn('An empty DataFrame was passed to put(). Continuing.')
+            return
         frame_no = df[self.t_column].values[0]  # validated to be all the same
         key = code_key(frame_no)
         # Store data as tabular instead of fixed-format.
@@ -249,6 +253,9 @@ class PandasHDFStoreSingleNode(FramewiseData):
         return self._t_column
 
     def put(self, df):
+        if len(df) == 0:
+            warnings.warn('An empty DataFrame was passed to put(). Continuing.')
+            return
         self._validate(df)
         self.store.append(self.key, df, data_columns=True)
 

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -9,8 +9,9 @@ import os
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 from numpy.testing.decorators import slow
-from pandas.util.testing import (assert_series_equal, assert_frame_equal)
-
+from pandas.util.testing import (assert_series_equal, assert_frame_equal,
+                                 assert_produces_warning)
+from pandas import DataFrame
 import trackpy as tp 
 
 
@@ -67,6 +68,10 @@ class FeatureSavingTester(object):
             assert_frame_equal(s.dump().reset_index(drop=True), 
                                self.expected.reset_index(drop=True))
             assert_frame_equal(s[0], s.get(0))
+
+            # Putting an empty df should warn
+            with assert_produces_warning(UserWarning):
+                s.put(DataFrame())
             s.close()
             os.remove(STORE_NAME)
 


### PR DESCRIPTION
Currently, if one frame happens to have zero features, `PandasHDFStore` or `PandasHDFStoreBig` will raise, stopping the feature-finding loop.

In this PR, the `put` method for each of these is modified to simply do nothing if the DataFrame passed to it is empty. It warns the user that an empty frame was passed, but it doesn't interrupt the process.

