### PR TITLE
Make refinement thresholds consistent; expose them through refine API

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -140,6 +140,7 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
     """
     # ensure that radius is tuple of integers, for direct calls to refine()
     radius = validate_tuple(radius, image.ndim)
+    separation = validate_tuple(separation, image.ndim)
     # Main loop will be performed in separate function.
     if engine == 'auto':
         if NUMBA_AVAILABLE and image.ndim in [2, 3]:

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -117,6 +117,9 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
         processed image, used for locating center of mass
     coord : array
         estimated position
+    separation : float or tuple
+        Minimum separtion between features.
+        Default is 0. May be a tuple, see diameter for details.
     max_iterations : integer
         max number of loops to refine the center of mass, default 10
     engine : {'python', 'numba'}

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -101,7 +101,8 @@ def _safe_center_of_mass(x, radius, grids):
 
 
 def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
-           engine='auto', characterize=True, walkthrough=False):
+           engine='auto', shift_thresh=0.6, break_thresh=0.005,
+           characterize=True, walkthrough=False):
     """Find the center of mass of a bright feature starting from an estimate.
 
     Characterize the neighborhood of a local maximum, and iteratively
@@ -118,12 +119,21 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
         estimated position
     max_iterations : integer
         max number of loops to refine the center of mass, default 10
+    engine : {'python', 'numba'}
+        Numba is faster if available, but it cannot do walkthrough.
+    shift_thresh : float, optional
+        Default 0.6 (unit is pixels).
+        If the brightness centroid is more than this far off the mask center,
+        shift mask to neighboring pixel. The new mask will be used for any
+        remaining iterations.
+    break_thresh : float, optional
+        Default: 0.005 (unit is pixels).
+        When the subpixel refinement along all dimensions is less than this
+        number, declare victory and stop refinement.
     characterize : boolean, True by default
         Compute and return mass, size, eccentricity, signal.
     walkthrough : boolean, False by default
         Print the offset on each loop and display final neighborhood image.
-    engine : {'python', 'numba'}
-        Numba is faster if available, but it cannot do walkthrough.
     """
     # ensure that radius is tuple of integers, for direct calls to refine()
     radius = validate_tuple(radius, image.ndim)
@@ -136,7 +146,7 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
     if engine == 'python':
         coords = np.array(coords)  # a copy, will not modify in place
         results = _refine(raw_image, image, radius, coords, max_iterations,
-                          characterize, walkthrough)
+                          shift_thresh, break_thresh, characterize, walkthrough)
     elif engine == 'numba':
         if not NUMBA_AVAILABLE:
             warnings.warn("numba could not be imported. Without it, the "
@@ -170,7 +180,8 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
                                              dtype=np.int16)
             _numba_refine_3D(np.asarray(raw_image), np.asarray(image),
                              radius[0], radius[1], radius[2], coords, N,
-                             int(max_iterations), characterize,
+                             int(max_iterations), shift_thresh, break_thresh,
+                             characterize,
                              image.shape[0], image.shape[1], image.shape[2],
                              maskZ, maskY, maskX, maskX.shape[0],
                              r2_mask, z2_mask, y2_mask, x2_mask, results)
@@ -179,7 +190,7 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
             results = np.empty((N, 3), dtype=np.float64)
             _numba_refine_2D(np.asarray(raw_image), np.asarray(image),
                              radius[0], radius[1], coords, N,
-                             int(max_iterations),
+                             int(max_iterations), shift_thresh, break_thresh,
                              image.shape[0], image.shape[1],
                              mask_coordsY, mask_coordsX, mask_coordsY.shape[0],
                              results)
@@ -191,7 +202,7 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
             smask = sinmask(radius)[mask]
             _numba_refine_2D_c(np.asarray(raw_image), np.asarray(image),
                                radius[0], radius[1], coords, N,
-                               int(max_iterations),
+                               int(max_iterations), shift_thresh, break_thresh,
                                image.shape[0], image.shape[1],
                                mask_coordsY, mask_coordsX, mask_coordsY.shape[0],
                                r2_mask, cmask, smask, results)
@@ -205,8 +216,8 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
             smask = sinmask(radius)[mask]
             _numba_refine_2D_c_a(np.asarray(raw_image), np.asarray(image),
                                  radius[0], radius[1], coords, N,
-                                 int(max_iterations),
-                                 image.shape[0], image.shape[1],
+                                 int(max_iterations), shift_thresh,
+                                 break_thresh, image.shape[0], image.shape[1],
                                  mask_coordsY, mask_coordsX, mask_coordsY.shape[0],
                                  y2_mask, x2_mask, cmask, smask, results)
     else:
@@ -243,9 +254,7 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
 
 # (This is pure Python. A numba variant follows below.)
 def _refine(raw_image, image, radius, coords, max_iterations,
-            characterize, walkthrough):
-    SHIFT_THRESH = 0.6
-    GOOD_ENOUGH_THRESH = 0.005
+            shift_thresh, break_thresh, characterize, walkthrough):
 
     ndim = image.ndim
     isotropic = np.all(radius[1:] == radius[:-1])
@@ -281,15 +290,15 @@ def _refine(raw_image, image, radius, coords, max_iterations,
         for iteration in range(max_iterations):
             off_center = cm_n - radius
             logger.debug('off_center: %f', off_center)
-            if np.all(np.abs(off_center) < GOOD_ENOUGH_THRESH):
+            if np.all(np.abs(off_center) < break_thresh):
                 break  # Accurate enough.
 
             # If we're off by more than half a pixel in any direction, move.
-            elif np.any(np.abs(off_center) > SHIFT_THRESH) & allow_moves:
+            elif np.any(np.abs(off_center) > shift_thresh) & allow_moves:
                 # In here, coord is an integer.
                 new_coord = coord
-                new_coord[off_center > SHIFT_THRESH] += 1
-                new_coord[off_center < -SHIFT_THRESH] -= 1
+                new_coord[off_center > shift_thresh] += 1
+                new_coord[off_center < -shift_thresh] -= 1
                 # Don't move outside the image!
                 upper_bound = np.array(image.shape) - 1 - radius
                 new_coord = np.clip(new_coord, radius, upper_bound).astype(int)

--- a/trackpy/feature_numba.py
+++ b/trackpy/feature_numba.py
@@ -10,7 +10,7 @@ def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
                      max_iterations, shapeY, shapeX, maskY, maskX, N_mask,
                      results):
     SHIFT_THRESH = 0.6
-    GOOD_ENOUGH_THRESH = 0.01
+    GOOD_ENOUGH_THRESH = 0.005
     # Column indices into the 'results' array
     MASS_COL = 2
 

--- a/trackpy/feature_numba.py
+++ b/trackpy/feature_numba.py
@@ -7,10 +7,8 @@ from .try_numba import try_numba_autojit
 
 @try_numba_autojit(nopython=True)
 def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
-                     max_iterations, shapeY, shapeX, maskY, maskX, N_mask,
-                     results):
-    SHIFT_THRESH = 0.6
-    GOOD_ENOUGH_THRESH = 0.005
+                     max_iterations, shift_thresh, break_thresh,
+                     shapeY, shapeX, maskY, maskX, N_mask, results):
     # Column indices into the 'results' array
     MASS_COL = 2
 
@@ -41,14 +39,14 @@ def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
         for iteration in range(max_iterations):
             off_centerY = cm_nY - radiusY
             off_centerX = cm_nX - radiusX
-            if (abs(off_centerY) < GOOD_ENOUGH_THRESH and
-                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+            if (abs(off_centerY) < break_thresh and
+                abs(off_centerX) < break_thresh):
                 break  # Go to next feature
 
             # If we're off by more than half a pixel in any direction, move.
             do_move = False
-            if allow_moves and (abs(off_centerY) > SHIFT_THRESH or
-                                abs(off_centerX) > SHIFT_THRESH):
+            if allow_moves and (abs(off_centerY) > shift_thresh or
+                                abs(off_centerX) > shift_thresh):
                 do_move = True
 
             if do_move:
@@ -56,14 +54,14 @@ def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
                 new_coordY = int(round(coordY))
                 new_coordX = int(round(coordX))
                 oc = off_centerY
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordY += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordY -= 1
                 oc = off_centerX
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordX += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordX -= 1
                 # Don't move outside the image!
                 if new_coordY < radiusY:
@@ -125,10 +123,9 @@ def _numba_refine_2D(raw_image, image, radiusY, radiusX, coords, N,
 
 @try_numba_autojit(nopython=True)
 def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
-                      max_iterations, shapeY, shapeX, maskY,
+                      max_iterations, shift_thresh, break_thresh,
+                      shapeY, shapeX, maskY,
                       maskX, N_mask, r2_mask, cmask, smask, results):
-    SHIFT_THRESH = 0.6
-    GOOD_ENOUGH_THRESH = 0.01
     # Column indices into the 'results' array
     MASS_COL = 2
     RG_COL = 3
@@ -163,14 +160,14 @@ def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
         for iteration in range(max_iterations):
             off_centerY = cm_nY - radiusY
             off_centerX = cm_nX - radiusX
-            if (abs(off_centerY) < GOOD_ENOUGH_THRESH and
-                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+            if (abs(off_centerY) < break_thresh and
+                abs(off_centerX) < break_thresh):
                 break  # Go to next feature
 
             # If we're off by more than half a pixel in any direction, move.
             do_move = False
-            if allow_moves and (abs(off_centerY) > SHIFT_THRESH or
-                                abs(off_centerX) > SHIFT_THRESH):
+            if allow_moves and (abs(off_centerY) > shift_thresh or
+                                abs(off_centerX) > shift_thresh):
                 do_move = True
 
             if do_move:
@@ -178,14 +175,14 @@ def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
                 new_coordY = int(round(coordY))
                 new_coordX = int(round(coordX))
                 oc = off_centerY
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordY += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordY -= 1
                 oc = off_centerX
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordX += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordX -= 1
                 # Don't move outside the image!
                 if new_coordY < radiusY:
@@ -266,11 +263,10 @@ def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
 
 @try_numba_autojit(nopython=True)
 def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
-                        max_iterations, shapeY, shapeX, maskY,
+                        max_iterations, shift_thresh, break_thresh,
+                        shapeY, shapeX, maskY,
                         maskX, N_mask, y2_mask, x2_mask, cmask, smask,
                         results):
-    SHIFT_THRESH = 0.6
-    GOOD_ENOUGH_THRESH = 0.01
     # Column indices into the 'results' array
     MASS_COL = 2
     RGX_COL = 3
@@ -306,14 +302,14 @@ def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
         for iteration in range(max_iterations):
             off_centerY = cm_nY - radiusY
             off_centerX = cm_nX - radiusX
-            if (abs(off_centerY) < GOOD_ENOUGH_THRESH and
-                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+            if (abs(off_centerY) < break_thresh and
+                abs(off_centerX) < break_thresh):
                 break  # Go to next feature
 
             # If we're off by more than half a pixel in any direction, move.
             do_move = False
-            if allow_moves and (abs(off_centerY) > SHIFT_THRESH or
-                                abs(off_centerX) > SHIFT_THRESH):
+            if allow_moves and (abs(off_centerY) > shift_thresh or
+                                abs(off_centerX) > shift_thresh):
                 do_move = True
 
             if do_move:
@@ -321,14 +317,14 @@ def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
                 new_coordY = int(round(coordY))
                 new_coordX = int(round(coordX))
                 oc = off_centerY
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordY += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordY -= 1
                 oc = off_centerX
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordX += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordX -= 1
                 # Don't move outside the image!
                 if new_coordY < radiusY:
@@ -412,11 +408,10 @@ def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
 
 @try_numba_autojit(nopython=True)
 def _numba_refine_3D(raw_image, image, radiusZ, radiusY, radiusX, coords, N,
-                     max_iterations, characterize, shapeZ, shapeY, shapeX,
+                     max_iterations, shift_thresh, break_thresh,
+                     characterize, shapeZ, shapeY, shapeX,
                      maskZ, maskY, maskX, N_mask, r2_mask, z2_mask, y2_mask,
                      x2_mask, results):
-    SHIFT_THRESH = 0.6
-    GOOD_ENOUGH_THRESH = 0.01
     # Column indices into the 'results' array
     MASS_COL = 3
     isotropic = (radiusX == radiusY and radiusX == radiusZ)
@@ -469,16 +464,16 @@ def _numba_refine_3D(raw_image, image, radiusZ, radiusY, radiusX, coords, N,
             off_centerZ = cm_nZ - radiusZ
             off_centerY = cm_nY - radiusY
             off_centerX = cm_nX - radiusX
-            if (abs(off_centerZ) < GOOD_ENOUGH_THRESH and
-                abs(off_centerY) < GOOD_ENOUGH_THRESH and
-                abs(off_centerX) < GOOD_ENOUGH_THRESH):
+            if (abs(off_centerZ) < break_thresh and
+                abs(off_centerY) < break_thresh and
+                abs(off_centerX) < break_thresh):
                 break  # Go to next feature
 
             # If we're off by more than half a pixel in any direction, move.
             do_move = False
-            if allow_moves and (abs(off_centerZ) > SHIFT_THRESH or
-                                abs(off_centerY) > SHIFT_THRESH or
-                                abs(off_centerX) > SHIFT_THRESH):
+            if allow_moves and (abs(off_centerZ) > shift_thresh or
+                                abs(off_centerY) > shift_thresh or
+                                abs(off_centerX) > shift_thresh):
                 do_move = True
 
             if do_move:
@@ -487,19 +482,19 @@ def _numba_refine_3D(raw_image, image, radiusZ, radiusY, radiusX, coords, N,
                 new_coordY = int(round(coordY))
                 new_coordX = int(round(coordX))
                 oc = off_centerZ
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordZ += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordZ -= 1
                 oc = off_centerY
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordY += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordY -= 1
                 oc = off_centerX
-                if oc > SHIFT_THRESH:
+                if oc > shift_thresh:
                     new_coordX += 1
-                elif oc < - SHIFT_THRESH:
+                elif oc < - shift_thresh:
                     new_coordX -= 1
                 # Don't move outside the image!
                 if new_coordZ < radiusZ:


### PR DESCRIPTION
As the title says, this does two separate things:

1. Set  `GOOD_ENOUGH_THRESH` in the numba codepath to the same value it has in the numpy code path. This closes #191 (thanks, @RebeccaWPerry!) This will slightly change the output of the numba code path, but all the tests pass without modification.
2. Stop hard-coding `GOOD_ENOUGH_THRESH` and `SHIFT_THRESH`, instead exposing them as new optional arguments to `refine`. This does not change the output at all. This closes #246 (thanks again, @sciunto )

These parameters are obscure. I welcome opinions on my choice of names ('break_thresh` and `shift_thresh`) and my attempt at explaining them in the docstring.

I intentionally do not expose these parameters through the already-overstuffed `locate`. Users who want to customize these will have to build a processing pipeline the long way.