### PR TITLE
CRITICAL: Prevent pims namespace conflicts

### DIFF
--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -1,6 +1,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
+
+# Import all of pims top-level for convenience. But do it first so
+# that trackpy names take precedence.
+from pims import *
+
 from .motion import *
 from .plots import *
 from .linking import *
@@ -10,6 +15,3 @@ from .preprocessing import bandpass
 from .framewise_data import *
 from . import utils
 from .try_numba import try_numba_autojit, enable_numba, disable_numba
-
-# Import all of pims top-level for convenience.
-from pims import *

--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -1,10 +1,29 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
+import warnings
 
-# Import all of pims top-level for convenience. But do it first so
-# that trackpy names take precedence.
-from pims import *
+# pims import is deprecated. We include it here for backwards
+# compatibility, but there will be warnings.
+import pims as _pims
+
+
+def _deprecate_pims(call):
+    """Wrap a pims callable with a warning that it is deprecated."""
+    def deprecated_pims_import(*args, **kw):
+        """Class imported from pims package. Its presence in trackpy is deprecated."""
+        warnings.warn(('trackpy.{0} is being called, but "{0}" is really part of the '
+                      'pims package. It will not be in future versions of trackpy. '
+                      'Consider importing pims and calling pims.{0} instead.'
+                      ).format(call.__name__), UserWarning)
+        return call(*args, **kw)
+    return deprecated_pims_import
+
+
+ImageSequence = _deprecate_pims(_pims.ImageSequence)
+Video = _deprecate_pims(_pims.Video)
+TiffStack = _deprecate_pims(_pims.TiffStack)
+
 
 from .motion import *
 from .plots import *

--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -3,6 +3,25 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import warnings
 
+from .motion import msd, imsd, emsd, compute_drift, subtract_drift, \
+           proximity, vanhove, relate_frames, velocity_corr, \
+           direction_corr, is_typical, diagonal_size
+from .plots import annotate, annotate3d, plot_traj, ptraj, \
+           plot_displacements, subpx_bias, mass_size, mass_ecc
+from .linking import HashTable, TreeFinder, Point, PointND, \
+           Track, TrackUnstored, UnknownLinkingError, \
+           SubnetOversizeException, link, link_df, link_iter, \
+           link_df_iter, strip_diagnostics
+from .filtering import filter_stubs, filter_clusters, filter
+from .feature import locate, batch, percentile_threshold, local_maxima, \
+           refine, estimate_mass, estimate_size
+from .preprocessing import bandpass
+from .framewise_data import FramewiseData, PandasHDFStore, PandasHDFStoreBig, \
+           PandasHDFStoreSingleNode
+from . import utils
+from .try_numba import try_numba_autojit, enable_numba, disable_numba
+
+
 # pims import is deprecated. We include it here for backwards
 # compatibility, but there will be warnings.
 import pims as _pims
@@ -24,13 +43,3 @@ ImageSequence = _deprecate_pims(_pims.ImageSequence)
 Video = _deprecate_pims(_pims.Video)
 TiffStack = _deprecate_pims(_pims.TiffStack)
 
-
-from .motion import *
-from .plots import *
-from .linking import *
-from .filtering import *
-from .feature import *
-from .preprocessing import bandpass
-from .framewise_data import *
-from . import utils
-from .try_numba import try_numba_autojit, enable_numba, disable_numba

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -18,9 +18,6 @@ import trackpy  # to get trackpy.__version__
 
 from .try_numba import try_numba_autojit, NUMBA_AVAILABLE
 
-__all__ = ['locate', 'batch', 'percentile_threshold', 'local_maxima',
-           'refine', 'estimate_mass', 'estimate_size']
-
 
 def percentile_threshold(image, percentile):
     """Find grayscale threshold based on distribution in image."""

--- a/trackpy/filtering.py
+++ b/trackpy/filtering.py
@@ -7,14 +7,14 @@ by wrapping pandas group-by and filter capabilities."""
 
 
 def filter_stubs(tracks, threshold=100):
-    """Filter out trajectories with few points. They are often specious.
+    """Filter out trajectories with few points. They are often spurious.
 
     Parameters
     ----------
     tracks : DataFrame
         must include columns named 'frame' and 'particle'
     threshold : integer, default 100
-        minimum number of points to survive
+        minimum number of points (video frames) to survive
 
     Returns
     -------

--- a/trackpy/framewise_data.py
+++ b/trackpy/framewise_data.py
@@ -8,9 +8,6 @@ import pandas as pd
 
 from .utils import print_update
 
-__all__ = ['FramewiseData', 'PandasHDFStore', 'PandasHDFStoreBig',
-           'PandasHDFStoreSingleNode']
-
 
 class FramewiseData(object):
     "Abstract base class defining a data container with framewise access."

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -14,11 +14,6 @@ import pandas as pd
 from .utils import print_update
 from .try_numba import try_numba_autojit, NUMBA_AVAILABLE
 
-__all__ = ['HashTable', 'TreeFinder', 'Point', 'PointND',
-           'Track', 'TrackUnstored', 'UnknownLinkingError',
-           'SubnetOversizeException', 'link', 'link_df', 'link_iter',
-           'link_df_iter', 'strip_diagnostics']
-
 
 class TreeFinder(object):
 

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -6,11 +6,6 @@ import pandas as pd
 from pandas import DataFrame, Series
 from scipy.spatial import cKDTree
 
-__all__ = ['msd', 'imsd', 'emsd', 'compute_drift', 'subtract_drift',
-           'proximity', 'vanhove', 'relate_frames', 'velocity_corr',
-           'direction_corr', 'is_typical', 'diagonal_size']
-
-
 def msd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=['x', 'y']):
     """Compute the mean displacement and mean squared displacement of one
     trajectory over a range of time intervals.

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -30,4 +30,7 @@ class APITests(unittest.TestCase):
             warnings.simplefilter('always', UserWarning)
             imseq = trackpy.ImageSequence(os.path.join(path, 'video/image_sequence/*.png'))
             assert isinstance(imseq, pims.ImageSequence)
+            if len(w) != 1:
+                print('Caught warnings:')
+                print(w)
             assert len(w) == 1

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -27,6 +27,7 @@ class APITests(unittest.TestCase):
         trackpy is deprecated as of v0.3 and will be removed in a future
         version."""
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('ignore')
             warnings.simplefilter('always', UserWarning)
             imseq = trackpy.ImageSequence(os.path.join(path, 'video/image_sequence/*.png'))
             assert isinstance(imseq, pims.ImageSequence)

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -1,10 +1,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
+import os
 import unittest
+import warnings
 
+import trackpy
 import trackpy.diag
 
+path, _ = os.path.split(os.path.abspath(__file__))
 
 class DiagTests(unittest.TestCase):
     def test_performance_report(self):
@@ -12,3 +16,11 @@ class DiagTests(unittest.TestCase):
 
     def test_dependencies(self):
         trackpy.diag.dependencies()
+
+
+class APITests(unittest.TestCase):
+    def test_pims_deprecation(self):
+        with warnings.catch_warnings(True) as w:
+            warnings.simplefilter('always')
+            _ = trackpy.ImageSequence(os.path.join(path, 'video/image_sequence/*.png'))
+            assert len(w) == 1

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -32,5 +32,6 @@ class APITests(unittest.TestCase):
             assert isinstance(imseq, pims.ImageSequence)
             if len(w) != 1:
                 print('Caught warnings:')
-                print(w)
+                for wrn in w:
+                    print(wrn, wrn.message)
             assert len(w) == 1

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -5,6 +5,7 @@ import os
 import unittest
 import warnings
 
+import pims
 import trackpy
 import trackpy.diag
 
@@ -20,7 +21,13 @@ class DiagTests(unittest.TestCase):
 
 class APITests(unittest.TestCase):
     def test_pims_deprecation(self):
-        with warnings.catch_warnings(True) as w:
-            warnings.simplefilter('always')
-            _ = trackpy.ImageSequence(os.path.join(path, 'video/image_sequence/*.png'))
+        """Using a pims class should work, but generate a warning.
+
+        The inclusion of these classes (and therefore this test) in
+        trackpy is deprecated as of v0.3 and will be removed in a future
+        version."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', UserWarning)
+            imseq = trackpy.ImageSequence(os.path.join(path, 'video/image_sequence/*.png'))
+            assert isinstance(imseq, pims.ImageSequence)
             assert len(w) == 1


### PR DESCRIPTION
It appears that `pims` now has a `utils` module, and the last line in `api.py` is `from pims import *`. Lots of tests were failing because depending on how `trackpy` was being imported, it was possible to end up with the pims utilities instead of the trackpy ones. 

I was in the habit of not running the full test suite locally, because I knew Travis would take care of that. This issue did not affect the tests I *was* running. Since Travis has been failing for other reasons, that's a very bad habit!

Unless I'm insane, please merge ASAP.