### PR TITLE
REF: Use np.percentile in place of scoreatpercentile.

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -6,7 +6,6 @@ import warnings
 import numpy as np
 import pandas as pd
 from scipy import ndimage
-from scipy import stats
 from scipy.spatial import cKDTree
 from pandas import DataFrame
 
@@ -28,7 +27,7 @@ def percentile_threshold(image, percentile):
     not_black = image[np.nonzero(image)]
     if len(not_black) == 0:
         return np.nan
-    return stats.scoreatpercentile(not_black, percentile)
+    return np.percentile(not_black, percentile)
 
 
 def local_maxima(image, radius, percentile=64, margin=None):


### PR DESCRIPTION
This takes @danielballan 's future-proofing commit in the now-defunct https://github.com/nkeim/trackpy/pull/2 and applies it in the present. As far as we know, there is no functionality or performance change.