### PR TITLE
ENH Anisotropic feature characterization

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -679,8 +679,9 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
         Npx = N_binary_mask(radius, ndim)
         mass = refined_coords[:, SIGNAL_COLUMN_INDEX + 1] - Npx * black_level
         ep = _static_error(mass, noise, radius[::-1], noise_size[::-1])
+        refined_coords = np.column_stack([refined_coords, ep])
 
-    f = DataFrame(np.column_stack([refined_coords, ep]), columns=columns)
+    f = DataFrame(refined_coords, columns=columns)
 
     # If this is a pims Frame object, it has a frame number.
     # Tag it on; this is helpful for parallelization.

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -13,7 +13,7 @@ from .preprocessing import bandpass, scale_to_gamut, scalefactor_to_gamut
 from .utils import record_meta, print_update, validate_tuple
 from .masks import (binary_mask, N_binary_mask, r_squared_mask,
                     x_squared_masks, cosmask, sinmask)
-from .uncertainty import static_error, measure_noise
+from .uncertainty import _static_error, measure_noise
 import trackpy  # to get trackpy.__version__
 
 from .try_numba import try_numba_autojit, NUMBA_AVAILABLE
@@ -678,7 +678,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
             black_level, noise = measure_noise(raw_image, diameter, threshold)
         Npx = N_binary_mask(radius, ndim)
         mass = refined_coords[:, SIGNAL_COLUMN_INDEX + 1] - Npx * black_level
-        ep = static_error(mass, noise, radius[::-1], ndim, noise_size[::-1])
+        ep = _static_error(mass, noise, radius[::-1], noise_size[::-1])
 
     f = DataFrame(np.column_stack([refined_coords, ep]), columns=columns)
 

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -616,7 +616,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
         approx_mass = np.empty(count_maxima)  # initialize to avoid appending
         for i in range(count_maxima):
             approx_mass[i] = estimate_mass(image, radius, coords[i])
-        condition = approx_mass > minmass
+        condition = approx_mass > minmass * scale_factor
         if maxsize is not None:
             approx_size = np.empty(count_maxima)
             for i in range(count_maxima):

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -57,14 +57,6 @@ def x_squared_masks(radius, ndim):
 
 
 @memo
-def root_sum_x_squared(radius, ndim):
-    "Returns the root of the sum of all x^2 inside the mask for each dim."
-    masks = x_squared_masks(radius, ndim)
-    r2 = np.sum(masks, axis=tuple(range(1, ndim + 1)))  # each ax except first
-    return np.sqrt(r2)
-
-
-@memo
 def theta_mask(radius):
     """Mask of values giving angular position relative to center. The angle is
     defined according to ISO standards in which the angle is measured counter-

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -69,7 +69,7 @@ def theta_mask(radius):
     "Mask of values giving angular position relative to center"
     # 2D only
     radius = validate_tuple(radius, 2)
-    tan_of_coord = lambda y, x: np.arctan2(radius[0] - y, x - radius[1])
+    tan_of_coord = lambda y, x: np.arctan2(y - radius[0], x - radius[1])
     return np.fromfunction(tan_of_coord, [r * 2 + 1 for r in radius])
 
 

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -17,8 +17,13 @@ def binary_mask(radius, ndim):
         coords = np.array(np.meshgrid(*points, indexing="ij"))
     else:
         coords = np.array([points[0]])
-    r = [(coord/rad)**2 for (coord,rad) in zip(coords,radius)]
+    r = [(coord/rad)**2 for (coord, rad) in zip(coords, radius)]
     return sum(r) <= 1
+
+
+@memo
+def N_binary_mask(radius, ndim):
+    return np.sum(binary_mask(radius,ndim))
 
 
 @memo
@@ -30,19 +35,42 @@ def r_squared_mask(radius, ndim):
         coords = np.array(np.meshgrid(*points, indexing="ij"))
     else:
         coords = np.array([points[0]])
-    r = [(coord/rad)**2 for (coord,rad) in zip(coords,radius)]
+    r = [(coord/rad)**2 for (coord, rad) in zip(coords, radius)]
     r2 = np.sum(coords**2, 0).astype(int)
     r2[sum(r) > 1] = 0
     return r2
+    
+
+@memo
+def x_squared_masks(radius, ndim):
+    "Returns ndim masks with values x^2 inside radius and 0 outside"
+    radius = validate_tuple(radius, ndim)
+    points = [np.arange(-rad, rad + 1) for rad in radius]
+    if len(radius) > 1:
+        coords = np.array(np.meshgrid(*points, indexing="ij"))
+    else:
+        coords = np.array([points[0]])
+    r = [(coord/rad)**2 for (coord, rad) in zip(coords, radius)]
+    masks = np.asarray(coords**2, dtype=int)
+    masks[:, sum(r) > 1] = 0
+    return masks
+
+
+@memo
+def root_sum_x_squared(radius, ndim):
+    "Returns the root of the sum of all x^2 inside the mask for each dim."
+    masks = x_squared_masks(radius, ndim)
+    r2 = np.sum(masks, axis=tuple(range(1, ndim + 1)))  # each ax except first
+    return np.sqrt(r2)
 
 
 @memo
 def theta_mask(radius):
     "Mask of values giving angular position relative to center"
     # 2D only
-    tan_of_coord = lambda y, x: np.arctan2(radius - y, x - radius)
-    diameter = 2*radius + 1
-    return np.fromfunction(tan_of_coord, (diameter, diameter))
+    radius = validate_tuple(radius, 2)
+    tan_of_coord = lambda y, x: np.arctan2(radius[0] - y, x - radius[1])
+    return np.fromfunction(tan_of_coord, [r * 2 + 1 for r in radius])
 
 
 @memo

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -66,7 +66,17 @@ def root_sum_x_squared(radius, ndim):
 
 @memo
 def theta_mask(radius):
-    "Mask of values giving angular position relative to center"
+    """Mask of values giving angular position relative to center. The angle is
+    defined according to ISO standards in which the angle is measured counter-
+    clockwise from the x axis, measured in a normal coordinate system with y-
+    axis pointing up and x axis pointing right.
+
+    In other words: for increasing angle, the coordinate moves counterclockwise
+    around the feature center starting on the right side.
+
+    However, in most images, the y-axis will point down so that the coordinate
+    will appear to move clockwise around the feature center.
+    """
     # 2D only
     radius = validate_tuple(radius, 2)
     tan_of_coord = lambda y, x: np.arctan2(y - radius[0], x - radius[1])

--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -37,11 +37,27 @@ else:
         return pyfftw.interfaces.numpy_fft.ifftn(a)
 
 
-def bandpass(image, lshort, llong, threshold=None, analyze_background=False):
+def bandpass_raw(image, lshort, llong):
+    lshort = validate_tuple(lshort, image.ndim)
+    llong = validate_tuple(llong, image.ndim)
+    if np.any([x*2 >= y for (x, y) in zip(lshort, llong)]):
+        raise ValueError("The smoothing length scale must be more" +
+                         "than twice the noise length scale.")
+    # Perform a rolling average (boxcar) with kernel size = 2*llong + 1
+    boxcar = np.asarray(image)
+    for (axis, size) in enumerate(llong):
+        boxcar = uniform_filter1d(boxcar, size*2+1, axis, mode='nearest',
+                                  cval=0)
+    # Perform a gaussian filter
+    gaussian = ifftn(fourier_gaussian(fftn(image), lshort)).real
+
+    return gaussian - boxcar
+
+
+def bandpass(image, lshort, llong, threshold=None):
     """Convolve with a Gaussian to remove short-wavelength noise,
     and subtract out long-wavelength variations,
     retaining features of intermediate scale.
-
     Parmeters
     ---------
     image : ndarray
@@ -51,42 +67,67 @@ def bandpass(image, lshort, llong, threshold=None, analyze_background=False):
         give a tuple value for different sizes per dimension
         give int value for same value for all dimensions
         when 2*lshort >= llong, no noise filtering is applied
-
     threshold : float or integer
         By default, 1 for integer images and 1/256. for float images.
-
     Returns
     -------
     ndarray, the bandpassed image
     """
-    lshort = validate_tuple(lshort, image.ndim)
-    llong = validate_tuple(llong, image.ndim)
-    if np.any([x*2 >= y for (x, y) in zip(lshort, llong)]):
-        raise ValueError("The smoothing length scale must be more" +
-                         "than twice the noise length scale.")
+    result = bandpass_raw(image, lshort, llong)
+
     if threshold is None:
         if np.issubdtype(image.dtype, np.integer):
             threshold = 1
         else:
             threshold = 1/256.
-    settings = dict(mode='nearest', cval=0)
-    axes = range(image.ndim)
-    sizes = [x*2+1 for x in llong]
-    boxcar = np.asarray(image)
-    for (axis, size) in zip(axes, sizes):
-        boxcar = uniform_filter1d(boxcar, size, axis, **settings)
-    gaussian = ifftn(fourier_gaussian(fftn(image), lshort)).real
-    result = gaussian - boxcar
-    signal = result > threshold
-    if not analyze_background:
-        return np.where(signal, result, 0)
-    background = image[~signal]
-    return np.where(signal, result, 0), background.mean(), background.std()
+
+    return np.where(result > threshold, result, 0)
 
 
-def scale_to_gamut(image, original_dtype, return_scale_factor=False):
-    scale_factor = np.iinfo(original_dtype).max / image.max()
+def bandpass_detailed(image, lshort, llong, threshold=None):
+    """Convolve with a Gaussian to remove short-wavelength noise,
+    and subtract out long-wavelength variations,
+    retaining features of intermediate scale.
+    Parmeters
+    ---------
+    image : ndarray
+    lshort : small-scale cutoff (noise)
+    llong : large-scale cutoff
+    for both lshort and llong:
+        give a tuple value for different sizes per dimension
+        give int value for same value for all dimensions
+        when 2*lshort >= llong, no noise filtering is applied
+    threshold : float or integer
+        By default, 1 for integer images and 1/256. for float images.
+    Returns
+    -------
+    ndarray, the bandpassed image
+    black_level, average background level
+    noise_size, standard deviation of background
+    """
+    result = bandpass_raw(image, lshort, llong)
+    if threshold is None:
+        if np.issubdtype(image.dtype, np.integer):
+            threshold = 1
+        else:
+            threshold = 1/256.
+
+    roi = result > threshold
+    processed_image = np.where(roi, result, 0)
+
+    # Analyze the background
+    background_image = image[~roi]
+    black_level = background_image.mean()
+    noise_size = background_image.std()
+    return processed_image, black_level, noise_size
+
+
+def scalefactor_to_gamut(image, original_dtype):
+    return np.iinfo(original_dtype).max / image.max()
+
+
+def scale_to_gamut(image, original_dtype, scale_factor=None):
+    if scale_factor is None:
+        scale_factor = scalefactor_to_gamut(image, original_dtype)
     scaled = (scale_factor * image.clip(min=0.)).astype(original_dtype)
-    if return_scale_factor:
-        return scaled, scale_factor
     return scaled

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -471,22 +471,20 @@ class CommonFeatureIdentificationTests(object):
 
     def test_size_anisotropic(self):
         # The separate columns 'size_x' and 'size_y' reflect the radii of
-        # gyration in the two separate directions. rg**2 = size_x**2+size_y**2
-        # so for comparison we need a factor of sqrt(2)
+        # gyration in the two separate directions.
 
         self.skip_numba()
         L = 101
         SIZE = 5
         dims = (L, L + 2)  # avoid square images in tests
         pos = [50, 55]
-        EXPECTED = SIZE/np.sqrt(2)
         for ar in [1.1, 1.5, 2]:
             image = np.zeros(dims, dtype='uint8')
             draw_feature(image, pos, [int(SIZE*8*ar), SIZE*8], rg=0.25)
             f = tp.locate(image, [int(SIZE*4*ar) * 2 - 1, SIZE*8 - 1], 1,
                           preprocess=False, engine=self.engine)
-            assert_allclose(f['size_x'], EXPECTED, rtol=0.1)
-            assert_allclose(f['size_y'], EXPECTED*ar, rtol=0.1)
+            assert_allclose(f['size_x'], SIZE, rtol=0.1)
+            assert_allclose(f['size_y'], SIZE*ar, rtol=0.1)
 
     def test_eccentricity(self):
         # Eccentricity (elongation) is measured with good accuracy and

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -10,7 +10,8 @@ import nose
 import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import (assert_almost_equal, assert_allclose,
+                           assert_array_less)
 from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_produces_warning)
@@ -19,6 +20,8 @@ import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point,
                                 gen_nonoverlapping_locations)
+                                
+from scipy.spatial import KDTree
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()
@@ -39,6 +42,12 @@ def compare(shape, count, radius, noise_level, engine):
     actual = f[cols].sort(cols)
     expected = DataFrame(pos, columns=cols).sort(cols)
     return actual, expected
+
+
+def sort_positions(actual, expected):
+    tree = KDTree(actual)
+    deviations, argsort = tree.query([expected])
+    return deviations, actual[argsort][0]
 
 
 class CommonFeatureIdentificationTests(object):
@@ -560,32 +569,73 @@ class CommonFeatureIdentificationTests(object):
         expected = ECC
         assert_allclose(actual, expected, atol=0.1)
 
-    def test_noise_estimation(self):
-        # Test wether the estimation of background noise indeed agrees with
-        # features on an artificial uniform distribution.
+    def test_ep(self):
+        # Test wether the estimated static error equals the rms deviation from
+        # the expected values. Next to the feature mass, the static error is
+        # calculated from the estimated image background level and variance.
+        # This estimate is also tested here.
 
-        # A threshold is necessary to estimate the noise_level correctly. Here
-        # this is put to noise_level / 4.
-        radius = 7
+        # A threshold is necessary to identify the background array so that
+        # background average and standard deviation can be estimated within 1%
+        # accuracy.
+
+        # The (absolute) tolerance for ep in this test is 0.05 pixels.
+        # Parameters are tweaked so that there is no deviation due to a too
+        # small mask size. Signal/noise ratios upto 50% are tested.
+        self.check_skip()
+        draw_diameter = 21
+        locate_diameter = 15
         N = 200
-        shape = (512, 512)
+        shape = (512, 513)
         noise_expectation = np.array([1/2., np.sqrt(1/12.)])  # average, stdev
 
         # Generate feature locations and make the image
-        expected = gen_nonoverlapping_locations(shape, N, radius*5, radius+2)
+        expected = gen_nonoverlapping_locations(shape, N, draw_diameter,
+                                                locate_diameter)
         expected = expected + np.random.random(expected.shape)
         N = expected.shape[0]
-        image = draw_spots(shape, expected, radius*3, bitdepth=12)
+        image = draw_spots(shape, expected, draw_diameter, bitdepth=12)
 
-        for n, noise in enumerate(np.arange(0.05, 0.8, 0.05)):
+        for n, noise in enumerate([0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.5]):
             noise_level = int((2**12 - 1) * noise)
             image_noisy = image + np.array(np.random.randint(0, noise_level,
                                                              image.shape),
                                            dtype=image.dtype)
-            actual_noise = tp.uncertainty.measure_noise(image_noisy, radius*2+1,
-                                                        threshold=noise_level/4)
+
+            f = tp.locate(image_noisy, locate_diameter, engine=self.engine,
+                          topn=N, threshold=noise_level/4)
+
+            _, actual = sort_positions(f[['y', 'x']].values, expected)
+            rms_dev = np.sqrt(np.mean(np.sum((actual-expected)**2, 1)))
+            assert_allclose(rms_dev, f['ep'].mean(), atol=0.05)
+
+            # Additionally test the measured noise
+            actual_noise = tp.uncertainty.measure_noise(image_noisy,
+                                                        locate_diameter,
+                                                        noise_level/4)
             assert_allclose(actual_noise, noise_expectation * noise_level,
-                            rtol=0.01)
+                            rtol=0.01, atol=1)
+
+    def test_ep_anisotropic(self):
+        # The separate columns 'ep_x' and 'ep_y' reflect the static errors
+        # in the two separate directions. The error in the direction with the
+        # smallest mask size should be lowest; their ratio is equal to the
+        # mask aspect ratio.
+
+        self.skip_numba()
+        L = 101
+        SIZE = 5
+        dims = (L, L + 2)  # avoid square images in tests
+        pos = [50, 55]
+        noise = 0.2
+        for ar in [1.1, 1.5, 2]:  # sizeY / sizeX
+            image = np.random.randint(0, int(noise*255), dims).astype('uint8')
+            draw_feature(image, pos, [int(SIZE*8*ar), SIZE*8],
+                         max_value=int((1-noise)*255))
+            f = tp.locate(image, [int(SIZE*4*ar) * 2 - 1, SIZE*8 - 1],
+                          threshold=int(noise*64), topn=1,
+                          engine=self.engine).loc[0]
+            assert_allclose(f['ep_y'] / f['ep_x'], ar, rtol=0.1)
 
     def test_whole_pixel_shifts(self):
         self.check_skip()

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -43,13 +43,14 @@ def _skip_if_no_pytables():
 
 
 class FeatureSavingTester(object):
-
     def prepare(self):
         directory = os.path.join(path, 'video', 'image_sequence')
         self.v = ImageSequence(os.path.join(directory, '*.png'))
-        self.PARAMS = (11, 200)
-        self.expected = tp.batch(self.v[[0, 1]], diameter=11, minmass=200,
-                                 engine='python', meta=False)
+        # mass depends on pixel dtype, which differs per reader
+        minmass = self.v[0].max() * 2
+        self.PARAMS = {'diameter': 11, 'minmass': minmass, 'invert': True}
+        self.expected = tp.batch(self.v[[0, 1]], engine='python', meta=False,
+                                 **self.PARAMS)
 
     def test_storage(self):
         STORE_NAME = 'temp_for_testing_{0}.h5'.format(_random_hash())
@@ -60,8 +61,8 @@ class FeatureSavingTester(object):
         except IOError:
             nose.SkipTest('Cannot make an HDF5 file. Skipping')
         else:
-            tp.batch(self.v[[0, 1]], *self.PARAMS,
-                     output=s, engine='python', meta=False)
+            tp.batch(self.v[[0, 1]], output=s, engine='python', meta=False,
+                     **self.PARAMS)
             self.assertEqual(len(s), 2)
             self.assertEqual(s.max_frame, 1)
             count_total_dumped = s.dump()['frame'].nunique()

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -13,6 +13,7 @@ import pandas
 from pandas.util.testing import (assert_series_equal, assert_frame_equal)
 
 import trackpy as tp 
+from pims import ImageSequence
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()
@@ -45,9 +46,9 @@ class FeatureSavingTester(object):
 
     def prepare(self):
         directory = os.path.join(path, 'video', 'image_sequence')
-        self.v = tp.ImageSequence(os.path.join(directory, '*.png'))
-        self.PARAMS = (11, 3000)
-        self.expected = tp.batch(self.v[[0, 1]], *self.PARAMS,
+        self.v = ImageSequence(os.path.join(directory, '*.png'))
+        self.PARAMS = (11, 200)
+        self.expected = tp.batch(self.v[[0, 1]], diameter=11, minmass=200,
                                  engine='python', meta=False)
 
     def test_storage(self):

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -3,10 +3,11 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import numpy as np
 from scipy.ndimage import morphology
+from pandas import DataFrame
 
 from .preprocessing import bandpass
-from .masks import binary_mask, N_binary_mask, root_sum_x_squared
-from .utils import validate_tuple
+from .masks import binary_mask, x_squared_masks
+from .utils import memo, validate_tuple
 
 
 def roi(image, diameter, threshold=None, image_bandpassed=None):
@@ -40,23 +41,46 @@ def measure_noise(image, diameter, threshold, image_bandpassed=None):
     return image[~signal_mask].mean(), image[~signal_mask].std()
 
 
-def static_error(mass, noise, radius, ndim=2, noise_size=1):
+@memo
+def _root_sum_x_squared(radius, ndim):
+    "Returns the root of the sum of all x^2 inside the mask for each dim."
+    masks = x_squared_masks(radius, ndim)
+    r2 = np.sum(masks, axis=tuple(range(1, ndim + 1)))  # each ax except first
+    return np.sqrt(r2)
+
+
+def _static_error(mass, noise, radius, noise_size):
+    coord_moments = _root_sum_x_squared(radius, len(radius))
+    N_S = noise / mass
+    if np.all(radius[1:] == radius[:-1]) and \
+       np.all(noise_size[1:] == noise_size[:-1]):
+        ep = N_S * noise_size[0] * coord_moments[0]
+    else:
+        ep = N_S[:, np.newaxis] * \
+             (np.array(noise_size) * np.array(coord_moments))[np.newaxis, :]
+    return ep
+
+
+def static_error(features, noise, diameter, noise_size=1, ndim=2):
     """Compute the uncertainty in particle position ("the static error").
 
     Parameters
     ----------
-    mass : ndarray of feature masses, already background corrected
-    noise : number, standard deviation of the noise
-    radius : number or tuple, feature radius used to locate centroids
-    ndim : number of image dimensions, default 2
+    features : DataFrame of features
+        The feature dataframe should have a `mass` column that is already
+        background corrected.
+    noise : number or DataFrame having `noise` column, indexed on `frame`
+        standard deviation of the noise
+    diameter : number or tuple, feature diameter used to locate centroids
     noise_size : noise correlation length, may be tuple-valued
+    ndim : number of image dimensions, default 2
+        if diameter is tuple-valued then its length will override ndim
 
     Returns
     -------
-    1D or 2D array of static error estimates, indexed like the trajectories.
-    When either radius or noise_size are anisotropic, a the returned array has
-    ndim columns, one for each dimension. The order of these columns are equal
-    to the order dimensions in radius and noise_size.
+    DataFrame of static error estimates, indexed like the features.
+    When either radius or noise_size are anisotropic, the returned DataFrame
+    contains one column for each dimension.
 
     Note
     ----
@@ -73,14 +97,25 @@ def static_error(mass, noise, radius, ndim=2, noise_size=1):
     discrete sum instead of taking the continuous limit and integrating. This
     makes it possible to generalize this analysis to anisotropic masks.
     """
-    noise_size = validate_tuple(noise_size, ndim)
-    radius = validate_tuple(radius, ndim)
-    coord_moments = root_sum_x_squared(radius, ndim)
-    isotropic = (np.all(radius[1:] == radius[:-1]) and
-                 np.all(noise_size[1:] == noise_size[:-1]))
-    if isotropic:
-        ep = noise * noise_size[0] * coord_moments[0] / mass
+    if hasattr(diameter, '__iter__'):
+        ndim = len(diameter)
+    noise_size = validate_tuple(noise_size, ndim)[::-1]
+    diameter = validate_tuple(diameter, ndim)[::-1]
+    radius = tuple([d // 2 for d in diameter])
+
+    if np.isscalar(noise):
+        ep = _static_error(features['mass'], noise, radius, noise_size)
     else:
-        noise_moments = noise * np.array(noise_size) * np.array(coord_moments)
-        ep = noise_moments[np.newaxis, :] / mass[:, np.newaxis]
+        assert 'noise' in noise
+        temp = features.join(noise, on='frame')
+        ep = _static_error(temp['mass'], temp['noise'], radius, noise_size)
+
+    if ep.ndim == 1:
+        ep.name = 'ep'
+    elif ep.ndim == 2:
+        if ndim < 4:
+            coord_columns = ['ep_x', 'ep_y', 'ep_z'][:ndim]
+        else:
+            coord_columns = map(lambda i: 'ep_x' + str(i), range(ndim))
+        ep = DataFrame(ep, columns=coord_columns, index=features.index)
     return ep

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.ndimage import morphology
 
 from .preprocessing import bandpass
-from .masks import binary_mask
+from .masks import binary_mask, N_binary_mask, root_sum_x_squared
 from .utils import validate_tuple
 
 
@@ -36,35 +36,65 @@ def measure_noise(image, diameter, threshold):
     return image[~signal_mask].mean(), image[~signal_mask].std()
 
 
-def static_error(features, noise, diameter, noise_size=1):
+def static_error(features, black_level, noise, radius, noise_size=1,
+                 coord_columns=None):
     """Compute the uncertainty in particle position ("the static error").
 
     Parameters
     ----------
-    features : DataFrame of features (or trajectories) including signal and size
+    features : DataFrame of features (or trajectories) including mass
+    black_level : Series of black level measurements, indexed by frame
     noise : Series of noise measurements, indexed by frame
-    diameter : feature diameter used to locate centroids
-    noise_size : half-width of Gaussian blurring used in image preparation
+    radius : tuple of feature radius used to locate centroids
+    noise_size : noise correlation length, may be tuple-valued (?)
+    coord_columns : names of the coordinates, only used for anisotropic errors
 
     Returns
     -------
-    Series of static error estimates, indexed like the trajectories
+    Series of static error estimates, indexed like the trajectories.
+    When either radius or noise_size are anisotropic, a list of ndim Series is
+    returned, one for each dimension. The order of this list is equal to the
+    order of coord_columns and the reverse of radius and noise_size.
 
     Note
     ----
-    This is based on the process described by Thierry Savin and Patrick S. Doyle in their
-    paper "Static and Dynamic Errors in Particle Tracking Microrheology,"
-    Biophysical Journal 88(1) 623-638.
+    This is an adjusted version of the process described by Thierry Savin and
+    Patrick S. Doyle in their paper "Static and Dynamic Errors in Particle
+    Tracking Microrheology," Biophysical Journal 88(1) 623-638.
+
+    Instead of measuring the peak intensity of the feature and calculating the
+    total intensity (assuming a certain feature shape), the total intensity
+    (=mass) is summed directly from the data. This quantity is more robust
+    to noise and gives a better estimate of the static error.
+
+    In addition, the sum of squared coordinates is calculated by taking the
+    discrete sum instead of taking the continuous limit and integrating. This
+    makes it easier to implement anisotropic and n-dimensional masks.
     """
-    # If this is just one frame, noise is a scalar.
-    if np.isscalar(noise):
-        N_S = noise/features['signal']
-    # Otherwise, join by frame number.
+    noise_size = validate_tuple(noise_size, len(radius))[::-1]
+    radius = radius[::-1]
+    N = N_binary_mask(radius, len(radius))
+    coord_moments = root_sum_x_squared(radius, len(radius))
+    # If this is just one frame black_level is a scalar.
+    if np.isscalar(black_level):
+        mass = features['mass'] - N * black_level
     else:
-        noise.name = 'noise'
-        N_S = features.join(noise, on='frame')['noise']/features['signal']
-    s = 2*((diameter//2-1)/features['size'])**2
-    ep = N_S*noise_size/(2*np.pi**0.5)*s/(1-np.exp(-s))
-    # ^ Savin & Doyle, Eq. 50
-    ep.name = 'ep'  # so it can be joined
-    return ep
+        mass = features['mass'] - \
+            N * features.join(black_level, on='frame')['black_level']
+    if np.isscalar(noise):
+        N_S = noise / mass
+    else:
+        N_S = features.join(noise, on='frame')['noise'] / mass
+    if (radius[1:] == radius[:-1]) and (noise_size[1:] == noise_size[:-1]):
+        ep = N_S * noise_size[0] * coord_moments[0]
+        ep.name = 'ep'  # so it can be joined
+        return ep
+    else:
+        eps = []
+        if coord_columns is None:
+            coord_columns = [str(i) for i in range(len(radius))]
+        for (size, rss, col) in zip(noise_size, coord_moments, coord_columns):
+            ep = N_S * size * rss
+            ep.name = 'ep_{}'.format(col)  # so it can be joined
+            eps.append(ep)
+        return eps


### PR DESCRIPTION
A number of changes that reach deep into the feature finding: please review carefully! The fixes are linked in subtle ways, that's why this is in one big commit. Please checkout [this](http://nbviewer.ipython.org/urls/dl.dropboxusercontent.com/u/36853001/Feature%20characterization%20v2.ipynb) notebook, which is a newer version that is referenced in #237, including demonstration of the new noise calculation and some tests.

- Changes the behaviour of the `mass` column: it is now calculated from
the raw image. This solves the issue #237 due to the rescaling of the
processed image and the subsequent calculation of mass on this image.
- Changes the behaviour of the `signal` column: previously it was
calculated from the raw image and subsequently the `black_level` was
subtracted. Because of the high sensitivity to noise, this gives
unpredictable results. It has been changed to: `signal =
preprocessed_feature.max()`. The rescaling has been accounted for via an
extra variable coming from `scale_to_gamut`.
- eccentricity is calculated on anisotropic masks too, assuming that
pixels are square
- size is calculated in all directions separately when an anisotropic
mask is used, giving `size_x`, `size_y` columns
- filtering on `maxsize` is done on sqrt(size_x^2 + size_y^2), which
equals the current behaviour if sizes are equal
- static error is calculated in all directions separately when an
anisotropic mask is used *or* when noise_size is anisotropic, giving
`ep_x`, `ep_y` columns
- `preprocessing.bandpass` now calculates the background level and
standard deviation (only if needed, defaults to current behaviour)
- `scale_to_gamut` returns the scale factor (only if needed, defaults to
current behaviour)
- docstring for eccentricity: 0 is circular, not 1 as it is documented
now
- characterization arrays are only initialized if needed