### PR TITLE
FIX Change in way conda is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: DEPS="numpy=1.8 scipy=0.14.0 nose matplotlib=1.3 pandas=0.14.0 scikit-image=0.10.1 pyyaml pytables"
 
 install:
+  - conda install --yes -c conda conda-env
   - conda create -n testenv --yes $DEPS pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - python setup.py install


### PR DESCRIPTION
Travis started giving an error on `source activate testenv`. This should fix it.

quote from travis log:

    $ source activate testenv
    We're making conda environments even better!  Part of this process is
    changing the way environment activation works.  You need to install the
    new conda-env package before you can use these feature:
    conda install -c conda conda-env
    
    For more information, please visit: https://github.com/conda/conda-env