### PR TITLE
FIX/TST: When an empty frame is put to FramewiseData, warn but continue

### DIFF
--- a/trackpy/framewise_data.py
+++ b/trackpy/framewise_data.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
+import warnings
 
 import pandas as pd
 
@@ -121,6 +122,9 @@ class PandasHDFStore(FramewiseData):
         return max(self.frames)
 
     def put(self, df):
+        if len(df) == 0:
+            warnings.warn('An empty DataFrame was passed to put(). Continuing.')
+            return
         frame_no = df[self.t_column].values[0]  # validated to be all the same
         key = code_key(frame_no)
         # Store data as tabular instead of fixed-format.
@@ -254,6 +258,9 @@ class PandasHDFStoreSingleNode(FramewiseData):
         return self._t_column
 
     def put(self, df):
+        if len(df) == 0:
+            warnings.warn('An empty DataFrame was passed to put(). Continuing.')
+            return
         self._validate(df)
         self.store.append(self.key, df, data_columns=True)
 

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -10,7 +10,8 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 from numpy.testing.decorators import slow
 import pandas
-from pandas.util.testing import (assert_series_equal, assert_frame_equal)
+from pandas.util.testing import (assert_series_equal, assert_frame_equal,
+                                 assert_produces_warning)
 
 import trackpy as tp 
 from pims import ImageSequence
@@ -72,6 +73,10 @@ class FeatureSavingTester(object):
             assert_frame_equal(s.dump().reset_index(drop=True), 
                                self.expected.reset_index(drop=True))
             assert_frame_equal(s[0], s.get(0))
+
+            # Putting an empty df should warn
+            with assert_produces_warning(UserWarning):
+                s.put(pandas.DataFrame())
             s.close()
             os.remove(STORE_NAME)
 

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -4,14 +4,14 @@ import six
 import functools
 import unittest
 import nose
+import warnings
 import os
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 from numpy.testing.decorators import slow
 import pandas
-from pandas.util.testing import (assert_series_equal, assert_frame_equal,
-                                 assert_produces_warning)
+from pandas.util.testing import (assert_series_equal, assert_frame_equal)
 
 import trackpy as tp 
 from pims import ImageSequence
@@ -75,8 +75,11 @@ class FeatureSavingTester(object):
             assert_frame_equal(s[0], s.get(0))
 
             # Putting an empty df should warn
-            with assert_produces_warning(UserWarning):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('ignore')
+                warnings.simplefilter('always', UserWarning)
                 s.put(pandas.DataFrame())
+                assert len(w) == 1
             s.close()
             os.remove(STORE_NAME)
 


### PR DESCRIPTION
Revived version of #174