### PR TITLE
Static error API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.7.1 scipy=0.12.0 matplotlib=1.3 pandas=0.12.0 scikit-image=0.9 pyyaml pytables"
+      env: DEPS="numpy=1.7.1 scipy=0.12.0 matplotlib=1.3 pandas=0.12.0 scikit-image=0.9 pyyaml pytables pyfftw"
     - python: "2.7"
-      env: DEPS="numpy=1.8.0 scipy=0.13.3 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables"
+      env: DEPS="numpy=1.8.0 scipy=0.13.3 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables pyfftw"
     # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
-      env: DEPS="numpy=1.9 scipy=0.15 matplotlib=1.4 pandas=0.15 scikit-image=0.10 pyyaml numba=0.17 pytables"
+      env: DEPS="numpy=1.9 scipy=0.15 matplotlib=1.4 pandas=0.15 scikit-image=0.10 pyyaml numba=0.17 pytables pyfftw"
     - python: "3.4"
-      env: DEPS="numpy=1.9 scipy=0.15 matplotlib=1.4 pandas=0.15 scikit-image=0.10 pyyaml numba=0.17 pytables"
+      env: DEPS="numpy=1.9 scipy=0.15 matplotlib=1.4 pandas=0.15 scikit-image=0.10 pyyaml numba=0.17 pytables pyfftw"
 
 install:
   # See:
@@ -21,6 +21,7 @@ install:
   # OK, this used to *fix* the build, but now it *breaks* the build.
   # If you're reading this, good luck out there. I'm not sure what to tell you.
   - conda update --yes conda
+  - conda config --add channels soft-matter
   - conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # for debugging...

--- a/trackpy/diag.py
+++ b/trackpy/diag.py
@@ -18,11 +18,6 @@ def performance_report():
     else:
         print("SLOW: numba was not found")
 
-    if preprocessing.USING_FFTW:
-        print("FAST: Using pyfftw for image preprocessing.")
-    else:
-        print("SLOW: pyfftw not found (slower image preprocessing).")
-
 
 def dependencies():
     """

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -571,11 +571,10 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
     # Estimate the uncertainty in position using signal (measured in refine)
     # and noise (measured here below).
     if characterize:
-        if preprocess:  # reuse processed image to increase performance
-            black_level, noise = measure_noise(raw_image, diameter,
-                                               threshold, image)
-        else:
-            black_level, noise = measure_noise(raw_image, diameter, threshold)
+        if preprocess:  # identify background regions from the processed image
+            black_level, noise = measure_noise(image, raw_image, radius)
+        else:  # identify background regions from the provided image
+            black_level, noise = measure_noise(raw_image, raw_image, radius)
         Npx = N_binary_mask(radius, ndim)
         mass = refined_coords[:, SIGNAL_COLUMN_INDEX + 1] - Npx * black_level
         ep = _static_error(mass, noise, radius[::-1], noise_size[::-1])

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -85,3 +85,12 @@ def sinmask(radius):
 def cosmask(radius):
     "Sin of theta_mask"
     return np.cos(2*theta_mask(radius))
+
+
+@memo
+def gaussian_kernel(sigma, truncate=4.0):
+    "1D discretized gaussian"
+    lw = int(truncate * sigma + 0.5)
+    x = np.arange(-lw, lw+1)
+    result = np.exp(x**2/(-2*sigma**2))
+    return result / np.sum(result)

--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -2,23 +2,83 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import numpy as np
-from scipy.ndimage.filters import uniform_filter1d
+from scipy.ndimage.filters import uniform_filter1d, gaussian_filter
 from scipy.ndimage.fourier import fourier_gaussian
 
 from .utils import print_update, validate_tuple
 
 
-# When loading module, try to use pyFFTW ("Fastest Fourier Transform in the
-# West") if it is available.
+def bandpass(image, lshort, llong, threshold=None, truncate=4):
+    """Remove noise and background variation.
+
+    Convolve with a Gaussian to remove short-wavelength noise and subtract out
+    long-wavelength variations, retaining features of intermediate scale.
+
+    This implementation relies on scipy.ndimage.filters.gaussian_filter, and it
+    is the fastest way known to the authors of performing a bandpass in
+    Python.
+
+    Parmeters
+    ---------
+    image : ndarray
+    lshort : small-scale cutoff (noise)
+    llong : large-scale cutoff
+    for both lshort and llong:
+        give a tuple value for different sizes per dimension
+        give int value for same value for all dimensions
+        when 2*lshort >= llong, no noise filtering is applied
+    threshold : float or integer
+        By default, 1 for integer images and 1/256. for float images.
+
+    Returns
+    -------
+    result : array
+        the bandpassed image
+
+    See Also
+    --------
+    legacy_bandpass, legacy_bandpass_fftw
+    """
+    lshort = validate_tuple(lshort, image.ndim)
+    llong = validate_tuple(llong, image.ndim)
+    if np.any([x*2 >= y for (x, y) in zip(lshort, llong)]):
+        raise ValueError("The smoothing length scale must be more" +
+                         "than twice the noise length scale.")
+    if threshold is None:
+        if np.issubdtype(image.dtype, np.integer):
+            threshold = 1
+        else:
+            threshold = 1/256.
+    settings = dict(mode='nearest', cval=0)
+    axes = range(image.ndim)
+    sizes = [x*2+1 for x in llong]
+    boxcar = np.asarray(image)
+    for (axis, size) in zip(axes, sizes):
+        boxcar = uniform_filter1d(boxcar, size, axis, **settings)
+    gaussian = gaussian_filter(image, lshort, truncate=truncate, **settings)
+    result = gaussian - boxcar
+    return np.where(result > threshold, result, 0)
+
+
+# Below are two older implementations of bandpass. Formerly, they were lumped
+# into one function, ``bandpass``, that used pyfftw if it was available and
+# numpy otherwise. Now there are separate functions for the pyfftw and numpy
+# code paths.
+
+# Both of these have been found to be slower than the new ``bandpass`` above
+# when benchmarked on typical inputs. Nonetheless, they are retained in case
+# they offer some advantage unforeseen by the authors.
+
+# All three functions give identical results, up to small numerical errors.
+
+
 try:
     import pyfftw
 except ImportError:
     # Use numpy.
-    USING_FFTW = False
-    fftn = np.fft.fftn
-    ifftn = np.fft.ifftn
+    FFTW_AVAILABLE = False
 else:
-    USING_FFTW = True
+    FFTW_AVAILABLE = True
     pyfftw.interfaces.cache.enable()
     planned = False
 
@@ -37,10 +97,16 @@ else:
         return pyfftw.interfaces.numpy_fft.ifftn(a)
 
 
-def bandpass(image, lshort, llong, threshold=None):
-    """Convolve with a Gaussian to remove short-wavelength noise,
-    and subtract out long-wavelength variations,
-    retaining features of intermediate scale.
+def legacy_bandpass(image, lshort, llong, threshold=None):
+    """Remove noise and background variation.
+
+    Convolve with a Gaussian to remove short-wavelength noise and subtract out
+    long-wavelength variations, retaining features of intermediate scale.
+
+    This implementation performs a Fourier transform using numpy.
+    In benchmarks using typical inputs, it was found to be slower than the
+    ``bandpass`` function in this module.
+
     Parmeters
     ---------
     image : ndarray
@@ -52,10 +118,76 @@ def bandpass(image, lshort, llong, threshold=None):
         when 2*lshort >= llong, no noise filtering is applied
     threshold : float or integer
         By default, 1 for integer images and 1/256. for float images.
+
     Returns
     -------
-    ndarray, the bandpassed image
+    result : array
+        the bandpassed image
+
+    See Also
+    --------
+    bandpass, legacy_bandpass_fftw
     """
+    fftn = np.fft.fftn
+    ifftn = np.fft.ifftn
+    lshort = validate_tuple(lshort, image.ndim)
+    llong = validate_tuple(llong, image.ndim)
+    if np.any([x*2 >= y for (x, y) in zip(lshort, llong)]):
+        raise ValueError("The smoothing length scale must be more" +
+                         "than twice the noise length scale.")
+    if threshold is None:
+        if np.issubdtype(image.dtype, np.integer):
+            threshold = 1
+        else:
+            threshold = 1/256.
+    # Perform a rolling average (boxcar) with kernel size = 2*llong + 1
+    boxcar = np.asarray(image)
+    for (axis, size) in enumerate(llong):
+        boxcar = uniform_filter1d(boxcar, size*2+1, axis, mode='nearest',
+                                  cval=0)
+    # Perform a gaussian filter
+    gaussian = ifftn(fourier_gaussian(fftn(image), lshort)).real
+
+    result = gaussian - boxcar
+    return np.where(result > threshold, result, 0)
+
+
+def legacy_bandpass_fftw(image, lshort, llong, threshold=None):
+    """Remove noise and background variation.
+
+    Convolve with a Gaussian to remove short-wavelength noise and subtract out
+    long-wavelength variations, retaining features of intermediate scale.
+
+    This implementation performs a Fourier transform using FFTW
+    (Fastest Fourier Transform in the West). Without FFTW and pyfftw, it
+    will raise an ImportError
+
+    In benchmarks using typical inputs, it was found to be slower than the
+    ``bandpass`` function in this module.
+
+    Parmeters
+    ---------
+    image : ndarray
+    lshort : small-scale cutoff (noise)
+    llong : large-scale cutoff
+    for both lshort and llong:
+        give a tuple value for different sizes per dimension
+        give int value for same value for all dimensions
+        when 2*lshort >= llong, no noise filtering is applied
+    threshold : float or integer
+        By default, 1 for integer images and 1/256. for float images.
+
+    Returns
+    -------
+    result : array
+        the bandpassed image
+
+    See Also
+    --------
+    bandpass, legacy_bandpass
+    """
+    if not FFTW_AVAILABLE:
+        raise ImportError("This implementation requires pyfftw.")
     lshort = validate_tuple(lshort, image.ndim)
     llong = validate_tuple(llong, image.ndim)
     if np.any([x*2 >= y for (x, y) in zip(lshort, llong)]):

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -610,9 +610,8 @@ class CommonFeatureIdentificationTests(object):
             assert_allclose(rms_dev, f['ep'].mean(), atol=0.05)
 
             # Additionally test the measured noise
-            actual_noise = tp.uncertainty.measure_noise(image_noisy,
-                                                        locate_diameter,
-                                                        noise_level/4)
+            actual_noise = tp.uncertainty.measure_noise(image, image_noisy,
+                                                        locate_diameter // 2)
             assert_allclose(actual_noise, noise_expectation * noise_level,
                             rtol=0.01, atol=1)
 

--- a/trackpy/tests/test_preprocessing.py
+++ b/trackpy/tests/test_preprocessing.py
@@ -1,16 +1,18 @@
+from __future__ import division
 from numpy.testing.utils import assert_allclose
-import nose
-import numpy as np
 from trackpy.preprocessing import *
+from trackpy.artificial import gen_nonoverlapping_locations, draw_spots
 
 
-small = np.random.randn(2**9, 2**9)
-bp_scipy = bandpass(small, 3, 11)
+pos = gen_nonoverlapping_locations((512, 512), 200, 20)
+frame = draw_spots((512, 512), pos, 20, noise_level=100)
+margin = 11
+bp_scipy = bandpass(frame, 3, 11)[margin:-margin, margin:-margin]
 
 
 def test_legacy_bandpass():
-    lbp_numpy = legacy_bandpass(small, 3, 11)
-    assert_allclose(lbp_numpy, bp_scipy, rtol=1e-3, atol=0.2)
+    lbp_numpy = legacy_bandpass(frame, 3, 11)[margin:-margin, margin:-margin]
+    assert_allclose(lbp_numpy, bp_scipy, atol=1.1)
 
 
 def test_legacy_bandpass_fftw():
@@ -18,5 +20,10 @@ def test_legacy_bandpass_fftw():
         import pyfftw
     except ImportError:
         raise nose.SkipTest("pyfftw not installed. Skipping.")
-    lbp_fftw = legacy_bandpass_fftw(small, 3, 11)
-    assert_allclose(lbp_fftw, bp_scipy)
+    lbp_fftw = legacy_bandpass_fftw(frame, 3, 11)[margin:-margin, margin:-margin]
+    assert_allclose(lbp_fftw, bp_scipy, atol=1.1)
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/trackpy/tests/test_preprocessing.py
+++ b/trackpy/tests/test_preprocessing.py
@@ -1,0 +1,22 @@
+from numpy.testing.utils import assert_allclose
+import nose
+import numpy as np
+from trackpy.preprocessing import *
+
+
+small = np.random.randn(2**9, 2**9)
+bp_scipy = bandpass(small, 3, 11)
+
+
+def test_legacy_bandpass():
+    lbp_numpy = legacy_bandpass(small, 3, 11)
+    assert_allclose(lbp_numpy, bp_scipy, rtol=1e-3, atol=0.2)
+
+
+def test_legacy_bandpass_fftw():
+    try:
+        import pyfftw
+    except ImportError:
+        raise nose.SkipTest("pyfftw not installed. Skipping.")
+    lbp_fftw = legacy_bandpass_fftw(small, 3, 11)
+    assert_allclose(lbp_fftw, bp_scipy)


### PR DESCRIPTION
As discussed in #244, this simplifies the API of `measure_noise`. It contains the commits of #244, only the latest commit is my addition. The function will never do image bandpassing.

The function `uncertainty.roi` is dropped and its functionality integrated into `measure_noise`. I am not sure wether to leave `uncertainty.roi` as a legacy function, but as the API will be changed anyway I can't think of a use for this. I am open for comments on this ;)

As the API is changing anyway, I replaced `diameter` by `radius`, to stop the tedious interconversion.