### PR TITLE
PERF: Faster peak-merging

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -223,13 +223,14 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
             to_drop = []
             for pair in duplicates:
                 # Drop the dimmer one.
-                if np.equal(*mass.take(pair, 0)):
+                m0, m1 = mass[pair[0]], mass[pair[1]]
+                if m0 == m1:
                     # Rare corner case: a tie!
                     # Break ties by sorting by sum of coordinates, to avoid
                     # any randomness resulting from cKDTree returning a set.
-                    dimmer = np.argsort(np.sum(positions.take(pair, 0), 1))[0]
+                    dimmer = np.argmin(np.sum(positions.take(pair, 0), 1))
                 else:
-                    dimmer = np.argmin(mass.take(pair, 0))
+                    dimmer = 0 if m0 < m1 else 1
                 to_drop.append(pair[dimmer])
             results = np.delete(results, to_drop, 0)
 

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -352,7 +352,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
 
     Preprocess the image by performing a band pass and a threshold.
     Locate all peaks of brightness, characterize the neighborhoods of the peaks
-    and take only those with given total brightnesss ("mass"). Finally,
+    and take only those with given total brightness ("mass"). Finally,
     refine the positions of each peak.
 
     Parameters
@@ -366,7 +366,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
         number(s) must be odd integers. When in doubt, round up.
     minmass : minimum integrated brightness
         Default is 100, but a good value is often much higher. This is a
-        crucial parameter for elminating spurious features.
+        crucial parameter for eliminating spurious features.
     maxsize : maximum radius-of-gyration of brightness, default None
     separation : feature separation, in pixels
         Default is diameter + 1. May be a tuple, see diameter for details.
@@ -601,7 +601,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
 
     Preprocess the image by performing a band pass and a threshold.
     Locate all peaks of brightness, characterize the neighborhoods of the peaks
-    and take only those with given total brightnesss ("mass"). Finally,
+    and take only those with given total brightness ("mass"). Finally,
     refine the positions of each peak.
 
     Parameters
@@ -615,7 +615,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
         number(s) must be odd integers. When in doubt, round up.
     minmass : minimum integrated brightness
         Default is 100, but a good value is often much higher. This is a
-        crucial parameter for elminating spurious features.
+        crucial parameter for eliminating spurious features.
     maxsize : maximum radius-of-gyration of brightness, default None
     separation : feature separation, in pixels
         Default is diameter + 1. May be a tuple, see diameter for details.
@@ -649,7 +649,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
         based on their estimated mass and size before refining position.
         True by default for performance.
     filter_after : boolean
-        Use final characterizations of mass and size to elminate spurious
+        Use final characterizations of mass and size to eliminate spurious
         features. True by default.
     characterize : boolean
         Compute "extras": eccentricity, signal, ep. True by default.

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -221,17 +221,18 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
             if len(duplicates) == 0:
                 break
             to_drop = []
-            for pair in duplicates:
+            for p0, p1 in duplicates:
                 # Drop the dimmer one.
-                m0, m1 = mass[pair[0]], mass[pair[1]]
-                if m0 == m1:
+                m0, m1 = mass[p0], mass[p1]
+                if m0 < m1:
+                    to_drop.append(p0)
+                elif m0 > m1:
+                    to_drop.append(p1)
+                else:
                     # Rare corner case: a tie!
                     # Break ties by sorting by sum of coordinates, to avoid
                     # any randomness resulting from cKDTree returning a set.
-                    dimmer = np.argmin(np.sum(positions.take(pair, 0), 1))
-                else:
-                    dimmer = 0 if m0 < m1 else 1
-                to_drop.append(pair[dimmer])
+                    to_drop.append([p0, p1][np.argmin(np.sum(positions.take([p0, p1], 0), 1))])
             results = np.delete(results, to_drop, 0)
 
     return results

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -112,7 +112,7 @@ def static_error(features, noise, diameter, noise_size=1, ndim=2):
         temp = features.join(noise, on='frame')
         ep = _static_error(temp['mass'], temp['noise'], radius, noise_size)
 
-    ep = ep.where(ep > 0, np.nan)
+    ep[ep < 0] = np.nan
 
     if ep.ndim == 1:
         ep.name = 'ep'


### PR DESCRIPTION
The code that merges nearby peaks (in `refine()`) was using numpy calls to compare peak masses. Since there are only 2 elements in each pair of peaks, switching to pure Python results in a huge speedup when there are lots of peaks. Merging ~10,000 pairs (don't ask!) went from ~20 s to < 0.5 s.

This also makes the operation in #252 in-place, and fixes some docstring typos.