### PR TITLE
BUG: Consistently add subnet distances in quadrature

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -1424,7 +1424,8 @@ def _numba_subnet_norecur(ncands, candsarray, dists2array, cur_assignments,
 
     cur_assignments, tmp_assignments are just temporary registers of length nj.
     best_assignments is modified in place.
-    Returns the best sum.
+    Returns the number of assignments tested (at all levels). This is basically
+    proportional to time spent.
     """
     nj = candsarray.shape[0]
     tmp_sum = 0.

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -1232,7 +1232,7 @@ class SubnetLinker(object):
     def do_recur(self, j):
         cur_s = self.s_lst[j]
         for cur_d, dist in cur_s.forward_cands:
-            tmp_sum = self.cur_sum + dist
+            tmp_sum = self.cur_sum + dist**2
             if tmp_sum > self.best_sum:
                 # if we are already greater than the best sum, bail we
                 # can bail all the way out of this branch because all
@@ -1255,7 +1255,8 @@ class SubnetLinker(object):
             # if we have hit the end of s_lst and made it this far, it
             # must be a better linking so save it.
             if j + 1 == self.MAX:
-                tmp_sum = self.cur_sum + self.search_range * (self.max_links - len(self.d_taken))
+                tmp_sum = self.cur_sum + self.search_range**2 * (
+                    self.max_links - len(self.d_taken))
                 if tmp_sum < self.best_sum:
                     self.best_sum = tmp_sum
                     self.best_pairs = list(self.cur_pairs)
@@ -1263,7 +1264,7 @@ class SubnetLinker(object):
                 # re curse!
                 self.do_recur(j + 1)
             # remove this step from the working
-            self.cur_sum -= dist
+            self.cur_sum -= dist**2
             if cur_d is not None:
                 self.d_taken.remove(cur_d)
             self.cur_pairs.pop()
@@ -1298,7 +1299,8 @@ def nonrecursive_link(source_list, dest_size, search_range, max_size=30, diag=Fa
             # base case, no more source candidates,
             # save the current configuration if it's better than the current max
             # add penalty for not linking to particles in the destination set
-            tmp_sum = cur_sum + search_range * (max_links - len([d for d in cur_back if d is not None]))
+            tmp_sum = cur_sum + search_range**2 * (
+                max_links - len([d for d in cur_back if d is not None]))
             if tmp_sum < best_sum:
                 best_sum = cur_sum
                 best_back = list(cur_back)
@@ -1328,7 +1330,7 @@ def nonrecursive_link(source_list, dest_size, search_range, max_size=30, diag=Fa
         # get the forward candidate
         cur_d, cur_dist = cand_list_list[j][k]
 
-        tmp_sum = cur_sum + cur_dist
+        tmp_sum = cur_sum + cur_dist**2
         if tmp_sum > best_sum:
             # nothing in this branch can do better than the current best
             j -= 1

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -1173,11 +1173,8 @@ def assign_candidates(cur_level, prev_hash, search_range, neighbor_strategy):
     if neighbor_strategy == 'BTree':
         # (Tom's code)
         for p in cur_level:
-            # get
             work_box = prev_hash.get_region(p, search_range)
             for wp in work_box:
-                # this should get changed to deal with squared values
-                # to save an eventually square root
                 d = p.distance(wp)
                 if d < search_range:
                     p.back_cands.append((wp, d))
@@ -1189,9 +1186,9 @@ def assign_candidates(cur_level, prev_hash, search_range, neighbor_strategy):
         nn = np.sum(np.isfinite(dists), 1)  # Number of neighbors of each particle
         for i, p in enumerate(cur_level):
             for j in range(nn[i]):
-                wp = hashpts[inds[i,j]]
-                p.back_cands.append((wp, dists[i,j]))
-                wp.forward_cands.append((p, dists[i,j]))
+                wp = hashpts[inds[i, j]]
+                p.back_cands.append((wp, dists[i, j]))
+                wp.forward_cands.append((p, dists[i, j]))
 
 
 class SubnetOversizeException(Exception):
@@ -1363,19 +1360,19 @@ def nonrecursive_link(source_list, dest_size, search_range, max_size=30, diag=Fa
     return source_list, best_back
 
 
-def numba_link(s_sn, dest_size, search_radius, max_size=30, diag=False):
+def numba_link(s_sn, dest_size, search_range, max_size=30, diag=False):
     """Recursively find the optimal bonds for a group of particles between 2 frames.
 
     This is only invoked when there is more than one possibility within
-    ``search_radius``.
+    ``search_range``.
 
     Note that ``dest_size`` is unused; it is determined from the contents of
     the source list.
     """
     # The basic idea: replace Point objects with integer indices into lists of Points.
-    # Then the hard part (recursion) runs quickly because it is just passing arrays.
-    # In fact, we can compile it with numba so that it runs in acceptable time.
-    max_candidates = 9 # Max forward candidates we expect for any particle
+    # Then the hard part runs quickly because it is just operating on arrays.
+    # We can compile it with numba for outstanding performance.
+    max_candidates = 9  # Max forward candidates we expect for any particle
     src_net = list(s_sn)
     nj = len(src_net) # j will index the source particles
     if nj > max_size:
@@ -1391,7 +1388,7 @@ def numba_link(s_sn, dest_size, search_radius, max_size=30, diag=False):
     # each row of the array. All other elements represent the null link option
     # (i.e. particle lost)
     candsarray = np.ones((nj, max_candidates + 1), dtype=np.int64) * -1
-    distsarray = np.ones((nj, max_candidates + 1), dtype=np.float64) * search_radius
+    distsarray = np.ones((nj, max_candidates + 1), dtype=np.float64) * search_range
     ncands = np.zeros((nj,), dtype=np.int64)
     for j, sp in enumerate(src_net):
         ncands[j] = len(sp.forward_cands)

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -648,21 +648,12 @@ class TestKDTreeWithDropLink(CommonTrackingTests, unittest.TestCase):
         f_expected_without_subnet = f.copy()
         f_expected_without_subnet['particle'] = [0, 0, 1]
         # The linker assigns new particle IDs in arbitrary order. So
-        # comparing with expected values is tricky. One thing that helps
-        # is to not sort the result by particle ID; we use retain_index.
-        # We also accept two valid versions of the output:
-        f_expected_with_subnet = f.copy()
-        f_expected_with_subnet['particle'] = [0, 1, 2]
-        f_expected_with_subnet_alt = f.copy()  # Other possible valid output
-        f_expected_with_subnet_alt['particle'] = [0, 2, 1]
+        # comparing with expected values is tricky.
+        # We just check for the creation of 2 new trajectories.
         without_subnet = self.link_df(f, 1.5, retain_index=True)
         assert_frame_equal(without_subnet, f_expected_without_subnet, check_dtype=False)
         with_subnet = self.link_df(f, 5, retain_index=True)
-        try:
-            assert_frame_equal(with_subnet, f_expected_with_subnet, check_dtype=False)
-        except AssertionError:
-            assert_frame_equal(with_subnet, f_expected_with_subnet_alt, check_dtype=False)
-
+        assert set(with_subnet.particle) == set((0, 1, 2))
 
 
 class TestBTreeWithRecursiveLink(SubnetNeededTests, unittest.TestCase):

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -477,6 +477,21 @@ class SubnetNeededTests(CommonTrackingTests):
         actual = self.link_df_iter(f1, 5, hash_size=(2*M, 2*M))
         assert_frame_equal(actual, expected)
 
+    def test_quadrature_distances(self):
+        """A simple test to check whether the subnet linker adds
+        distances in quadrature (as in Crocker-Grier)."""
+        def subnet_test(epsilon):
+            """Returns 2 features in 2 frames, which represent a special
+            case when the subnet linker adds distances in quadrature. With
+            epsilon=0, subnet linking is degenerate. Therefore
+            linking should differ for positive and negative epsilon."""
+            return pd.DataFrame([(0, 10, 11), (0, 10, 8),
+                                 (1, 9, 10), (1, 12, 10 + epsilon)],
+                         columns=['frame', 'x', 'y'])
+        trneg = self.link_df(subnet_test(0.01), 5, retain_index=True)
+        trpos = self.link_df(subnet_test(-0.01), 5, retain_index=True)
+        assert not np.allclose(trneg.particle.values, trpos.particle.values)
+
     def test_memory(self):
         """A unit-stepping trajectory and a random walk are observed
         simultaneously. The random walk is missing from one observation."""


### PR DESCRIPTION
According to the original [Crocker & Grier paper](http://dx.doi.org/10.1006/jcis.1996.0217), and mathy reasons, distances in n-D space are added in quadrature to make an (inverse) figure of merit for evaluating subnet solutions. This has been the practice of the numba linker basically for as long as it's been the default, so I doubt there's been any issue for the vast majority of our users. However, it was not done by the pure-Python linkers (recursive and non-recursive). (@tacaswell: Was this related to your original application for this code?)

This PR adds a simple test that discerns whether a subnet linker uses quadrature or not. The numba linker passes but the others fail. The Python linkers are then changed so they work in quadrature and pass the test.

There are also a few minor fixes thrown in for good measure.

**NOTE**: The Travis builds have been failing on my repo due to a conda error; the tests pass locally for me in py2.7 and py3. The problem does not appear to be in the conda issue tracker yet, but I really don't know enough about our use of conda to articulate what is going wrong. I'd appreciate some debugging, or perhaps some guidance on what to report over there.