### PR TITLE
PERF: Faster level-building

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -674,10 +674,8 @@ def link_df_iter(features, search_range, memory=0,
 
 def _build_level(frame, pos_columns, t_column):
     "Return IndexPointND objects for a DataFrame of points."
-    build_pt = lambda x: IndexedPointND(x[1], x[0][1].values, x[0][0])
-    # iterrows() returns: (index which we use as feature id, data)
-    zipped = zip(frame[pos_columns].iterrows(), frame[t_column])
-    return [build_pt(pt) for pt in zipped]
+    return list(map(IndexedPointND, frame[t_column],
+                    frame[pos_columns].values, frame.index))
 
 
 class UnknownLinkingError(Exception):


### PR DESCRIPTION
I was upset that the features I've been working on made linking several percent slower, so I went looking for ways to claw that back. It turns out that `DataFrame.iterrows()`, which was used by `link_df*`, creates a Series instance for each row (i.e. particle). This was responsible for more than half of the `real_data.DenseLinkingSuite.time_numba` benchmark. I don't know why we didn't notice this before; perhaps there was a change in Pandas.

Bypassing `iterrows()` reduces *all* of the linking benchmark times (and unit test times) by ~50%.