### PR TITLE
FIX Return empty df when batch finds no features

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -724,6 +724,10 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
             output.put(features)
 
     if output is None:
-        return pd.concat(all_features).reset_index(drop=True)
+        if len(all_features) > 0:
+            return pd.concat(all_features).reset_index(drop=True)
+        else:  # return empty DataFrame
+            warnings.warn("No maxima found in any frame.")
+            return pd.DataFrame(columns=list(features.columns) + ['frame'])
     else:
         return output


### PR DESCRIPTION
Fixes the following issue when `tp.batch` finds nothing. Now returns an empty dataframe and produces a warning.

	in batch(frames, diamete
	r, minmass, maxsize, separation, noise_size, smoothing_size, threshold, invert,
	percentile, topn, preprocess, max_iterations, filter_before, filter_after, chara
	cterize, engine, output, meta)
		725
		726     if output is None:
	--> 727         return pd.concat(all_features).reset_index(drop=True)
		728     else:
		729         return output

	in concat(objs, axis, join,
	 join_axes, ignore_index, keys, levels, names, verify_integrity, copy)
		752                        keys=keys, levels=levels, names=names,
		753                        verify_integrity=verify_integrity,
	--> 754                        copy=copy)
		755     return op.get_result()
		756

	in __init__(self, objs, axi
	s, join, join_axes, keys, levels, names, ignore_index, verify_integrity, copy)
		797
		798         if len(objs) == 0:
	--> 799             raise ValueError('All objects passed were None')
		800
		801         # consolidate data & figure out what our result ndim is going to be

	ValueError: All objects passed were None