### PR TITLE
FIX typo in 3d numba size_z characterization

### DIFF
--- a/trackpy/feature_numba.py
+++ b/trackpy/feature_numba.py
@@ -596,7 +596,7 @@ def _numba_refine_3D(raw_image, image, radiusZ, radiusY, radiusX, coords, N,
                            squareX + maskX[i]]
                 mass_ += px
 
-                RgZ += y2_mask[i]*px
+                RgZ += z2_mask[i]*px
                 RgY += y2_mask[i]*px
                 RgX += x2_mask[i]*px
 


### PR DESCRIPTION
Small typo, big consequences: the `size_z` was equal to `size_y`. Apparently this isn't tested.
It should go into v0.3.