### PR TITLE
FIX Image processing when preprocess=False

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -597,7 +597,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
         if preprocess:  # identify background regions from the processed image
             black_level, noise = measure_noise(image, raw_image, radius)
         else:  # identify background regions from the provided image
-            black_level, noise = measure_noise(raw_image, raw_image, radius)
+            black_level, noise = measure_noise(image, raw_image, radius)
         Npx = N_binary_mask(radius, ndim)
         mass = refined_coords[:, SIGNAL_COLUMN_INDEX + 1] - Npx * black_level
         ep = _static_error(mass, noise, radius[::-1], noise_size[::-1])

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -276,7 +276,7 @@ class CommonFeatureIdentificationTests(object):
         # two neighboring pixels of unequal brightness
         pos1 = np.array([7, 13])
         pos2 = np.array([8, 13])
-        pos = [7.25, 13]  # center is between pixels, biased left
+        pos = [7.33, 13]  # center is between pixels, biased left
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 100)
         draw_point(image, pos2, 50)
@@ -285,7 +285,7 @@ class CommonFeatureIdentificationTests(object):
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
-        pos = [7.75, 13]  # center is between pixels, biased right
+        pos = [7.67, 13]  # center is between pixels, biased right
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 50)
         draw_point(image, pos2, 100)
@@ -296,7 +296,7 @@ class CommonFeatureIdentificationTests(object):
 
         pos1 = np.array([7, 12])
         pos2 = np.array([7, 13])
-        pos = [7, 12.25]  # center is between pixels, biased down
+        pos = [7, 12.33]  # center is between pixels, biased up
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 100)
         draw_point(image, pos2, 50)
@@ -305,7 +305,7 @@ class CommonFeatureIdentificationTests(object):
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
-        pos = [7, 12.75]  # center is between pixels, biased up
+        pos = [7, 12.67]  # center is between pixels, biased down
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 50)
         draw_point(image, pos2, 100)
@@ -315,11 +315,11 @@ class CommonFeatureIdentificationTests(object):
         assert_allclose(actual, expected, atol=PRECISION)
 
         # four neighboring pixels of unequal brightness
-        pos1 = np.array([7, 13])
-        pos2 = np.array([8, 13])
+        pos1 = np.array([7, 12])
+        pos2 = np.array([8, 12])
         pos3 = np.array([7, 13])
         pos4 = np.array([8, 13])
-        pos = [7.25, 13]  # center is between pixels, biased left
+        pos = [7.33, 12.5]  # center is between pixels, biased left
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 100)
         draw_point(image, pos2, 50)
@@ -330,7 +330,7 @@ class CommonFeatureIdentificationTests(object):
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
-        pos = [7.75, 13]  # center is between pixels, biased right 
+        pos = [7.67, 12.5]  # center is between pixels, biased right
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 50)
         draw_point(image, pos2, 100)
@@ -341,23 +341,23 @@ class CommonFeatureIdentificationTests(object):
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
-        pos1 = np.array([7, 12])
-        pos2 = np.array([7, 13])
-        pos3 = np.array([7, 12])
-        pos4 = np.array([7, 13])
-        pos = [7, 12.25]  # center is between pixels, biased down
+        pos = [7.5, 12.33]  # center is between pixels, biased up
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 100)
-        draw_point(image, pos2, 50)
+        draw_point(image, pos2, 100)
+        draw_point(image, pos3, 50)
+        draw_point(image, pos4, 50)
         actual = tp.locate(image, 5, 1, preprocess=False,
                            engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
-        pos = [7, 12.75]  # center is between pixels, biased up 
+        pos = [7.5, 12.67]  # center is between pixels, biased down
         image = np.ones(dims, dtype='uint8')
         draw_point(image, pos1, 50)
-        draw_point(image, pos2, 100)
+        draw_point(image, pos2, 50)
+        draw_point(image, pos3, 100)
+        draw_point(image, pos4, 100)
         actual = tp.locate(image, 5, 1, preprocess=False,
                            engine=self.engine)[cols]
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -29,8 +29,11 @@ def measure_noise(image_bp, image_raw, radius):
     background mean, background standard deviation
     """
     structure = binary_mask(radius, image_bp.ndim)
-    signal_mask = morphology.binary_dilation(image_bp, structure=structure)
-    return image_raw[~signal_mask].mean(), image_raw[~signal_mask].std()
+    background = ~morphology.binary_dilation(image_bp, structure=structure)
+    if background.sum() == 0:  # edge case of no background identified
+        return np.nan, np.nan
+    else:
+        return image_raw[background].mean(), image_raw[background].std()
 
 
 @memo


### PR DESCRIPTION
This changes the preprocessing / rescaling logic. Rescaling is necessary because the subsequent grey dilation only takes integer images. Now 3 cases are considered:

- `preprocess == True`: do preprocessing and gamut rescaling
- `preprocess = False` and image of integer type: do nothing, rescaling is obsolete and would only degrade picture quality. omit copy because image is not changed after this.
- `preprocess = False` and float image: do gamut rescaling