### PR TITLE
FIX: Annotate mirrors image

### DIFF
--- a/doc/releases/v0.3.0.txt
+++ b/doc/releases/v0.3.0.txt
@@ -15,3 +15,8 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fixed a bug in v0.2.3 and v0.2.4 that broke the ``circle_size`` parameter in ``annotate()``. (:issue:`169`, :issue:`170`)
+
+API changes
+~~~~~~~~~~~
+
+- The plot function ``annotate()`` now displays the image with the vertical axis inverted, to be consistent with the ``pims`` display function and ``plot_traj()``.

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -232,6 +232,7 @@ def annotate(centroids, image, circle_size=None, color=None,
         ax.imshow(image, **_imshow_style)
     ax.set_xlim(-0.5, image.shape[1] - 0.5)
     ax.set_ylim(-0.5, image.shape[0] - 0.5)
+    ax.invert_yaxis()
 
     if split_category is None:
         if np.size(color) > 1:
@@ -260,7 +261,6 @@ def annotate(centroids, image, circle_size=None, color=None,
         _plot_style.update(markeredgecolor=color[-1])
         ax.plot(centroids['x'][high], centroids['y'][high],
                 **_plot_style)
-    ax.invert_yaxis()
     return ax
 
 

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -260,6 +260,7 @@ def annotate(centroids, image, circle_size=None, color=None,
         _plot_style.update(markeredgecolor=color[-1])
         ax.plot(centroids['x'][high], centroids['y'][high],
                 **_plot_style)
+    ax.invert_yaxis()
     return ax
 
 


### PR DESCRIPTION
Something I encountered in PR #193, annotate displays a mirror image because y axis is not inverted, which is common practice in images. The rest of the functions do invert the y axis. Or is there a special reason for this?