### PR TITLE
ENH: Artificial feature images

### DIFF
--- a/doc/releases/v0.3.0.txt
+++ b/doc/releases/v0.3.0.txt
@@ -11,6 +11,8 @@ Feature-Finding
 
 - The percentile-based thresholding was moved into a serpate function, so it can now be called directly. That will be useful to users who want to inspect what the thresholding is doing to their images. It will also be useful for profiling. (:issue:`139`)
 
+- The performance of feature-finding can now be tested in a custom way using new routines in ``artificial.py``. Users can provide a custom feature shape to test the feature-finding on their own system.
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -19,6 +19,7 @@ from .preprocessing import bandpass
 from .framewise_data import FramewiseData, PandasHDFStore, PandasHDFStoreBig, \
            PandasHDFStoreSingleNode
 from . import utils
+from . import artificial
 from .try_numba import try_numba_autojit, enable_numba, disable_numba
 
 

--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -77,7 +77,7 @@ def draw_feature(image, position, diameter, max_value=None,
             raise ValueError("Diameter is already anisotropic; eccentricity is"
                              " not defined.")
         diameter = (diameter[0] / (1 - ecc), diameter[1] * (1 - ecc))
-    radius = tuple([(d - 1) / 2 for d in diameter])
+    radius = tuple([d / 2 for d in diameter])
     if max_value is None:
         max_value = np.iinfo(image.dtype).max - 3
     rect = []

--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -1,0 +1,180 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import six
+import numpy as np
+from scipy.spatial import cKDTree
+from trackpy.utils import validate_tuple
+
+
+def draw_point(image, pos, value):
+    image[tuple(pos)] = value
+
+
+def feat_gauss(r, rg=0.333):
+    """ Gaussian at r = 0 with max value of 1. Its radius of gyration is
+    given by rg. """
+    return np.exp((r/rg)**2 * r.ndim/-2)
+
+
+def feat_gauss_edge(r, value_at_edge=0.1):
+    """ Gaussian at r = 0 with max value of 1. Its value at r = 1 is given by
+    value_at_edge. """
+    return np.exp(np.log(value_at_edge)*r**2)
+
+
+def feat_ring(r, r_at_max, value_at_edge=0.1):
+    """ Ring feature with a gaussian profile, centered at r_at_max. Its value
+    at r = 1 is given by value_at_edge."""
+    return np.exp(np.log(value_at_edge)*((r - r_at_max) / (1 - r_at_max))**2)
+
+
+def feat_hat(r, disc_size, value_at_edge=0.1):
+    """ Solid disc of size disc_size, with Gaussian smoothed borders. """
+    mask = r > disc_size
+    spot = (~mask).astype(r.dtype)
+    spot[mask] = feat_ring(r[mask], disc_size, value_at_edge)
+    spot[~mask] = 1
+    return spot
+
+
+def feat_step(r):
+    """ Solid disc. """
+    return r <= 1
+
+
+def draw_feature(image, position, diameter, max_value=None,
+                 feat_func=feat_gauss, ecc=None, **kwargs):
+    """ Draws a radial symmetric feature and adds it to the image at given
+    position.
+
+    Parameters
+    ----------
+    image : ndarray
+        image to draw features on
+    position : iterable
+        coordinates of feature position
+    diameter : number
+        defines the box that will be drawn on
+    max_value : number
+        maximum feature value. should be much less than the max value of the
+        image dtype, to avoid pixel wrapping at overlapping features
+    feat_func : function. Default: feat_gauss
+        function f(r) that takes an ndarray of radius values
+        and returns intensity values <= 1
+    ecc : positive number, optional
+        eccentricity of feature, defined only in 2D. Identical to setting
+        diameter to (diameter / (1 - ecc), diameter * (1 - ecc))
+    kwargs : keyword arguments are passed to feat_func
+    """
+    if len(position) != image.ndim:
+        raise ValueError("Number of position coordinates should match image"
+                         " dimensionality.")
+    diameter = validate_tuple(diameter, image.ndim)
+    if ecc is not None:
+        if len(diameter) != 2:
+            raise ValueError("Eccentricity is only defined in 2 dimensions")
+        if diameter[0] != diameter[1]:
+            raise ValueError("Diameter is already anisotropic; eccentricity is"
+                             " not defined.")
+        diameter = (diameter[0] / (1 - ecc), diameter[1] * (1 - ecc))
+    radius = tuple([(d - 1) / 2 for d in diameter])
+    if max_value is None:
+        max_value = np.iinfo(image.dtype).max - 3
+    rect = []
+    vectors = []
+    for (c, r, lim) in zip(position, radius, image.shape):
+        if (c >= lim) or (c < 0):
+            raise ValueError("Position outside of image.")
+        lower_bound = max(int(np.floor(c - r)), 0)
+        upper_bound = min(int(np.ceil(c + r + 1)), lim)
+        rect.append(slice(lower_bound, upper_bound))
+        vectors.append(np.arange(lower_bound - c, upper_bound - c) / r)
+    coords = np.meshgrid(*vectors, indexing='ij', sparse=True)
+    r = np.sqrt(np.sum(np.array(coords)**2, axis=0))
+    spot = max_value * feat_func(r, **kwargs)
+    image[rect] += spot.astype(image.dtype)
+
+
+def gen_random_locations(shape, count, margin=0):
+    """ Generates `count` number of positions within `shape`. If a `margin` is
+    given, positions will be inside this margin. Margin may be tuple-valued.
+    """
+    margin = validate_tuple(margin, len(shape))
+    np.random.seed(0)
+    pos = [np.random.randint(round(m), round(s - m), count)
+           for (s, m) in zip(shape, margin)]
+    return np.array(pos).T
+
+
+def eliminate_overlapping_locations(f, separation):
+    """ Makes sure that no position is within `separation` from each other, by
+    deleting one of the that are to close to each other.
+    """
+    separation = validate_tuple(separation, f.shape[1])
+    assert np.greater(separation, 0).all()
+    # Rescale positions, so that pairs are identified below a distance of 1.
+    f = f / separation
+    while True:
+        duplicates = cKDTree(f, 30).query_pairs(1)
+        if len(duplicates) == 0:
+            break
+        to_drop = []
+        for pair in duplicates:
+            to_drop.append(pair[1])
+        f = np.delete(f, to_drop, 0)
+    return f * separation
+
+
+def gen_nonoverlapping_locations(shape, count, separation, margin=0):
+    """ Generates `count` number of positions within `shape`, that have minimum
+    distance `separatin` from each other. The number of positions returned may
+    be lower than `count`, because positions too close to each other will be
+    deleted. If a `margin` is given, positions will be inside this margin.
+    Margin may be tuple-valued.
+    """
+    positions = gen_random_locations(shape, count, margin)
+    return eliminate_overlapping_locations(positions, separation)
+
+
+def draw_spots(shape, positions, diameter, noise_level=0, bitdepth=8,
+               feat_func=feat_gauss, ecc=None, **kwargs):
+    """ Generates an image with features at given positions.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        the shape of the produced image
+    positions : iterable of tuples
+        an iterable of positions
+    diameter : number or tuple
+        the sizes of the box that will be used per feature. The actual feature
+        'size' is determined by feat_func and kwargs given to feat_func.
+    noise_level : int, default: 0
+        white noise will be generated up to this level
+    bitdepth : int, default: 8
+        the desired bitdepth of the image (<=32 bits)
+    feat_func : function, default: feat_gauss
+        function f(r) that takes an ndarray of radius values
+        and returns intensity values <= 1
+    ecc : positive number, optional
+        eccentricity of feature, defined only in 2D. Identical to setting
+        diameter to (diameter / (1 - ecc), diameter * (1 - ecc))
+    kwargs : keyword arguments are passed to feat_func
+    """
+    if bitdepth <= 8:
+        dtype = np.uint8
+        internaldtype = np.uint16
+    elif bitdepth <= 16:
+        dtype = np.uint16
+        internaldtype = np.uint32
+    elif bitdepth <= 32:
+        dtype = np.uint32
+        internaldtype = np.uint64
+    else:
+        raise ValueError('Bitdepth should be <= 32')
+    np.random.seed(0)
+    image = np.random.randint(0, noise_level + 1, shape).astype(internaldtype)
+    for pos in positions:
+        draw_feature(image, pos, diameter, max_value=2**bitdepth - 1,
+                     feat_func=feat_func, ecc=ecc, **kwargs)
+    return image.clip(0, 2**bitdepth - 1).astype(dtype)

--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -45,7 +45,8 @@ def feat_step(r):
 def draw_feature(image, position, diameter, max_value=None,
                  feat_func=feat_gauss, ecc=None, **kwargs):
     """ Draws a radial symmetric feature and adds it to the image at given
-    position.
+    position. The given function will be evaluated at each pixel coordinate,
+    no averaging or convolution is done.
 
     Parameters
     ----------
@@ -127,7 +128,7 @@ def eliminate_overlapping_locations(f, separation):
 
 def gen_nonoverlapping_locations(shape, count, separation, margin=0):
     """ Generates `count` number of positions within `shape`, that have minimum
-    distance `separatin` from each other. The number of positions returned may
+    distance `separation` from each other. The number of positions returned may
     be lower than `count`, because positions too close to each other will be
     deleted. If a `margin` is given, positions will be inside this margin.
     Margin may be tuple-valued.
@@ -138,7 +139,9 @@ def gen_nonoverlapping_locations(shape, count, separation, margin=0):
 
 def draw_spots(shape, positions, diameter, noise_level=0, bitdepth=8,
                feat_func=feat_gauss, ecc=None, **kwargs):
-    """ Generates an image with features at given positions.
+    """ Generates an image with features at given positions. A feature with
+    position x will be centered around pixel x. In other words, the origin of
+    the output image is located at the center of pixel (0, 0).
 
     Parameters
     ----------

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -495,6 +495,10 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
 
     Notes
     -----
+    Locate works with a coordinate system that has its origin at the center of
+    pixel (0, 0). In almost all cases this will be the topleft pixel: the
+    y-axis is pointing downwards.
+
     This is an implementation of the Crocker-Grier centroid-finding algorithm.
     [1]_
 
@@ -732,6 +736,10 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
     -----
     This is an implementation of the Crocker-Grier centroid-finding algorithm.
     [1]_
+
+    Locate works with a coordinate system that has its origin at the center of
+    pixel (0, 0). In almost all cases this will be the topleft pixel: the
+    y-axis is pointing downwards.
 
     References
     ----------

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -552,42 +552,34 @@ class CommonFeatureIdentificationTests(object):
         # http://www.physics.emory.edu/~weeks/idl/radius.html
 
         self.check_skip()
-        L = 101 
+        L = 101
         dims = (L, L + 2)  # avoid square images in tests
         pos = [50, 55]
-        cols = ['y', 'x']
-
-        SIZE = 2
-        image = np.ones(dims, dtype='uint8')
-        draw_feature(image, pos, (SIZE*2 + 1) * 3)
-        actual = tp.locate(image, SIZE*2 + 5, 1, preprocess=False,
-                           engine=self.engine)['size']
-        expected = SIZE
-        assert_allclose(actual, expected, rtol=0.1)
 
         SIZE = 3
         image = np.ones(dims, dtype='uint8')
-        draw_feature(image, pos, (SIZE*2 + 1) * 3)
-        actual = tp.locate(image, SIZE*2 + 5, 1, preprocess=False,
+        draw_feature(image, pos, (SIZE*2 + 1) * 3, rg=0.333)
+        actual = tp.locate(image, (SIZE*2 + 1) * 3, 1, preprocess=False,
                            engine=self.engine)['size']
-        expected = SIZE
+        expected = SIZE + 0.2  # rg always turns out slightly higher
         assert_allclose(actual, expected, rtol=0.1)
 
         SIZE = 5
         image = np.ones(dims, dtype='uint8')
-        draw_feature(image, pos, (SIZE*2 + 1) * 3)
-        actual = tp.locate(image, SIZE*2 + 7, 1, preprocess=False,
+        draw_feature(image, pos, (SIZE*2 + 1) * 3, rg=0.333)
+        actual = tp.locate(image, (SIZE*2 + 1) * 3, 1, preprocess=False,
                            engine=self.engine)['size']
-        expected = SIZE
+        expected = SIZE + 0.2  # rg always turns out slightly higher
         assert_allclose(actual, expected, rtol=0.1)
 
-        SIZE = 7
+        SIZE = 8
         image = np.ones(dims, dtype='uint8')
-        draw_feature(image, pos, (SIZE*2 + 1) * 3)
-        actual = tp.locate(image, SIZE*2 + 11, 1, preprocess=False,
+        draw_feature(image, pos, (SIZE*2 + 1) * 3, rg=0.333)
+        actual = tp.locate(image, (SIZE*2 + 1) * 3, 1, preprocess=False,
                            engine=self.engine)['size']
-        expected = SIZE
+        expected = SIZE + 0.2  # rg always turns out slightly higher
         assert_allclose(actual, expected, rtol=0.1)
+
 
     def test_eccentricity(self):
         # Eccentricity (elongation) is measured with good accuracy and

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -405,9 +405,12 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=PRECISION)
 
     def test_rg(self):
-        # For Gaussians with radii 2, 3, 5, and 7 px, with proportionately
-        # chosen feature (mask) sizes, the 'size' comes out to be within 10%
-        # of the true Gaussian width.
+        # To draw Gaussians with radii 2, 3, 5, and 7 px, we supply the draw
+        # function with rg=0.25. This means that the radius of gyration will be
+        # one fourth of the max radius in the draw area, which is diameter/2.
+
+        # The 'size' comes out to be within 3%, which is because of the
+        # pixelation of the Gaussian.
 
         # The IDL code has mistake in this area, documented here:
         # http://www.physics.emory.edu/~weeks/idl/radius.html
@@ -415,32 +418,13 @@ class CommonFeatureIdentificationTests(object):
         self.check_skip()
         L = 101
         dims = (L, L + 2)  # avoid square images in tests
-        pos = [50, 55]
-
-        SIZE = 3
-        image = np.ones(dims, dtype='uint8')
-        draw_feature(image, pos, (SIZE*2 + 1) * 3, rg=0.333)
-        actual = tp.locate(image, (SIZE*2 + 1) * 3, 1, preprocess=False,
-                           engine=self.engine)['size']
-        expected = SIZE + 0.2  # rg always turns out slightly higher
-        assert_allclose(actual, expected, rtol=0.1)
-
-        SIZE = 5
-        image = np.ones(dims, dtype='uint8')
-        draw_feature(image, pos, (SIZE*2 + 1) * 3, rg=0.333)
-        actual = tp.locate(image, (SIZE*2 + 1) * 3, 1, preprocess=False,
-                           engine=self.engine)['size']
-        expected = SIZE + 0.2  # rg always turns out slightly higher
-        assert_allclose(actual, expected, rtol=0.1)
-
-        SIZE = 8
-        image = np.ones(dims, dtype='uint8')
-        draw_feature(image, pos, (SIZE*2 + 1) * 3, rg=0.333)
-        actual = tp.locate(image, (SIZE*2 + 1) * 3, 1, preprocess=False,
-                           engine=self.engine)['size']
-        expected = SIZE + 0.2  # rg always turns out slightly higher
-        assert_allclose(actual, expected, rtol=0.1)
-
+        for pos in [[50, 55], [50.2, 55], [50.5, 55]]:
+            for SIZE in [2, 3, 5, 7]:
+                image = np.zeros(dims, dtype='uint8')
+                draw_feature(image, pos, SIZE*8, rg=0.25)
+                actual = tp.locate(image, SIZE*8 - 1, 1, preprocess=False,
+                                   engine=self.engine)['size']
+                assert_allclose(actual, SIZE, rtol=0.1)
 
     def test_eccentricity(self):
         # Eccentricity (elongation) is measured with good accuracy and


### PR DESCRIPTION
I combined some work that I did on the creation of artificial feature images. This is more flexible than the functions in `test_feature.py`, enabling the user to write any radial function and generate artificial images based on that.

A new file `artificial.py` is created so that users can use `tp.artificial.draw_spots` to make their own tests. I tried to make the documentation in the functions complete.

I changed `test_feature.py` to make use of these functions. The changes are:
 - `draw_gaussian_spot` needed the radius of gyration as a parameter. The new `draw_feature` defaults to a gaussian, but you need to supply the box size on which is drawn. By default, this is 6x the radius of gyration. 
 - `test_feature.compare` is now protected against features that overlap. Incidentally, this could go wrong before.
 - `test_rg` was going right coincidentally all along. See commit message https://github.com/soft-matter/trackpy/commit/75877a4dd39b27253dc78afa6e1f85597ff48fec for a further clarification

