### PR TITLE
BLD: Add a conda recipe that builds binary package from current git rev.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,20 @@ language: python
 matrix:
   include: 
     - python: "2.7"
+      # minimum versions, without numba
       env: DEPS="numpy=1.7.1 scipy=0.13.0 nose matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml pytables"
     - python: "2.7"
-      env: DEPS="numpy=1.7.1 scipy=0.13.0 nose matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.11 pytables"
+      # minimum versions, with numba
+      env: DEPS="numpy=1.7.1 scipy=0.13.0 nose matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml pytables numba=0.11"
     - python: "2.7"
-      env: DEPS="numpy=1.8 scipy nose matplotlib=1.3 pandas=0.13.0 scikit-image=0.10.1 pyyaml numba=0.12 pytables"
+      # latest tested versions, without numba
+      env: DEPS="numpy=1.9.1 scipy=0.14.0 nose matplotlib=1.4.2 pandas=0.15.2 scikit-image=0.10.1 pyyaml pytables"
     - python: "2.7"
-      env: DEPS="numpy=1.8 scipy=0.14.0 nose matplotlib=1.3 pandas=0.13.0 scikit-image=0.10.1 pyyaml numba=0.12.2 pytables"
+      # latest tested versions, with numba
+      env: DEPS="numpy=1.9.1 scipy=0.14.0 nose matplotlib=1.4.2 pandas=0.15.2 scikit-image=0.10.1 pyyaml pytables numba=0.16.0"
     - python: "3.4"
-      env: DEPS="numpy=1.8 scipy=0.14.0 nose matplotlib=1.3 pandas=0.14.0 scikit-image=0.10.1 pyyaml pytables"
+      # latest tested versions, with numba (py34 this time)
+      env: DEPS="numpy=1.9.1 scipy=0.14.0 nose matplotlib=1.4.2 pandas=0.15.2 scikit-image=0.10.1 pyyaml pytables numba=0.16.0"
 
 install:
   - conda create -n testenv --yes $DEPS pip python=$TRAVIS_PYTHON_VERSION

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,0 +1,36 @@
+What is this?
+-------------
+
+This directory contains a recipe for building a 
+[conda](http://conda.pydata.org/docs/index.html) package for trackpy. It is 
+configured for creating "nightly builds," snapshots of the code in development 
+between releases. The built packages are uploaded to trackpy's 
+[dev channel on binstar](https://binstar.org/soft-matter/trackpy/channels),
+where they can easily be installed on any platform as described in the 
+doucmentation.
+
+Tagged releases are built using a modified recipe that includes the MD5 hash
+of the released code. They are uploaded to trackpy's main channel on binstar.
+
+Building a Package
+------------------
+
+See more detailed background information in the
+[release checklist](https://github.com/soft-matter/trackpy/wiki/Release-Checklist).
+This is just a handy cheatsheet.
+
+    cd trackpy/conda-recipe
+    conda build . --no-binstar-upload --python=2.7
+    conda build . --no-binstar-upload --python=3.3
+    # Note: As of this writing, trackpy does not actually support a version
+    # of numba compatible with Python 3.4.
+
+    conda convert `conda build . --output --python=2.7` --platform all
+    conda convert `conda build . --output --python=3.3` --platform all
+
+
+    binstar upload win-32/trackpy* -u soft-matter -c dev
+    binstar upload win-62/trackpy* -u soft-matter -c dev
+    binstar upload linux-32/trackpy* -u soft-matter -c dev
+    binstar upload linux-64/trackpy* -u soft-matter -c dev
+    binstar upload osx-64/trackpy* -u soft-matter -c dev

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipe/build-all-platforms-and-upload.sh
+++ b/conda-recipe/build-all-platforms-and-upload.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+VERSIONS="27 33 34"
+
+for VERSION in $VERSIONS; do
+	conda build . --python=$VERSION;
+	TARBALL_PATH=$(conda build . --python=$VERSION --output);
+	TARBALL_NAME=$(basename $TARBALL_PATH);
+	conda convert $TARBALL_PATH --platform=all;
+	binstar upload win-32/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload win-64/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload osx-64/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload linux-32/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload linux-64/$TARBALL_NAME -u soft-matter -c dev;
+done

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: trackpy
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('0.2.3', '0.2.4') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG').replace('0.2.3', '0.2.4') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -31,7 +31,7 @@ requirements:
     - matplotlib
     - pims >=0.2.2
     - pyyaml
-    - numba 0.12.2
+    - numba >=0.12.2
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,45 @@
+package:
+  name: trackpy
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('0.2.3', '0.2.4') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: {{ environ.get('GIT_BUILD_STR', '') + '_py' + environ['PY_VER'] }}
+
+source:
+  git_url: ../
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+    - pyyaml
+    - numpy
+    - pandas
+    - scipy
+    - pims
+    - matplotlib
+
+  run:
+    - python
+    - six >=1.8
+    - pyyaml
+    - numpy >=1.7
+    - pandas >=0.12.0
+    - scipy >=0.12.0
+    - matplotlib
+    - pims >=0.2.2
+    - pyyaml
+    - numba 0.12.2
+
+test:
+  imports:
+    - tifffile
+    - pims
+    - trackpy
+
+about:
+  home: http://trackpy.readthedocs.org
+  license: 3-clause BSD License
+  summary: 'Python particle-tracking toolkit'

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -144,7 +144,7 @@ Optional Dependencies:
       we recommend sticking with one of these. Note that numba v0.12.0
       (included with Anaconda 1.9.0) has a bug and will not work at all;
       if you have this version, you should update Anaconda. We support numba
-      versions 0.11 and 0.12.2.
+      versions 0.11 and >=0.12.2. We currently test on 0.16.0.
 
 PIMS has its own optional dependencies for reading various formats. You
 can read what you need for each format


### PR DESCRIPTION
This is the "conda recipe" I have been using to create the conda packages in trackpy's development channel. By including them in the repo itself, it will be possible to make Travis build conda packages and upload them to binstar. ([Others](https://github.com/rmcgibbo/python-appveyor-conda-example#binstar) have already figured out the details of how to do this.)

FYI, the dev conda packages are up to date. Anyone who wants to take the improved 3D capabilities for a spin can easily [install the latest development version](http://soft-matter.github.io/trackpy/installation.html#latest-version-under-development). attn: @mmdriscoll