### PR TITLE
BUG: Use unsigned ints for peak finding

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -572,7 +572,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
     if np.issubdtype(raw_image.dtype, np.integer):
         dtype = raw_image.dtype
     else:
-        dtype = np.int8
+        dtype = np.uint8
     image = scale_to_gamut(image, dtype)
 
     # Set up a DataFrame for the final results.


### PR DESCRIPTION
When `locate()` is given a float image, it casts it to integers for more efficient peak-finding. (`refine()` is still done with the float image.) As currently written, float images are cast to signed 8-bit integers (max. value 127). This seems like a needless loss of precision that could actually have a performance cost, as it may increase the need for tie-breaking in the merging step. This PR uses unsigned 8-bit ints instead.