### PR TITLE
ENH: Generalize plotting to 2D/3D

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -10,8 +10,7 @@ import warnings
 
 import numpy as np
 
-from PIL import Image
-from pims import Frame
+from pims import plot_to_frame, plots_to_frame, normalize
 
 from .utils import print_update
 
@@ -19,7 +18,7 @@ from .utils import print_update
 __all__ = ['annotate', 'scatter', 'plot_traj', 'ptraj',
            'annotate3d', 'scatter3d', 'plot_traj3d', 'ptraj3d',
            'plot_displacements', 'subpx_bias', 'mass_size', 'mass_ecc',
-           'plot_density_profile', 'plot_to_frame', 'plots_to_frame']
+           'plot_density_profile']
 
 
 def make_axes(func):
@@ -160,71 +159,6 @@ def _set_labels(ax, label_format, pos_columns):
     ax.set_ylabel(label_format.format(pos_columns[1]))
     if hasattr(ax, 'set_zlabel') and len(pos_columns) > 2:
         ax.set_zlabel(label_format.format(pos_columns[2]))
-
-
-def plot_to_frame(fig, dpi, **imsave_kwargs):
-    """ Renders a matplotlib figure or axes object into a numpy array
-    containing RGBA data of the rendered image.
-
-    Parameters
-    ----------
-    fig : matplotlib Figure or Axes object
-    dpi : number, dots per inch used in figure rendering
-    imsave_kwargs : keyword arguments passed to `Figure.imsave(...)`
-
-    Returns
-    -------
-    pims.Frame object containing RGBA values (dtype uint8)
-    """
-    import matplotlib as mpl
-    buffer = six.BytesIO()
-    if isinstance(fig, mpl.axes.Axes):
-        fig = fig.figure
-    fig.savefig(buffer, format='tif', dpi=dpi, **imsave_kwargs)
-    buffer.seek(0)
-    im = np.asarray(Image.open(buffer))
-    buffer.close()
-    return Frame(im)
-
-
-def plots_to_frame(figures, width=512, **imsave_kwargs):
-    """ Renders an iterable of matplotlib figures or axes objects into a
-    pims Frame object, that will be displayed as scrollable stack in IPython.
-
-    Parameters
-    ----------
-    figures : iterable of matplotlib Figure or Axes objects
-    width : integer, width in pixels
-    imsave_kwargs : keyword arguments passed to `Figure.imsave(...)`
-
-    Returns
-    -------
-    pims.Frame object containing a stack of RGBA values (dtype uint8)
-    """
-    import matplotlib as mpl
-    if 'dpi' in imsave_kwargs or 'format' in imsave_kwargs:
-        raise ValueError('Do not specify dpi or format imsave kwargs.')
-    if isinstance(figures, mpl.axes.Axes) or \
-       isinstance(figures, mpl.figure.Figure):
-        raise ValueError('Use plot_to_frame for single figures, or supply '
-                         'an iterable of figures to plots_to_frame.')
-
-    # render first image to calculate the correct dpi and image size
-    size = plot_to_frame(figures[0], 100, **imsave_kwargs).shape
-    dpi = width * 100 / size[1]
-    h = width * size[0] / size[1]
-
-    frames = []
-    for n, fig in enumerate(figures):
-        im = plot_to_frame(fig, dpi, **imsave_kwargs)
-        # make the image the same size as the first image
-        if (im.shape[0] != h) or (im.shape[1] != width):
-            im = np.pad(im[:h, :width], ((0, max(0, h - im.shape[0])),
-                                         (0, max(0, width - im.shape[1])),
-                                         (0, 0)), mode=b'constant')
-        frames.append(im)
-
-    return Frame(np.array(frames))
 
 @make_axes
 def scatter(centroids, mpp=None, cmap=None, ax=None, pos_columns=None,
@@ -522,11 +456,7 @@ def annotate3d(centroids, image, **kwargs):
                          "converted to RGB using pims.display.to_rgb.")
 
     # We want to normalize on the full image and stop imshow from normalizing.
-    ptp = (image.max() - image.min()) / 255
-    # Handle edge case of a flat image.
-    if ptp == 0:
-        ptp = 255
-    normalized = ((image - image.min()) / ptp).astype(np.uint8)
+    normalized = (normalize(image) * 255).astype(np.uint8)
     imshow_style = dict(vmin=0, vmax=255)
     if '_imshow_style' in kwargs:
         kwargs['imshow_style'].update(imshow_style)
@@ -545,7 +475,7 @@ def annotate3d(centroids, image, **kwargs):
         annotate(centroidsZ, imageZ, **kwargs)
         figures.append(fig)
 
-    result = mpl_to_frame(figures, width=512, bbox_inches='tight')
+    result = plots_to_frame(figures, width=512, bbox_inches='tight')
 
     for fig in figures:
         plt.close(fig)

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -23,11 +23,11 @@ def make_axes(func):
     A decorator for plotting functions.
     NORMALLY: Direct the plotting function to the current axes, gca().
               When it's done, make the legend and show that plot.
-              (Instant gratificaiton!)
+              (Instant gratificaiton!) The axes have to be 2d or else the
+              current figure will be cleared.
     BUT:      If the uses passes axes to plotting function, write on those axes
               and return them. The user has the option to draw a more complex
-              plot in multiple steps. The axes have to be 2d or else the
-              current figure will be cleared.
+              plot in multiple steps.
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -44,7 +44,7 @@ def make_axes(func):
             else:
                 del kwargs['legend']
             result = func(*args, **kwargs)
-            if not (kwargs['ax'].get_legend_handles_labels() == ([], []) or \
+            if not (kwargs['ax'].get_legend_handles_labels() == ([], []) or
                     legend is False):
                 plt.legend(loc='best')
             plt.show()
@@ -59,11 +59,11 @@ def make_axes3d(func):
     A decorator for plotting 3d functions.
     NORMALLY: Direct the plotting function to the current axes, gca().
               When it's done, make the legend and show that plot.
-              (Instant gratificaiton!)
+              (Instant gratificaiton!) The axes have to be 3d or else the
+              current figure will be cleared.
     BUT:      If the uses passes axes to plotting function, write on those axes
               and return them. The user has the option to draw a more complex
-              plot in multiple steps. The axes have to be 3d or else the
-              current figure will be cleared.
+              plot in multiple steps.
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -126,17 +126,7 @@ def _plot(ax, coords, pos_columns, **plot_style):
     -------
     Axes object
     """
-    if len(pos_columns) == 3 and type(coords[pos_columns[0]]) is DataFrame:
-        # When a single column is a DataFrame, not Series, then there are
-        # multiple lines to be plotted. In 3D, this has to be dealt with using
-        # a for loop.
-        coords = coords[pos_columns]
-        plotcount = coords.shape[0] - 1
-        for i in range(plotcount):
-            ax.plot(coords.icol(i), coords.icol(i + plotcount),
-                    zs=coords.icol(i + 2*plotcount), **plot_style)
-        return ax
-    elif len(pos_columns) == 3:
+    if len(pos_columns) == 3:
         return ax.plot(coords[pos_columns[0]], coords[pos_columns[1]],
                        zs=coords[pos_columns[2]], **plot_style)
     elif len(pos_columns) == 2:
@@ -146,7 +136,7 @@ def _plot(ax, coords, pos_columns, **plot_style):
 
 
 def _set_labels(ax, label_format, pos_columns):
-    """This sets axes labels according to a label format and position column 
+    """This sets axes labels according to a label format and position column
     names. Applicable to 2D and 3D plotting.
 
     Parameters
@@ -217,7 +207,7 @@ def scatter(centroids, mpp=None, cmap=None, ax=None, pos_columns=None,
 
 @make_axes3d
 def scatter3d(*args, **kwargs):
-    """3D extension of plot_traj"""
+    """3D extension of scatter"""
     if kwargs.get('pos_columns') is None:
         kwargs['pos_columns'] = ['x', 'y', 'z']
     return scatter(*args, **kwargs)
@@ -292,8 +282,9 @@ def plot_traj(traj, colorby='particle', mpp=None, label=False,
     # Trajectories
     if colorby == 'particle':
         # Unstack particles into columns.
-        unstacked = traj.set_index([t_column, 'particle'])[pos_columns].unstack()
-        _plot(ax, mpp*unstacked, pos_columns, **_plot_style)
+        unstacked = traj.set_index(['particle', t_column])[pos_columns].unstack()
+        for i, trajectory in unstacked.iterrows():
+            _plot(ax, mpp*trajectory, pos_columns, **_plot_style)
     if colorby == 'frame':
         # Read http://www.scipy.org/Cookbook/Matplotlib/MulticoloredLine
         x = traj.set_index([t_column, 'particle'])['x'].unstack()

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -10,7 +10,12 @@ import warnings
 
 import numpy as np
 
-from pims import plot_to_frame, plots_to_frame, normalize
+try:
+    from pims import plot_to_frame, plots_to_frame, normalize
+except ImportError:
+    plot_to_frame = None
+    plots_to_frame = None
+    normalize = None
 
 from .utils import print_update
 
@@ -446,6 +451,10 @@ def annotate3d(centroids, image, **kwargs):
     An extension of annotate that annotates a 3D image and returns a scrollable
     stack for display in IPython. Parameters: see annotate.
     """
+    if plots_to_frame is None:
+        raise ImportError('annotate3d requires pims 0.3 or later, please '
+                          'update pims')
+
     import matplotlib as mpl
     import matplotlib.pyplot as plt
 


### PR DESCRIPTION
This implements 3D plotting of points (`scatter` / `scatter3d`) and trajectories (`plot_traj`, `plot_traj3d`). The approach I used slightly altered `plot_traj` to make it usable for both 2D and 3D. Then `plot_traj3d` directly calls `plot_traj`, with the diffence that the 3D version sets up 3D axes, and the 2D version sets up 2D axes. This could be extended to all other plotting functions, but I first would like some feedback on the approach.

The downside is that it makes `plot_traj` a bit more unclear, but I think altogether this is a better solution than making a new `plot_traj3d` that is more or less a copy of `plot_traj`.

To make this working, I added `_plot` that wraps `Axes.plot` to give it the same call signature for 2D
and 3D. For convenience, also `_set_labels` to set up all axis labels according to a string pattern.

This is also compatible with the mpl nbagg backend, so that you can rotate 3D graphs inline. But annotate3d isn't, so you would end up switching between backends.