### PR TITLE
PERF: Support for numba 0.16+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
 
 matrix:
-  include: 
+  include:
+    # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.7.1 scipy=0.13.0 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml pytables"
+      env: DEPS="numpy=1.7.1 scipy=0.12.0 matplotlib=1.3 pandas=0.12.0 scikit-image=0.9 pyyaml pytables"
     - python: "2.7"
-      env: DEPS="numpy=1.7.1 scipy=0.13.0 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.11 pytables"
+      env: DEPS="numpy=1.8.0 scipy=0.13.3 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables"
+    # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
-      env: DEPS="numpy=1.8 scipy matplotlib=1.3 pandas=0.13.0 scikit-image=0.10.1 pyyaml numba=0.12 pytables"
-    - python: "2.7"
-      env: DEPS="numpy=1.8 scipy=0.14.0 matplotlib=1.3 pandas=0.13.0 scikit-image=0.10.1 pyyaml numba=0.12.2 pytables"
+      env: DEPS="numpy=1.9 scipy=0.15 matplotlib=1.4 pandas=0.15 scikit-image=0.10 pyyaml numba=0.17 pytables"
     - python: "3.4"
-      env: DEPS="numpy=1.8 scipy=0.14.0 matplotlib=1.3 pandas=0.14.0 scikit-image=0.10.1 pyyaml pytables"
+      env: DEPS="numpy=1.9 scipy=0.15 matplotlib=1.4 pandas=0.15 scikit-image=0.10 pyyaml numba=0.17 pytables"
 
 install:
   # See:

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,0 +1,36 @@
+What is this?
+-------------
+
+This directory contains a recipe for building a 
+[conda](http://conda.pydata.org/docs/index.html) package for trackpy. It is 
+configured for creating "nightly builds," snapshots of the code in development 
+between releases. The built packages are uploaded to trackpy's 
+[dev channel on binstar](https://binstar.org/soft-matter/trackpy/channels),
+where they can easily be installed on any platform as described in the 
+doucmentation.
+
+Tagged releases are built using a modified recipe that includes the MD5 hash
+of the released code. They are uploaded to trackpy's main channel on binstar.
+
+Building a Package
+------------------
+
+See more detailed background information in the
+[release checklist](https://github.com/soft-matter/trackpy/wiki/Release-Checklist).
+This is just a handy cheatsheet.
+
+    cd trackpy/conda-recipe
+    conda build . --no-binstar-upload --python=2.7
+    conda build . --no-binstar-upload --python=3.3
+    # Note: As of this writing, trackpy does not actually support a version
+    # of numba compatible with Python 3.4.
+
+    conda convert `conda build . --output --python=2.7` --platform all
+    conda convert `conda build . --output --python=3.3` --platform all
+
+
+    binstar upload win-32/trackpy* -u soft-matter -c dev
+    binstar upload win-62/trackpy* -u soft-matter -c dev
+    binstar upload linux-32/trackpy* -u soft-matter -c dev
+    binstar upload linux-64/trackpy* -u soft-matter -c dev
+    binstar upload osx-64/trackpy* -u soft-matter -c dev

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipe/build-all-platforms-and-upload.sh
+++ b/conda-recipe/build-all-platforms-and-upload.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+VERSIONS="27 33 34"
+
+for VERSION in $VERSIONS; do
+	conda build . --python=$VERSION;
+	TARBALL_PATH=$(conda build . --python=$VERSION --output);
+	TARBALL_NAME=$(basename $TARBALL_PATH);
+	conda convert $TARBALL_PATH --platform=all;
+	binstar upload win-32/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload win-64/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload osx-64/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload linux-32/$TARBALL_NAME -u soft-matter -c dev;
+	binstar upload linux-64/$TARBALL_NAME -u soft-matter -c dev;
+done

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: trackpy
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('0.2.3', '0.2.4') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG').replace('0.2.3', '0.2.4') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -31,7 +31,7 @@ requirements:
     - matplotlib
     - pims >=0.2.2
     - pyyaml
-    - numba 0.12.2
+    - numba >=0.12.2
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,45 @@
+package:
+  name: trackpy
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('0.2.3', '0.2.4') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: {{ environ.get('GIT_BUILD_STR', '') + '_py' + environ['PY_VER'] }}
+
+source:
+  git_url: ../
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+    - pyyaml
+    - numpy
+    - pandas
+    - scipy
+    - pims
+    - matplotlib
+
+  run:
+    - python
+    - six >=1.8
+    - pyyaml
+    - numpy >=1.7
+    - pandas >=0.12.0
+    - scipy >=0.12.0
+    - matplotlib
+    - pims >=0.2.2
+    - pyyaml
+    - numba 0.12.2
+
+test:
+  imports:
+    - tifffile
+    - pims
+    - trackpy
+
+about:
+  home: http://trackpy.readthedocs.org
+  license: 3-clause BSD License
+  summary: 'Python particle-tracking toolkit'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: trackpy
-  version: {{ environ.get('GIT_DESCRIBE_TAG').replace('0.2.3', '0.2.4') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG').replace('0.2.4', '0.3.0-pre') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -31,7 +31,7 @@ requirements:
     - matplotlib
     - pims >=0.2.2
     - pyyaml
-    - numba >=0.12.2
+    - numba >=0.13.4
 
 test:
   imports:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -141,10 +141,8 @@ Optional Dependencies:
       HDF5 file. This is included with Anaconda.
   * `numba <http://numba.pydata.org/>`__ for accelerated feature-finding and linking. This is
       included with Anaconda and Canopy. Installing it any other way is difficult;
-      we recommend sticking with one of these. Note that numba v0.12.0
-      (included with Anaconda 1.9.0) has a bug and will not work at all;
-      if you have this version, you should update Anaconda. We support numba
-      versions 0.11 and 0.12.2.
+      we recommend sticking with one of these. We support numba
+      versions >=0.13.4 (though 0.13.3 appears to work). We currently test on 0.17.
 
 PIMS has its own optional dependencies for reading various formats. You
 can read what you need for each format

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -1417,7 +1417,7 @@ def numba_link(s_sn, dest_size, search_range, max_size=30, diag=False):
     dest_results = [dcands[i] if i >= 0 else None for i in best_assignments]
     return source_results, dest_results
 
-@try_numba_autojit(nopython=True)
+@try_numba_autojit
 def _numba_subnet_norecur(ncands, candsarray, dists2array, cur_assignments,
                           cur_sums, tmp_assignments, best_assignments):
     """Find the optimal track assigments for a subnetwork, without recursion.

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -1417,7 +1417,7 @@ def numba_link(s_sn, dest_size, search_range, max_size=30, diag=False):
     dest_results = [dcands[i] if i >= 0 else None for i in best_assignments]
     return source_results, dest_results
 
-@try_numba_autojit
+@try_numba_autojit(nopython=True)
 def _numba_subnet_norecur(ncands, candsarray, dists2array, cur_assignments,
                           cur_sums, tmp_assignments, best_assignments):
     """Find the optimal track assigments for a subnetwork, without recursion.


### PR DESCRIPTION
Due to a refactoring of the numba backend starting with 0.16 (they are now on 0.17), the numba feature-finding code could no longer be compiled to LLVM; instead it was running slower than pure Python. To fix it, I had to remove all array allocation from the function. The result should now run even faster than before, with all compatible versions of numba.