### PR TITLE
BUG/TST: Address Pandas potential chained-assingment issue

### DIFF
--- a/trackpy/predict.py
+++ b/trackpy/predict.py
@@ -96,7 +96,7 @@ class _RecentVelocityPredict(NullPredict):
         positions = disps[self.pos_columns]
         vels = disps[[cn + '_disp_' for cn in self.pos_columns]] / dt
         # 'vels' will have same column names as 'positions'
-        vels.rename(columns=lambda n: n[:-6], inplace=True)
+        vels = vels.rename(columns=lambda n: n[:-6])
         return dt, positions, vels
 
 

--- a/trackpy/tests/test_correlations.py
+++ b/trackpy/tests/test_correlations.py
@@ -9,6 +9,9 @@ import pandas as pd
 from numpy.testing import assert_allclose
 from pandas import DataFrame, Series
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pd.set_option('mode.chained_assignment', 'raise')
+
 import trackpy as tp
 
 class TestCorrelations(unittest.TestCase):

--- a/trackpy/tests/test_correlations.py
+++ b/trackpy/tests/test_correlations.py
@@ -9,10 +9,10 @@ import pandas as pd
 from numpy.testing import assert_allclose
 from pandas import DataFrame, Series
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pd.set_option('mode.chained_assignment', 'raise')
-
 import trackpy as tp
+
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+tp.utils.make_pandas_strict()
 
 class TestCorrelations(unittest.TestCase):
 

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -15,6 +15,9 @@ from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_produces_warning)
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pd.set_option('mode.chained_assignment', 'raise')
+
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point,

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -15,14 +15,13 @@ from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_produces_warning)
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pd.set_option('mode.chained_assignment', 'raise')
-
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point,
                                 gen_nonoverlapping_locations)
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+tp.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -9,7 +9,11 @@ import os
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 from numpy.testing.decorators import slow
+import pandas
 from pandas.util.testing import (assert_series_equal, assert_frame_equal)
+
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pandas.set_option('mode.chained_assignment', 'raise')
 
 import trackpy as tp 
 

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -12,11 +12,10 @@ from numpy.testing.decorators import slow
 import pandas
 from pandas.util.testing import (assert_series_equal, assert_frame_equal)
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pandas.set_option('mode.chained_assignment', 'raise')
-
 import trackpy as tp 
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+tp.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -14,6 +14,9 @@ from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_almost_equal)
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pd.set_option('mode.chained_assignment', 'raise')
+
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking import PointND, link, Hash_table

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -14,13 +14,12 @@ from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_almost_equal)
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pd.set_option('mode.chained_assignment', 'raise')
-
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking import PointND, link, Hash_table
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+tp.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 path = os.path.join(path, 'data')

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -12,11 +12,11 @@ from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_almost_equal)
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pd.set_option('mode.chained_assignment', 'raise')
-
 import trackpy as tp 
 from trackpy.utils import suppress_plotting
+
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+tp.utils.make_pandas_strict()
 
 def random_walk(N):
     return np.cumsum(np.random.randn(N))

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -12,6 +12,9 @@ from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_almost_equal)
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pd.set_option('mode.chained_assignment', 'raise')
+
 import trackpy as tp 
 from trackpy.utils import suppress_plotting
 

--- a/trackpy/tests/test_plot_traj_labeling.py
+++ b/trackpy/tests/test_plot_traj_labeling.py
@@ -7,6 +7,9 @@ import os
 from numpy.testing.decorators import slow
 import pandas as pd
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pd.set_option('mode.chained_assignment', 'raise')
+
 from trackpy import ptraj
 from trackpy.utils import suppress_plotting
 

--- a/trackpy/tests/test_plot_traj_labeling.py
+++ b/trackpy/tests/test_plot_traj_labeling.py
@@ -7,12 +7,12 @@ import os
 from numpy.testing.decorators import slow
 import pandas as pd
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pd.set_option('mode.chained_assignment', 'raise')
-
+import trackpy
 from trackpy import ptraj
 from trackpy.utils import suppress_plotting
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+trackpy.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -7,11 +7,12 @@ import numpy as np
 import pandas as pd
 from pandas import Series, DataFrame
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pd.set_option('mode.chained_assignment', 'raise')
-
+import trackpy
 from trackpy import plots
 from trackpy.utils import suppress_plotting, fit_powerlaw
+
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+trackpy.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -6,6 +6,10 @@ import os
 import numpy as np
 import pandas as pd
 from pandas import Series, DataFrame
+
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pd.set_option('mode.chained_assignment', 'raise')
+
 from trackpy import plots
 from trackpy.utils import suppress_plotting, fit_powerlaw
 

--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -8,11 +8,11 @@ import nose.tools
 import numpy as np
 import pandas
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-pandas.set_option('mode.chained_assignment', 'raise')
-
 import trackpy
 from trackpy import predict
+
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+trackpy.utils.make_pandas_strict()
 
 def mkframe(n=1, Nside=3):
     xg, yg = np.mgrid[:Nside,:Nside]

--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -8,6 +8,9 @@ import nose.tools
 import numpy as np
 import pandas
 
+# Catch attempts to set values on an inadvertent copy of a Pandas object.
+pandas.set_option('mode.chained_assignment', 'raise')
+
 import trackpy
 from trackpy import predict
 

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -195,3 +195,16 @@ def print_update(message):
         pass
     print(message)
     sys.stdout.flush()
+
+
+def make_pandas_strict():
+    """Configure Pandas to raise an exception for "chained assignments."
+
+    This is useful during tests.
+    See http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
+
+    Does nothing for Pandas versions before 0.13.0.
+    """
+    major, minor, micro = pd.__version__.split('.')
+    if major == '0' and int(minor) >= 13:
+        pd.set_option('mode.chained_assignment', 'raise')


### PR DESCRIPTION
See #231. Under certain conditions (still not quite understood), the prediction code could try to set values in an inadvertently-generated *copy* of a DataFrame. This is bad if the values in the original DataFrame were ever needed again, so Pandas generates a warning.

This PR fixes the line of code that caused the warning reported by @apiszcz in #231. It also makes Pandas more strict about this condition in tests, as I explain in one of the commit messages below:

"See http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy . This commit addresses no past or current known bugs, but it could prevent future surprises by causing tests to fail if there are chained assignments inherent in the code. In regular (non-test) use, such a condition would generate a warning only (which would promptly get cleared from the IPython output during multi-frame operations), while *possibly* leading to incorrect results."

I believe this PR *would* have caught exactly such a bug that I created when implementing diagnostics, and that, as it was, I had a very hard time tracking down.