### PR TITLE
BUG: Fix linking memory leak

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -953,7 +953,8 @@ class Linker(object):
 
         # Assume everything in first level starts a Track.
         # Iterate over prev_level, not prev_set, because order -> track ID.
-        self.track_lst = [self.track_cls(p) for p in prev_level]
+        for p in prev_level:
+            self.track_cls(p)
         self.mem_set = set()
 
         # Initialize memory with empty sets.
@@ -1018,7 +1019,7 @@ class Linker(object):
                         self.mem_set.remove(sp)
                 elif sp is None:
                     # if unclaimed destination particle, a track is born!
-                    self.track_lst.append(self.track_cls(dp))
+                    self.track_cls(dp)
                 elif dp is None:
                     # add the unmatched source particles to the new
                     # memory set


### PR DESCRIPTION
Linking currently appends all new track objects to `track_lst`. This is presumably a vestige of when trackpy was exclusively in-core. It causes a serious memory leak when there are many dropped particles in each frame. This PR removes `track_lst` so that the dead tracks can be GC'd.

For future reference, here is code that reproduces the memory leak:

```python
import numpy as np
import pandas as pd
import trackpy as tp
from itertools import count

def change_frame():
    for fnum in count():
        x, y = np.mgrid[-100:100,-100:100].astype('float') + (0.5 * (fnum % 2))
        yield pd.DataFrame({'x': x.flat, 'y': y.flat, 'frame': fnum})

for lf in tp.link_df_iter(change_frame(), 0.1):
    pass
```