### PR TITLE
ENH: Never return negative uncertainty; return NaN instead (updated)

### DIFF
--- a/doc/releases/v0.3.0.txt
+++ b/doc/releases/v0.3.0.txt
@@ -47,3 +47,4 @@ API changes
 
 - The plot function ``annotate()`` now displays the image with the vertical axis inverted, to be consistent with the ``pims`` display function and ``plot_traj()``. (:issue:`217`)
 - Using trackpy to access pims functionality (e.g. ``trackpy.ImageSequence()``) is now deprecated; it still works but will generate a warning message. This capability will be removed from future versions of trackpy, in favor of accessing it in the pims package directly (e.g. ``pims.ImageSequence()``). (:issue:`214`)
+- When trackpy estimates the error in a feature's position (returned as the ``ep`` column), the procedure can fail and result in a nonsense value. This will now result in the value of ``ep`` being NaN (not a number); previous versions of trackpy returned a negative value in this situation. To restore the previous behavior, you can replace these values with negative numbers by using the Pandas ``fillna()`` method. (:issue:`113`)

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -570,7 +570,7 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=0.1)
 
     def test_ep(self):
-        # Test wether the estimated static error equals the rms deviation from
+        # Test whether the estimated static error equals the rms deviation from
         # the expected values. Next to the feature mass, the static error is
         # calculated from the estimated image background level and variance.
         # This estimate is also tested here.
@@ -581,7 +581,7 @@ class CommonFeatureIdentificationTests(object):
 
         # The (absolute) tolerance for ep in this test is 0.05 pixels.
         # Parameters are tweaked so that there is no deviation due to a too
-        # small mask size. Signal/noise ratios upto 50% are tested.
+        # small mask size. Signal/noise ratios up to 50% are tested.
         self.check_skip()
         draw_diameter = 21
         locate_diameter = 15
@@ -668,20 +668,27 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=0.1)
 
     def test_uncertainty_failure(self):
+        """When the uncertainty ("ep") calculation results in a nonsense negative
+        value, it should return NaN instead.
+        """
         self.check_skip()
         L = 21
         dims = (L, L + 2)  # avoid square images in tests
         pos = np.array([7, 13])
         cols = ['x', 'y']
-        expected = DataFrame(pos.reshape(1, -1), columns=cols)
+        expected = DataFrame(pos[::-1].reshape(1, -1), columns=cols)
 
         image = 100*np.ones(dims, dtype='uint8')
-        image[:, [0, -1]] = 255
-        draw_gaussian_spot(image, pos[::-1], 4, max_value=150)
+        # For a feature to have a negative uncertainty, its integrated mass
+        # must be less than if it were not there at all (replaced
+        # with the average background intensity). So our feature will be a
+        # small bright spot surrounded by a dark annulus.
+        draw_feature(image, pos, 6, max_value=-100)
+        draw_feature(image, pos, 4, max_value=200)
+        
         actual = tp.locate(image, 9, 1, preprocess=False, engine=self.engine)
-        print actual.signal, actual.ep
-        self.assertLess(np.asscalar(actual.signal), 0)
-        assert_equal(np.asscalar(actual.ep), np.nan)
+        assert np.allclose(actual[['x', 'y']], expected[['x', 'y']])
+        assert np.isnan(np.asscalar(actual.ep))
 
 
 class TestFeatureIdentificationWithVanillaNumpy(

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -667,6 +667,22 @@ class CommonFeatureIdentificationTests(object):
                                    engine=self.engine)[:, :2][:, ::-1]
         assert_allclose(actual, expected, atol=0.1)
 
+    def test_uncertainty_failure(self):
+        self.check_skip()
+        L = 21
+        dims = (L, L + 2)  # avoid square images in tests
+        pos = np.array([7, 13])
+        cols = ['x', 'y']
+        expected = DataFrame(pos.reshape(1, -1), columns=cols)
+
+        image = 100*np.ones(dims, dtype='uint8')
+        image[:, [0, -1]] = 255
+        draw_gaussian_spot(image, pos[::-1], 4, max_value=150)
+        actual = tp.locate(image, 9, 1, preprocess=False, engine=self.engine)
+        print actual.signal, actual.ep
+        self.assertLess(np.asscalar(actual.signal), 0)
+        assert_equal(np.asscalar(actual.ep), np.nan)
+
 
 class TestFeatureIdentificationWithVanillaNumpy(
     CommonFeatureIdentificationTests, unittest.TestCase):

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -82,6 +82,8 @@ def static_error(features, noise, diameter, noise_size=1, ndim=2):
     When either radius or noise_size are anisotropic, the returned DataFrame
     contains one column for each dimension.
 
+    Where uncertainty estimation fails, NaN is returned.
+
     Note
     ----
     This is an adjusted version of the process described by Thierry Savin and
@@ -109,6 +111,8 @@ def static_error(features, noise, diameter, noise_size=1, ndim=2):
         assert 'noise' in noise
         temp = features.join(noise, on='frame')
         ep = _static_error(temp['mass'], temp['noise'], radius, noise_size)
+
+    ep = ep.where(ep > 0, np.nan)
 
     if ep.ndim == 1:
         ep.name = 'ep'


### PR DESCRIPTION
This is meant to supersede #113. The idea and implementation are the same as @danielballan 's original; this PR mostly just updates the testing to work with the new mass-based error analysis (#239). I use a highly contrived method to make a feature that defies uncertainty estimation.

I added this to the release notes under "API changes," though it could just as easily go under enhancements or bug fixes.