### PR TITLE
ENH: Annotation of 3D frame

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -10,10 +10,6 @@ import warnings
 
 import numpy as np
 
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-
-from pims.display import to_rgb, scrollable_stack
 from .utils import print_update
 
 
@@ -33,6 +29,7 @@ def make_axes(func):
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
+        import matplotlib.pyplot as plt
         if kwargs.get('ax') is None:
             kwargs['ax'] = plt.gca()
             # Delete legend keyword so remaining ones can be passed to plot().
@@ -54,6 +51,7 @@ def make_axes(func):
 
 def make_fig(func):
     """See make_axes."""
+    import matplotlib.pyplot as plt
     wraps(func)
     def wrapper(*args, **kwargs):
         if 'fig' not in kwargs:
@@ -89,6 +87,10 @@ def plot_traj(traj, colorby='particle', mpp=None, label=False,
     -------
     None
     """
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    from matplotlib.collections import LineCollection
+
     if cmap is None:
         cmap = plt.cm.winter
     if t_column is None:
@@ -132,7 +134,7 @@ def plot_traj(traj, colorby='particle', mpp=None, label=False,
             points = np.array(
                 [x[particle].values, y[particle].values]).T.reshape(-1, 1, 2)
             segments = np.concatenate([points[:-1], points[1:]], axis=1)
-            lc = mpl.collections.LineCollection(segments, cmap=cmap)
+            lc = LineCollection(segments, cmap=cmap)
             lc.set_array(color_numbers)
             ax.add_collection(lc)
             ax.set_xlim(x.apply(np.min).min(), x.apply(np.max).max())
@@ -183,6 +185,8 @@ def annotate(centroids, image, circle_size=None, color=None,
     ------
     axes
     """
+    import matplotlib.pyplot as plt
+
     if circle_size is not None:
         warnings.warn("circle_size will be removed in future version of "
                       "trackpy. Use plot_style={'markersize': ...} instead.")
@@ -260,6 +264,9 @@ def annotate3d(centroids, image, **kwargs):
     annotate for parameters. Returns either (for 2D) an axis object or (for 3D)
     a scrollable stack.
     """
+    import matplotlib.pyplot as plt
+    from pims.display import to_rgb, scrollable_stack
+
     if kwargs.get('ax') is None:
         kwargs['ax'] = plt.gca()
     # Identify whether image is multichannel, convert to rgb if necessary
@@ -333,6 +340,8 @@ def subpx_bias(f, ax=None):
 @make_axes
 def fit(data, fits, inverted_model=False, logx=False, logy=False, ax=None,
         **kwargs):
+    import matplotlib.pyplot as plt
+
     data = data.dropna()
     x, y = data.index.values.astype('float64'), data.values
     datalines = plt.plot(x, y, 'o', label=data.name, **kwargs)
@@ -378,6 +387,8 @@ def plot_principal_axes(img, x_bar, y_bar, cov, ax=None):
     ax.imshow(img)
 
 def examine_jumps(data, jumps):
+    import matplotlib.pyplot as plt
+
     fig, axes = plt.subplots(len(jumps), 1)
     for i, jump in enumerate(jumps):
         roi = data.ix[jump-10:jump+10]

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -187,6 +187,12 @@ def annotate(centroids, image, circle_size=None, color=None,
     """
     import matplotlib.pyplot as plt
 
+    if image.ndim != 2 and not (image.ndim == 3 and image.shape[-1] in (3, 4)):
+        raise ValueError("image has incorrect dimensions. Please input a 2D "
+                         "grayscale or RGB(A) image. For 3D image annotation, "
+                         "use annotate3d. Multichannel images can be "
+                         "converted to RGB using pims.display.to_rgb.")
+
     if circle_size is not None:
         warnings.warn("circle_size will be removed in future version of "
                       "trackpy. Use plot_style={'markersize': ...} instead.")
@@ -259,52 +265,37 @@ def annotate(centroids, image, circle_size=None, color=None,
 
 def annotate3d(centroids, image, **kwargs):
     """
-    An extension of annotate that distinguishes between 2D, 2D multichannel,
-    3D, and 3D multichannel images, just as in pims.frame.__repr_html_. See
-    annotate for parameters. Returns either (for 2D) an axis object or (for 3D)
-    a scrollable stack.
+    An extension of annotate that annotates a 3D image and returns a scrollable
+    stack for display in IPython. Parameters: see annotate.
     """
     import matplotlib.pyplot as plt
-    from pims.display import to_rgb, scrollable_stack
+    from pims.display import scrollable_stack
+
+    if image.ndim != 3 and not (image.ndim == 4 and image.shape[-1] in (3, 4)):
+        raise ValueError("image has incorrect dimensions. Please input a 3D "
+                         "grayscale or RGB(A) image. For 2D image annotation, "
+                         "use annotate. Multichannel images can be "
+                         "converted to RGB using pims.display.to_rgb.")
 
     if kwargs.get('ax') is None:
         kwargs['ax'] = plt.gca()
-    # Identify whether image is multichannel, convert to rgb if necessary
-    if image.ndim > 2 and image.shape[0] < 5:
-        try:
-            colors = image.metadata['colors']
-        except KeyError or AttributeError:
-            colors = None
-        image = to_rgb(image, colors, normalize=True)
-        has_color_channels = True
-    else:
-        has_color_channels = (3 in image.shape) or (4 in image.shape)
-    # If image is 2D, make single axis objct
-    if image.ndim == 2 or (image.ndim == 3 and has_color_channels):
-        return annotate(centroids, image, **kwargs)
-    # If Frame is 3D, display as a scrollable stack.
-    elif image.ndim == 3 or (image.ndim == 4 and has_color_channels):
-        for i, imageZ in enumerate(image):
-            centroidsZ = centroids[np.logical_and(centroids['z'] > i - 0.5,
-                                                  centroids['z'] < i + 0.5)]
-            ax = annotate(centroidsZ, imageZ, **kwargs)
-            fig = ax.get_figure()
-            fig.canvas.draw()
-            if i == 0:
-                w, h = fig.canvas.get_width_height()
-                result = np.empty((image.shape[0], h, w, 4))
-            plot_rgb = np.fromstring(fig.canvas.tostring_argb(),
-                                     dtype=np.uint8)
-            plot_rgb = plot_rgb.reshape(h, w, 4)
-            result[i] = np.roll(plot_rgb, 3, axis=2)  # argb to rgba
-            ax.cla()
-        fig.clf()
-        return scrollable_stack(result, width=w)
-    else:
-        # This exception will be caught by IPython and displayed
-        # as a FormatterWarning.
-        raise ValueError("No plot representation is available for "
-                         "{0}-dimensional Frames".format(image.ndim))
+
+    for i, imageZ in enumerate(image):
+        centroidsZ = centroids[np.logical_and(centroids['z'] > i - 0.5,
+                                              centroids['z'] < i + 0.5)]
+        ax = annotate(centroidsZ, imageZ, **kwargs)
+        fig = ax.get_figure()
+        fig.canvas.draw()
+        if i == 0:
+            w, h = fig.canvas.get_width_height()
+            result = np.empty((image.shape[0], h, w, 4))
+        plot_rgb = np.fromstring(fig.canvas.tostring_argb(),
+                                 dtype=np.uint8)
+        plot_rgb = plot_rgb.reshape(h, w, 4)
+        result[i] = np.roll(plot_rgb, 3, axis=2)  # argb to rgba
+        ax.cla()
+    fig.clf()
+    return scrollable_stack(result, width=w)
 
 
 @make_axes


### PR DESCRIPTION
This implements `annotate3d` that uses the same format as `pims.frame.__repr_html_` to generate scrollable stacks of 3d images. Just as in `pims`, it distinguishes between 2D, 2D multichannel, 3D, and 3D multichannel images. Returns either (for 2D) an axis object or (for 3D) a scrollable stack.

I also took the liberty of moving `import matplotlib / pyplot` to the top.

I don't really have an idea how to write unittests for this. I will make an example in a notebook that also explains the new anisotropic feature finding.