### PR TITLE
List versions

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -125,6 +125,15 @@ Utility functions
     utils.fit_powerlaw
     utils.print_update
 
+Diagnostic functions
+--------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   diag.performance_report
+   diag.dependencies
+
 Low-Level API (Advanced)
 ------------------------
 

--- a/trackpy/diag.py
+++ b/trackpy/diag.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import sys
+from collections import OrderedDict
 
 from . import try_numba
 from . import preprocessing
@@ -34,7 +35,7 @@ def dependencies():
     """
     packages = ['six', 'numpy', 'scipy', 'matplotlib', 'pandas',
                 'scikit-image', 'pyyaml', 'pytables', 'numba', 'pyfftw']
-    result = dict()
+    result = OrderedDict()
     for package_name in packages:
         try:
             package = __import__(package_name)

--- a/trackpy/diag.py
+++ b/trackpy/diag.py
@@ -1,16 +1,16 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
+import sys
 
-from . import __version__
 from . import try_numba
 from . import preprocessing
+
 
 def performance_report():
     """Display summary of which optional speedups are installed/enabled"""
     print("Yes, but could it be faster?")
     if try_numba.NUMBA_AVAILABLE:
-        #FIXME Handle 0.12/0.11 distinction
         print("FAST: numba is available and enabled "
               "(fast subnets and feature-finding).")
     else:
@@ -20,3 +20,35 @@ def performance_report():
         print("FAST: Using pyfftw for image preprocessing.")
     else:
         print("SLOW: pyfftw not found (slower image preprocessing).")
+
+
+def dependencies():
+    """
+    Give the version of each of the dependencies -- useful for bug reports.
+
+    Returns
+    -------
+    result : dict
+        mapping the name of each package to its version string or, if an
+        optional dependency is not installed, None
+    """
+    packages = ['six', 'numpy', 'scipy', 'matplotlib', 'pandas',
+                'scikit-image', 'pyyaml', 'pytables', 'numba', 'pyfftw']
+    result = dict()
+    for package_name in packages:
+        try:
+            package = __import__(package_name)
+        except ImportError:
+            result[package_name] = None
+        else:
+            try:
+                version = package.__version__
+            except AttributeError:
+                version = package.version  # pyfftw does not have __version__
+            result[package_name] = version
+    # Build Python version string
+    version_info = sys.version_info
+    version_string = '.'.join(map(str, [version_info[0], version_info[1],
+                                  version_info[2]]))
+    result['python'] = version_string
+    return result

--- a/trackpy/diag.py
+++ b/trackpy/diag.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import sys
+import importlib
 from collections import OrderedDict
 
 from . import try_numba
@@ -38,7 +39,7 @@ def dependencies():
     result = OrderedDict()
     for package_name in packages:
         try:
-            package = __import__(package_name)
+            package = importlib.import_module(package_name)
         except ImportError:
             result[package_name] = None
         else:

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -9,3 +9,6 @@ import trackpy.diag
 class DiagTests(unittest.TestCase):
     def test_performance_report(self):
         trackpy.diag.performance_report()
+
+    def test_dependencies(self):
+        trackpy.diag.dependencies()


### PR DESCRIPTION
This will be useful for bug reports:

    >>> import trackpy.diag
    >>> trackpy.diag.dependencies()
    {'scipy': '0.15.0', 'pytables': None, 'scikit-image': None, 'matplotlib': '1.4.2', 'pyfftw': 0.9.2,
    'numpy': '1.9.1', 'pyyaml': None, 'six': '1.9.0', 'numba': '0.16.0', 'pandas': '0.15.2',
    'python': '3.4.2'}

Any missing deps are mapped to `None` instead of a version string.