### PR TITLE
BUG/API: Reduce link_df[_iter]() confusion

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -674,8 +674,9 @@ def link_df_iter(features, search_range, memory=0,
 
     # Non-destructively check the type of the first item of features
     feature_iter, feature_checktype_iter = itertools.tee(iter(features))
-    if not isinstance(next(itertools.islice(feature_checktype_iter, 1)),
-                      pd.DataFrame):
+    try:  # If it quacks like a DataFrame...
+        next(itertools.islice(feature_checktype_iter, 1)).reset_index()
+    except AttributeError:
         raise ValueError("Features data must be an iterable of DataFrames, one per "
                          "video frame. Use link_df() if you have a single DataFrame "
                          "describing multiple frames.")

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -675,11 +675,13 @@ def link_df_iter(features, search_range, memory=0,
     # Non-destructively check the type of the first item of features
     feature_iter, feature_checktype_iter = itertools.tee(iter(features))
     try:  # If it quacks like a DataFrame...
-        next(itertools.islice(feature_checktype_iter, 1)).reset_index()
+        next(feature_checktype_iter).reset_index()
     except AttributeError:
         raise ValueError("Features data must be an iterable of DataFrames, one per "
                          "video frame. Use link_df() if you have a single DataFrame "
                          "describing multiple frames.")
+    del feature_checktype_iter  # Otherwise pipes will back up.
+
     # To allow retain_index
     features_for_reset, features_forindex = itertools.tee(feature_iter)
     index_iter = (fr.index.copy() for fr in features_forindex)

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -706,7 +706,7 @@ def link_df_iter(features, search_range, memory=0,
             # produces a malformed labeling.
             _verify_integrity(frame_no, labels)
             # additional checks particular to link_df_iter
-            if not all(frame_no == source_features.frame.values):
+            if not all(frame_no == source_features[t_column].values):
                 raise UnknownLinkingError("The features passed for Frame %d "
                                           "do not all share the same frame "
                                           "number.".format(frame_no))

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -672,7 +672,13 @@ def link_df_iter(features, search_range, memory=0,
     # Group the DataFrame by time steps and make a 'level' out of each
     # one, using the index to keep track of Points.
 
-    feature_iter = iter(features)
+    # Non-destructively check the type of the first item of features
+    feature_iter, feature_checktype_iter = itertools.tee(iter(features))
+    if not isinstance(next(itertools.islice(feature_checktype_iter, 1)),
+                      pd.DataFrame):
+        raise ValueError("Features data must be an iterable of DataFrames, one per "
+                         "video frame. Use link_df() if you have a single DataFrame "
+                         "describing multiple frames.")
     # To allow retain_index
     features_for_reset, features_forindex = itertools.tee(feature_iter)
     index_iter = (fr.index.copy() for fr in features_forindex)

--- a/trackpy/predict.py
+++ b/trackpy/predict.py
@@ -53,6 +53,21 @@ class NullPredict(object):
             self.observe(frame)
             yield frame
 
+    def link_df(self, *args, **kw):
+        """Wrapper for linking.link_df_iter() that causes it to use this predictor.
+
+        As with linking.link_df(), the features data is a single DataFrame.
+
+        Note that this does not wrap linking.link_df(), and does not accept the same
+        options as that function. However in most cases it is functionally equivalent.
+        """
+        args = list(args)
+        features = args.pop(0)
+        if kw.get('t_column') is None:
+            kw['t_column'] = 'frame'
+        features_iter = (frame for fnum, frame in features.groupby(kw['t_column']))
+        return pd.concat(self.link_df_iter(*([features_iter, ] + args), **kw))
+
     def observe(self, frame):
         """Examine the latest output of the linker, to update our predictions."""
         pass

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -348,7 +348,10 @@ class TestOnce(unittest.TestCase):
 
         # smoke tests
         tp.link_df(f, 5, t_column=name, verify_integrity=True)
-        tp.link_df_iter(f, 5, t_column=name, verify_integrity=True)
+
+        f_iter = (frame for fnum, frame in f.groupby('arbitrary name'))
+        list(tp.link_df_iter(f_iter, 5, t_column=name, verify_integrity=True))
+
 
 class SubnetNeededTests(CommonTrackingTests):
     """Tests that assume a best-effort subnet linker (i.e. not "drop")."""

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -352,6 +352,12 @@ class TestOnce(unittest.TestCase):
         f_iter = (frame for fnum, frame in f.groupby('arbitrary name'))
         list(tp.link_df_iter(f_iter, 5, t_column=name, verify_integrity=True))
 
+    @nose.tools.raises(ValueError)
+    def test_check_iter(self):
+        """Check that link_df_iter() makes a useful error message if we
+        try to pass a single DataFrame."""
+        list(tp.link_df_iter(self.features.copy(), 5))
+
 
 class SubnetNeededTests(CommonTrackingTests):
     """Tests that assume a best-effort subnet linker (i.e. not "drop")."""

--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -35,10 +35,24 @@ class BaselinePredictTests(unittest.TestCase):
         """Make sure that a prediction of no motion does not interfere
         with normal tracking.
         """
+        # link_df_iter
         pred = predict.NullPredict()
         ll = get_linked_lengths((mkframe(0), mkframe(0.25)),
                                 pred.link_df_iter, 0.45)
         assert all(ll.values == 2)
+
+        # link_df
+        pred = predict.NullPredict()
+        ll_df = pred.link_df(pandas.concat((mkframe(0), mkframe(0.25))), 0.45)
+        assert all(ll_df.groupby('particle').x.count().values == 2)
+
+        # Make sure that keyword options are handled correctly
+        # (This checks both link_df and link_df_iter)
+        features = pandas.concat((mkframe(0), mkframe(0.25)))
+        features.rename(columns=lambda n: n + '_', inplace=True)
+        pred = predict.NullPredict()
+        ll_df = pred.link_df(features, 0.45, t_column='frame_', pos_columns=['x_', 'y_'])
+        assert all(ll_df.groupby('particle').x_.count().values == 2)
 
     def test_predict_decorator(self):
         """Make sure that a prediction of no motion does not interfere


### PR DESCRIPTION
This addresses https://github.com/soft-matter/trackpy/issues/220 :

1. Useful error message when `link_df_iter()` is passed a single DataFrame
2. Predictors now have `link_df()` methods. It is actually a wrapper for `link_df_iter()` and so does *not* have the default in-place behavior that `link_df()` does.
3. It turned out that `link_df_iter()`'s implementation of the `t_column` option was not being tested and did not actually work. Fixed.

My solution on the second point is not ideal. The docstring clearly states the limitation of my solution, and I think that overall it's more helpful to have a drop-in replacement that works for most users, than to require those users to learn some Pandas tricks if they want to try out prediction on their data. I concluded that implementing a *true* `link_df()` wrapper would require us to either (i) add special prediction code to `link_df()`, (ii) seriously refactor it, or (iii) copy its code into `predict.py`.