### PR TITLE
BLD: Run in a Travis container for faster testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 matrix:
   include:


### PR DESCRIPTION
By surrendering sudo access (which we don't use) we can run our tests in Travis's "containers," which kick off more promptly and run on faster hardware.