### PR TITLE
ENH 3D feature finding with numba

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -362,12 +362,12 @@ def _numba_refine(raw_image, image, radius, coords, N, max_iterations,
                 if oc > SHIFT_THRESH:
                     new_coordY += 1
                 elif oc < - SHIFT_THRESH:
-                    new_coordY += -1
+                    new_coordY -= 1
                 oc = off_centerX
                 if oc > SHIFT_THRESH:
                     new_coordX += 1
                 elif oc < - SHIFT_THRESH:
-                    new_coordX += -1
+                    new_coordX -= 1
                 # Don't move outside the image!
                 if new_coordY < radius:
                     new_coordY = radius
@@ -423,21 +423,25 @@ def _numba_refine(raw_image, image, radius, coords, N, max_iterations,
         ecc2 = 0.
         signal_ = 0.
 
-        for i in range(N_mask):
-            px = image[squareY + maskY[i],
-                       squareX + maskX[i]]
-            mass_ += px
+        if characterize:
+            for i in range(N_mask):
+                px = image[squareY + maskY[i],
+                           squareX + maskX[i]]
+                mass_ += px
 
-            # Will short-circuiting if characterize=False slow it down?
-            if not characterize:
-                continue
-            Rg_ += r2_mask[i]*px
-            ecc1 += cmask[i]*px
-            ecc2 += smask[i]*px
-            raw_mass_ += raw_image[squareY + maskY[i],
-                                   squareX + maskX[i]]
-            if px > signal_:
-                signal_ = px
+                Rg_ += r2_mask[i]*px
+                ecc1 += cmask[i]*px
+                ecc2 += smask[i]*px
+                raw_mass_ += raw_image[squareY + maskY[i],
+                                       squareX + maskX[i]]
+                if px > signal_:
+                    signal_ = px
+        else:
+            for i in range(N_mask):
+                px = image[squareY + maskY[i],
+                           squareX + maskX[i]]
+                mass_ += px
+
         results[feat, MASS_COL] = mass_
         if characterize:
             results[feat, RG_COL] = np.sqrt(Rg_/mass_)

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -126,7 +126,7 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
     radius = validate_tuple(radius, image.ndim)
     # Main loop will be performed in separate function.
     if engine == 'auto':
-        if NUMBA_AVAILABLE:
+        if NUMBA_AVAILABLE and image.ndim in [2, 3]:
             engine = 'numba'
         else:
             engine = 'python'

--- a/trackpy/feature_numba.py
+++ b/trackpy/feature_numba.py
@@ -5,7 +5,7 @@ import numpy as np
 from .try_numba import try_numba_autojit
 
 
-@try_numba_autojit(nopython=False)
+@try_numba_autojit(nopython=True)
 def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
                      max_iterations, shapeY, shapeX, maskY, maskX, N_mask,
                      results):
@@ -123,7 +123,7 @@ def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
 
     return 0  # Unused
 
-@try_numba_autojit(nopython=False)
+@try_numba_autojit(nopython=True)
 def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
                       max_iterations, shapeY, shapeX, maskY,
                       maskX, N_mask, r2_mask, cmask, smask, results):
@@ -264,7 +264,7 @@ def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
     return 0  # Unused
     
 
-@try_numba_autojit(nopython=False)
+@try_numba_autojit(nopython=True)
 def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
                         max_iterations, shapeY, shapeX, maskY,
                         maskX, N_mask, y2_mask, x2_mask, cmask, smask,
@@ -410,7 +410,7 @@ def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
     return 0  # Unused
 
 
-@try_numba_autojit(nopython=False)
+@try_numba_autojit(nopython=True)
 def _numba_refine_3D(raw_image, image, radiusZ, radiusY, radiusX, coords, N,
                      max_iterations, characterize, shapeZ, shapeY, shapeX,
                      maskZ, maskY, maskX, N_mask, r2_mask, z2_mask, y2_mask,

--- a/trackpy/feature_numba.py
+++ b/trackpy/feature_numba.py
@@ -1,0 +1,410 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import six
+import numpy as np
+from .try_numba import try_numba_autojit
+
+
+@try_numba_autojit(nopython=False)
+def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
+                     max_iterations, shapeY, shapeX, maskY, maskX, N_mask,
+                     results):
+    SHIFT_THRESH = 0.6
+    GOOD_ENOUGH_THRESH = 0.01
+    # Column indices into the 'results' array
+    MASS_COL = 2
+
+    upper_boundY = shapeY - radiusY - 1
+    upper_boundX = shapeX - radiusX - 1
+
+    for feat in range(N):
+        # Define the circular neighborhood of (x, y).
+        coordY = coords[feat, 0]
+        coordX = coords[feat, 1]
+        cm_nY = 0.
+        cm_nX = 0.
+        squareY = int(round(coordY)) - radiusY
+        squareX = int(round(coordX)) - radiusX
+        mass_ = 0.0
+        for i in range(N_mask):
+            px = image[squareY + maskY[i],
+                       squareX + maskX[i]]
+            cm_nY += px*maskY[i]
+            cm_nX += px*maskX[i]
+            mass_ += px
+
+        cm_nY /= mass_
+        cm_nX /= mass_
+        cm_iY = cm_nY - radiusY + coordY
+        cm_iX = cm_nX - radiusX + coordX
+        allow_moves = True
+        for iteration in range(max_iterations):
+            off_centerY = cm_nY - radiusY
+            off_centerX = cm_nX - radiusX
+            if (abs(off_centerY) < GOOD_ENOUGH_THRESH and
+                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+                break  # Go to next feature
+
+            # If we're off by more than half a pixel in any direction, move.
+            do_move = False
+            if allow_moves and (abs(off_centerY) > SHIFT_THRESH or
+                                abs(off_centerX) > SHIFT_THRESH):
+                do_move = True
+
+            if do_move:
+                # In here, coord is an integer.
+                new_coordY = int(round(coordY))
+                new_coordX = int(round(coordX))
+                oc = off_centerY
+                if oc > SHIFT_THRESH:
+                    new_coordY += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordY -= 1
+                oc = off_centerX
+                if oc > SHIFT_THRESH:
+                    new_coordX += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordX -= 1
+                # Don't move outside the image!
+                if new_coordY < radiusY:
+                    new_coordY = radiusY
+                if new_coordX < radiusX:
+                    new_coordX = radiusX
+                if new_coordY > upper_boundY:
+                    new_coordY = upper_boundY  
+                if new_coordX > upper_boundX:
+                    new_coordX = upper_boundX
+                # Update slice to shifted position.
+                squareY = new_coordY - radiusY
+                squareX = new_coordX - radiusX
+                cm_nY = 0.
+                cm_nX = 0.
+
+            # If we're off by less than half a pixel, interpolate.
+            else:
+                break
+                # TODO Implement this for numba.
+                # Remember to zero cm_n somewhere in here.
+                # Here, coord is a float. We are off the grid.
+                # neighborhood = ndimage.shift(neighborhood, -off_center,
+                #                              order=2, mode='constant', cval=0)
+                # new_coord = np.float_(coord) + off_center
+                # Disallow any whole-pixels moves on future iterations.
+                # allow_moves = False
+
+            # cm_n was re-zeroed above in an unrelated loop
+            mass_ = 0.
+            for i in range(N_mask):
+                px = image[squareY + maskY[i],
+                           squareX + maskX[i]]
+                cm_nY += px*maskY[i]
+                cm_nX += px*maskX[i]
+                mass_ += px
+
+            cm_nY /= mass_
+            cm_nX /= mass_
+            cm_iY = cm_nY - radiusY + new_coordY
+            cm_iX = cm_nX - radiusX + new_coordX
+            coordY = new_coordY
+            coordX = new_coordX
+
+        # matplotlib and ndimage have opposite conventions for xy <-> yx.
+        results[feat, 0] = cm_iX
+        results[feat, 1] = cm_iY
+
+        # Characterize the neighborhood of our final centroid.
+        mass_ = 0.
+        for i in range(N_mask):
+            px = image[squareY + maskY[i],
+                       squareX + maskX[i]]
+            mass_ += px
+
+        results[feat, MASS_COL] = mass_
+
+    return 0  # Unused
+
+@try_numba_autojit(nopython=False)
+def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
+                      max_iterations, shapeY, shapeX, maskY,
+                      maskX, N_mask, r2_mask, cmask, smask, results):
+    SHIFT_THRESH = 0.6
+    GOOD_ENOUGH_THRESH = 0.01
+    # Column indices into the 'results' array
+    MASS_COL = 2
+    RG_COL = 3
+    ECC_COL = 4
+    SIGNAL_COL = 5
+    RAW_MASS_COL = 6
+
+    upper_boundY = shapeY - radiusY - 1
+    upper_boundX = shapeX - radiusX - 1
+
+    for feat in range(N):
+        # Define the circular neighborhood of (x, y).
+        coordY = coords[feat, 0]
+        coordX = coords[feat, 1]
+        cm_nY = 0.
+        cm_nX = 0.
+        squareY = int(round(coordY)) - radiusY
+        squareX = int(round(coordX)) - radiusX
+        mass_ = 0.0
+        for i in range(N_mask):
+            px = image[squareY + maskY[i],
+                       squareX + maskX[i]]
+            cm_nY += px*maskY[i]
+            cm_nX += px*maskX[i]
+            mass_ += px
+
+        cm_nY /= mass_
+        cm_nX /= mass_
+        cm_iY = cm_nY - radiusY + coordY
+        cm_iX = cm_nX - radiusX + coordX
+        allow_moves = True
+        for iteration in range(max_iterations):
+            off_centerY = cm_nY - radiusY
+            off_centerX = cm_nX - radiusX
+            if (abs(off_centerY) < GOOD_ENOUGH_THRESH and
+                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+                break  # Go to next feature
+
+            # If we're off by more than half a pixel in any direction, move.
+            do_move = False
+            if allow_moves and (abs(off_centerY) > SHIFT_THRESH or
+                                abs(off_centerX) > SHIFT_THRESH):
+                do_move = True
+
+            if do_move:
+                # In here, coord is an integer.
+                new_coordY = int(round(coordY))
+                new_coordX = int(round(coordX))
+                oc = off_centerY
+                if oc > SHIFT_THRESH:
+                    new_coordY += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordY -= 1
+                oc = off_centerX
+                if oc > SHIFT_THRESH:
+                    new_coordX += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordX -= 1
+                # Don't move outside the image!
+                if new_coordY < radiusY:
+                    new_coordY = radiusY
+                if new_coordX < radiusX:
+                    new_coordX = radiusX
+                if new_coordY > upper_boundY:
+                    new_coordY = upper_boundY  
+                if new_coordX > upper_boundX:
+                    new_coordX = upper_boundX
+                # Update slice to shifted position.
+                squareY = new_coordY - radiusY
+                squareX = new_coordX - radiusX
+                cm_nY = 0.
+                cm_nX = 0.
+
+            # If we're off by less than half a pixel, interpolate.
+            else:
+                break
+                # TODO Implement this for numba.
+                # Remember to zero cm_n somewhere in here.
+                # Here, coord is a float. We are off the grid.
+                # neighborhood = ndimage.shift(neighborhood, -off_center,
+                #                              order=2, mode='constant', cval=0)
+                # new_coord = np.float_(coord) + off_center
+                # Disallow any whole-pixels moves on future iterations.
+                # allow_moves = False
+
+            # cm_n was re-zeroed above in an unrelated loop
+            mass_ = 0.
+            for i in range(N_mask):
+                px = image[squareY + maskY[i],
+                           squareX + maskX[i]]
+                cm_nY += px*maskY[i]
+                cm_nX += px*maskX[i]
+                mass_ += px
+
+            cm_nY /= mass_
+            cm_nX /= mass_
+            cm_iY = cm_nY - radiusY + new_coordY
+            cm_iX = cm_nX - radiusX + new_coordX
+            coordY = new_coordY
+            coordX = new_coordX
+
+        # matplotlib and ndimage have opposite conventions for xy <-> yx.
+        results[feat, 0] = cm_iX
+        results[feat, 1] = cm_iY
+
+        # Characterize the neighborhood of our final centroid.
+        mass_ = 0.
+        raw_mass_ = 0.
+        Rg_ = 0.
+        ecc1 = 0.
+        ecc2 = 0.
+        signal_ = 0.
+
+        for i in range(N_mask):
+            px = image[squareY + maskY[i],
+                       squareX + maskX[i]]
+            mass_ += px
+
+            Rg_ += r2_mask[i]*px
+            ecc1 += cmask[i]*px
+            ecc2 += smask[i]*px
+            raw_mass_ += raw_image[squareY + maskY[i],
+                                   squareX + maskX[i]]
+            if px > signal_:
+                signal_ = px
+        results[feat, RG_COL] = np.sqrt(Rg_/mass_)
+        results[feat, MASS_COL] = mass_
+        center_px = image[squareY + radiusY, squareX + radiusX]
+        results[feat, ECC_COL] = np.sqrt(ecc1**2 + ecc2**2) / (mass_ - center_px + 1e-6)
+        results[feat, SIGNAL_COL] = signal_
+        results[feat, RAW_MASS_COL] = raw_mass_
+
+    return 0  # Unused
+    
+
+@try_numba_autojit(nopython=False)
+def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
+                        max_iterations, shapeY, shapeX, maskY,
+                        maskX, N_mask, y2_mask, x2_mask, cmask, smask,
+                        results):
+    SHIFT_THRESH = 0.6
+    GOOD_ENOUGH_THRESH = 0.01
+    # Column indices into the 'results' array
+    MASS_COL = 2
+    RGX_COL = 3
+    RGY_COL = 4
+    ECC_COL = 5
+    SIGNAL_COL = 6
+    RAW_MASS_COL = 7
+
+    upper_boundY = shapeY - radiusY - 1
+    upper_boundX = shapeX - radiusX - 1
+
+    for feat in range(N):
+        # Define the circular neighborhood of (x, y).
+        coordY = coords[feat, 0]
+        coordX = coords[feat, 1]
+        cm_nY = 0.
+        cm_nX = 0.
+        squareY = int(round(coordY)) - radiusY
+        squareX = int(round(coordX)) - radiusX
+        mass_ = 0.0
+        for i in range(N_mask):
+            px = image[squareY + maskY[i],
+                       squareX + maskX[i]]
+            cm_nY += px*maskY[i]
+            cm_nX += px*maskX[i]
+            mass_ += px
+
+        cm_nY /= mass_
+        cm_nX /= mass_
+        cm_iY = cm_nY - radiusY + coordY
+        cm_iX = cm_nX - radiusX + coordX
+        allow_moves = True
+        for iteration in range(max_iterations):
+            off_centerY = cm_nY - radiusY
+            off_centerX = cm_nX - radiusX
+            if (abs(off_centerY) < GOOD_ENOUGH_THRESH and
+                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+                break  # Go to next feature
+
+            # If we're off by more than half a pixel in any direction, move.
+            do_move = False
+            if allow_moves and (abs(off_centerY) > SHIFT_THRESH or
+                                abs(off_centerX) > SHIFT_THRESH):
+                do_move = True
+
+            if do_move:
+                # In here, coord is an integer.
+                new_coordY = int(round(coordY))
+                new_coordX = int(round(coordX))
+                oc = off_centerY
+                if oc > SHIFT_THRESH:
+                    new_coordY += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordY -= 1
+                oc = off_centerX
+                if oc > SHIFT_THRESH:
+                    new_coordX += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordX -= 1
+                # Don't move outside the image!
+                if new_coordY < radiusY:
+                    new_coordY = radiusY
+                if new_coordX < radiusX:
+                    new_coordX = radiusX
+                if new_coordY > upper_boundY:
+                    new_coordY = upper_boundY  
+                if new_coordX > upper_boundX:
+                    new_coordX = upper_boundX
+                # Update slice to shifted position.
+                squareY = new_coordY - radiusY
+                squareX = new_coordX - radiusX
+                cm_nY = 0.
+                cm_nX = 0.
+
+            # If we're off by less than half a pixel, interpolate.
+            else:
+                break
+                # TODO Implement this for numba.
+                # Remember to zero cm_n somewhere in here.
+                # Here, coord is a float. We are off the grid.
+                # neighborhood = ndimage.shift(neighborhood, -off_center,
+                #                              order=2, mode='constant', cval=0)
+                # new_coord = np.float_(coord) + off_center
+                # Disallow any whole-pixels moves on future iterations.
+                # allow_moves = False
+
+            # cm_n was re-zeroed above in an unrelated loop
+            mass_ = 0.
+            for i in range(N_mask):
+                px = image[squareY + maskY[i],
+                           squareX + maskX[i]]
+                cm_nY += px*maskY[i]
+                cm_nX += px*maskX[i]
+                mass_ += px
+
+            cm_nY /= mass_
+            cm_nX /= mass_
+            cm_iY = cm_nY - radiusY + new_coordY
+            cm_iX = cm_nX - radiusX + new_coordX
+            coordY = new_coordY
+            coordX = new_coordX
+
+        # matplotlib and ndimage have opposite conventions for xy <-> yx.
+        results[feat, 0] = cm_iX
+        results[feat, 1] = cm_iY
+
+        # Characterize the neighborhood of our final centroid.
+        mass_ = 0.
+        raw_mass_ = 0.
+        RgY = 0.
+        RgX = 0.
+        ecc1 = 0.
+        ecc2 = 0.
+        signal_ = 0.
+
+        for i in range(N_mask):
+            px = image[squareY + maskY[i],
+                       squareX + maskX[i]]
+            mass_ += px
+
+            RgY += y2_mask[i]*px
+            RgX += x2_mask[i]*px
+            ecc1 += cmask[i]*px
+            ecc2 += smask[i]*px
+            raw_mass_ += raw_image[squareY + maskY[i],
+                                   squareX + maskX[i]]
+            if px > signal_:
+                signal_ = px
+        results[feat, RGY_COL] = np.sqrt(RgY/mass_)
+        results[feat, RGX_COL] = np.sqrt(RgX/mass_)
+        results[feat, MASS_COL] = mass_
+        center_px = image[squareY + radiusY, squareX + radiusX]
+        results[feat, ECC_COL] = np.sqrt(ecc1**2 + ecc2**2) / (mass_ - center_px + 1e-6)
+        results[feat, SIGNAL_COL] = signal_
+        results[feat, RAW_MASS_COL] = raw_mass_
+
+    return 0  # Unused

--- a/trackpy/feature_numba.py
+++ b/trackpy/feature_numba.py
@@ -408,3 +408,211 @@ def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
         results[feat, RAW_MASS_COL] = raw_mass_
 
     return 0  # Unused
+
+
+@try_numba_autojit(nopython=False)
+def _numba_refine_3D(raw_image, image, radiusZ, radiusY, radiusX, coords, N,
+                     max_iterations, characterize, shapeZ, shapeY, shapeX,
+                     maskZ, maskY, maskX, N_mask, r2_mask, z2_mask, y2_mask,
+                     x2_mask, results):
+    SHIFT_THRESH = 0.6
+    GOOD_ENOUGH_THRESH = 0.01
+    # Column indices into the 'results' array
+    MASS_COL = 3
+    isotropic = (radiusX == radiusY and radiusX == radiusZ)
+    if isotropic:
+        RG_COL = 4
+        ECC_COL = 5
+        SIGNAL_COL = 6
+        RAW_MASS_COL = 7
+    else:
+        RGX_COL = 4
+        RGY_COL = 5
+        RGZ_COL = 6
+        ECC_COL = 7
+        SIGNAL_COL = 8
+        RAW_MASS_COL = 9
+
+    upper_boundZ = shapeZ - radiusZ - 1
+    upper_boundY = shapeY - radiusY - 1
+    upper_boundX = shapeX - radiusX - 1
+
+    for feat in range(N):
+        # Define the neighborhood of (x, y, z).
+        coordZ = coords[feat, 0]
+        coordY = coords[feat, 1]
+        coordX = coords[feat, 2]
+        cm_nZ = 0.
+        cm_nY = 0.
+        cm_nX = 0.
+        squareZ = int(round(coordZ)) - radiusZ
+        squareY = int(round(coordY)) - radiusY
+        squareX = int(round(coordX)) - radiusX
+        mass_ = 0.0
+        for i in range(N_mask):
+            px = image[squareZ + maskZ[i],
+                       squareY + maskY[i],
+                       squareX + maskX[i]]
+            cm_nZ += px*maskZ[i]
+            cm_nY += px*maskY[i]
+            cm_nX += px*maskX[i]
+            mass_ += px
+
+        cm_nZ /= mass_
+        cm_nY /= mass_
+        cm_nX /= mass_
+        cm_iZ = cm_nZ - radiusZ + coordZ
+        cm_iY = cm_nY - radiusY + coordY
+        cm_iX = cm_nX - radiusX + coordX
+        allow_moves = True
+        for iteration in range(max_iterations):
+            off_centerZ = cm_nZ - radiusZ
+            off_centerY = cm_nY - radiusY
+            off_centerX = cm_nX - radiusX
+            if (abs(off_centerZ) < GOOD_ENOUGH_THRESH and
+                abs(off_centerY) < GOOD_ENOUGH_THRESH and
+                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+                break  # Go to next feature
+
+            # If we're off by more than half a pixel in any direction, move.
+            do_move = False
+            if allow_moves and (abs(off_centerZ) > SHIFT_THRESH or
+                                abs(off_centerY) > SHIFT_THRESH or
+                                abs(off_centerX) > SHIFT_THRESH):
+                do_move = True
+
+            if do_move:
+                # In here, coord is an integer.
+                new_coordZ = int(round(coordZ))
+                new_coordY = int(round(coordY))
+                new_coordX = int(round(coordX))
+                oc = off_centerZ
+                if oc > SHIFT_THRESH:
+                    new_coordZ += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordZ -= 1
+                oc = off_centerY
+                if oc > SHIFT_THRESH:
+                    new_coordY += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordY -= 1
+                oc = off_centerX
+                if oc > SHIFT_THRESH:
+                    new_coordX += 1
+                elif oc < - SHIFT_THRESH:
+                    new_coordX -= 1
+                # Don't move outside the image!
+                if new_coordZ < radiusZ:
+                    new_coordZ = radiusZ
+                if new_coordY < radiusY:
+                    new_coordY = radiusY
+                if new_coordX < radiusX:
+                    new_coordX = radiusX
+                if new_coordZ > upper_boundZ:
+                    new_coordZ = upper_boundZ  
+                if new_coordY > upper_boundY:
+                    new_coordY = upper_boundY  
+                if new_coordX > upper_boundX:
+                    new_coordX = upper_boundX
+                # Update slice to shifted position.
+                squareZ = new_coordZ - radiusZ
+                squareY = new_coordY - radiusY
+                squareX = new_coordX - radiusX
+                cm_nZ = 0.
+                cm_nY = 0.
+                cm_nX = 0.
+
+            # If we're off by less than half a pixel, interpolate.
+            else:
+                break
+                # TODO Implement this for numba.
+                # Remember to zero cm_n somewhere in here.
+                # Here, coord is a float. We are off the grid.
+                # neighborhood = ndimage.shift(neighborhood, -off_center,
+                #                              order=2, mode='constant', cval=0)
+                # new_coord = np.float_(coord) + off_center
+                # Disallow any whole-pixels moves on future iterations.
+                # allow_moves = False
+
+            # cm_n was re-zeroed above in an unrelated loop
+            mass_ = 0.
+            for i in range(N_mask):
+                px = image[squareZ + maskZ[i],
+                           squareY + maskY[i],
+                           squareX + maskX[i]]
+                cm_nZ += px*maskZ[i]
+                cm_nY += px*maskY[i]
+                cm_nX += px*maskX[i]
+                mass_ += px
+
+            cm_nZ /= mass_
+            cm_nY /= mass_
+            cm_nX /= mass_
+            cm_iZ = cm_nZ - radiusZ + new_coordZ
+            cm_iY = cm_nY - radiusY + new_coordY
+            cm_iX = cm_nX - radiusX + new_coordX
+            coordZ = new_coordZ
+            coordY = new_coordY
+            coordX = new_coordX
+
+        # matplotlib and ndimage have opposite conventions for xy <-> yx.
+        results[feat, 0] = cm_iX
+        results[feat, 1] = cm_iY
+        results[feat, 2] = cm_iZ
+
+        # Characterize the neighborhood of our final centroid.
+        mass_ = 0.
+        raw_mass_ = 0.
+        Rg_ = 0.
+        RgZ = 0.
+        RgY = 0.
+        RgX = 0.
+        signal_ = 0.
+
+        if not characterize:
+            for i in range(N_mask):
+                px = image[squareZ + maskZ[i],
+                           squareY + maskY[i],
+                           squareX + maskX[i]]
+                mass_ += px
+        elif isotropic:
+            for i in range(N_mask):
+                px = image[squareZ + maskZ[i],
+                           squareY + maskY[i],
+                           squareX + maskX[i]]
+                mass_ += px
+
+                Rg_ += r2_mask[i]*px
+                raw_mass_ += raw_image[squareZ + maskZ[i],
+                                       squareY + maskY[i],
+                                       squareX + maskX[i]]
+                if px > signal_:
+                    signal_ = px
+            results[feat, RG_COL] = np.sqrt(Rg_/mass_)
+        else:
+            for i in range(N_mask):
+                px = image[squareZ + maskZ[i],
+                           squareY + maskY[i],
+                           squareX + maskX[i]]
+                mass_ += px
+
+                RgZ += y2_mask[i]*px
+                RgY += y2_mask[i]*px
+                RgX += x2_mask[i]*px
+
+                raw_mass_ += raw_image[squareZ + maskZ[i],
+                                       squareY + maskY[i],
+                                       squareX + maskX[i]]
+                if px > signal_:
+                    signal_ = px
+            results[feat, RGZ_COL] = np.sqrt(RgZ/mass_)
+            results[feat, RGY_COL] = np.sqrt(RgY/mass_)
+            results[feat, RGX_COL] = np.sqrt(RgX/mass_)
+
+        results[feat, MASS_COL] = mass_
+        if characterize:
+            results[feat, SIGNAL_COL] = signal_
+            results[feat, ECC_COL] = np.nan
+            results[feat, RAW_MASS_COL] = raw_mass_
+
+    return 0  # Unused

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -382,7 +382,7 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=0.5)
 
     def test_multiple_anisotropic_3D_simple(self):
-        self.check_skip()
+        self.skip_numba()
         actual, expected = compare((100, 120, 10), 4, (4, 4, 2), noise_level=0,
                                    engine=self.engine)
         assert_allclose(actual, expected, atol=0.5)

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -382,7 +382,7 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=0.5)
 
     def test_multiple_anisotropic_3D_simple(self):
-        self.skip_numba()
+        self.check_skip()
         actual, expected = compare((100, 120, 10), 4, (4, 4, 2), noise_level=0,
                                    engine=self.engine)
         assert_allclose(actual, expected, atol=0.5)
@@ -522,7 +522,7 @@ class CommonFeatureIdentificationTests(object):
         # The separate columns 'size_x' and 'size_y' reflect the radii of
         # gyration in the two separate directions.
 
-        self.skip_numba()
+        self.check_skip()
         L = 101
         SIZE = 5
         dims = (L, L + 2)  # avoid square images in tests
@@ -622,7 +622,7 @@ class CommonFeatureIdentificationTests(object):
         # smallest mask size should be lowest; their ratio is equal to the
         # mask aspect ratio.
 
-        self.skip_numba()
+        self.check_skip()
         L = 101
         SIZE = 5
         dims = (L, L + 2)  # avoid square images in tests

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -21,7 +21,7 @@ from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point,
                                 gen_nonoverlapping_locations)
                                 
-from scipy.spatial import KDTree
+from scipy.spatial import cKDTree
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()
@@ -45,7 +45,7 @@ def compare(shape, count, radius, noise_level, engine):
 
 
 def sort_positions(actual, expected):
-    tree = KDTree(actual)
+    tree = cKDTree(actual)
     deviations, argsort = tree.query([expected])
     return deviations, actual[argsort][0]
 

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -86,7 +86,7 @@ class CommonFeatureIdentificationTests(object):
             f = tp.locate(black_image, 5, engine=self.engine)
 
     def test_maxima_in_margin_3D(self):
-        self.skip_numba()
+        self.check_skip()
         black_image = np.ones((21, 23, 25)).astype(np.uint8)
         draw_point(black_image, [1, 1, 1], 100)
         with assert_produces_warning(UserWarning):
@@ -190,7 +190,7 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=0.1)
 
     def test_one_centered_gaussian_3D(self):
-        self.skip_numba()
+        self.check_skip()
         L = 21
         dims = (L, L + 2, L + 4)  # avoid square images in tests
         pos = [7, 13, 9]
@@ -204,7 +204,7 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=0.1)
 
     def test_one_centered_gaussian_3D_anisotropic(self):
-        self.skip_numba()
+        self.check_skip()
         L = 21
         dims = (L, L + 2, L + 4)  # avoid square images in tests
         pos = [7, 13, 9]
@@ -382,7 +382,7 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=0.5)
 
     def test_multiple_anisotropic_3D_simple(self):
-        self.skip_numba()
+        self.check_skip()
         actual, expected = compare((100, 120, 10), 4, (4, 4, 2), noise_level=0,
                                    engine=self.engine)
         assert_allclose(actual, expected, atol=0.5)


### PR DESCRIPTION
This adds some performance increases for the 2D feature finding, as well as an extension to anistoropic and to 3D. I did this by writing several similar `_numba_refine` routines in a new `numba_feature.py`.

Apparently, the characterization was still slowing down the numba engine, even with `characterize=False`. Splitting the functions got me a 30% performance increase. Also replacing the length-2 buffers with scalar variables got some performance increase.

This PR contains some commits from #239, only the last 7 are for numba. Please refer to https://github.com/soft-matter/trackpy/commit/bf1509a8632608c590cebac6f4bfdb8c2bad9ed9, https://github.com/soft-matter/trackpy/commit/389eaa7ab3e05197f671100b4b922c6506e96c4a and https://github.com/soft-matter/trackpy/commit/5507595d0e29efaaed0a5d9907050feec8d8df97 for the major changes in the 2D version.