### PR TITLE
Minmass change convenience function

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -143,6 +143,7 @@ Utility functions
 .. autosummary::
     :toctree: generated/
 
+    minmass_version_change
     utils.fit_powerlaw
     strip_diagnostics
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -71,9 +71,14 @@ Trackpy includes functions for plotting the data in ways that are commonly usefu
     :toctree: generated/
 
     annotate
+	scatter
     plot_traj
+	annotate3d
+	scatter3d
+	plot_traj3d
     plot_displacements
     subpx_bias
+	plot_density_profile
 
 These two are almost too simple to justify their existence -- just a convenient shorthand for a common plotting task.
 

--- a/doc/releases/v0.3.0.txt
+++ b/doc/releases/v0.3.0.txt
@@ -26,7 +26,7 @@ Enhancements
 
 - The minimum feature separation can be as small as zero. Formerly, it was constrained to be larger than the feature diameter. If ``serparation=0``, "merging" of duplicate maxima is effectively turned off. (:issue:`139`)
 
-- The percentile-based thresholding was moved into a serpate function, so it can now be called directly. That will be useful to users who want to inspect what the thresholding is doing to their images. It will also be useful for profiling. (:issue:`139`)
+- The percentile-based thresholding was moved into a separate function, so it can now be called directly. That will be useful to users who want to inspect what the thresholding is doing to their images. It will also be useful for profiling. (:issue:`139`)
 
 - The performance of feature-finding can now be tested in a custom way using new routines in ``artificial.py``. Users can provide a custom feature shape to test the feature-finding on their own system.
 
@@ -39,7 +39,7 @@ Bug Fixes
 
 - Fixed a bug in v0.2.3 and v0.2.4 that broke the ``circle_size`` parameter in ``annotate()``. (:issue:`169`, :issue:`170`)
 - Fixed a bug where subnetwork distances were not addded in quadrature in the python linker. (:issue:`212`). (The impact of this bug is not as large as one might expect. See issue link for details.)
-- Input images with a float datatype are internally converted to integer datatype for faster computation. They were converted to signed integers; now they are converted to unsigned. (:issue:`188`)
+- Input images with a float datatype are internally converted to integer datatype for faster computation. They were converted to signed integers; now they are converted to unsigned. (:issue:`188`). When preprocessing is turned off, integer images are not converted at all (:issue:`264`).
 - Slow feature-finding with more recent versions of the numba package (0.16 and 0.17 specifically) is addressed.
 
 API changes
@@ -48,3 +48,4 @@ API changes
 - The plot function ``annotate()`` now displays the image with the vertical axis inverted, to be consistent with the ``pims`` display function and ``plot_traj()``. (:issue:`217`)
 - Using trackpy to access pims functionality (e.g. ``trackpy.ImageSequence()``) is now deprecated; it still works but will generate a warning message. This capability will be removed from future versions of trackpy, in favor of accessing it in the pims package directly (e.g. ``pims.ImageSequence()``). (:issue:`214`)
 - When trackpy estimates the error in a feature's position (returned as the ``ep`` column), the procedure can fail and result in a nonsense value. This will now result in the value of ``ep`` being NaN (not a number); previous versions of trackpy returned a negative value in this situation. To restore the previous behavior, you can replace these values with negative numbers by using the Pandas ``fillna()`` method. (:issue:`113`)
+- The mass calculation is changed. Before v0.3 the mass was calculated from a rescaled image. From this version, this rescaling is compensated at the end so that the mass reflects the actual intensities in the image. ``minmass_version_change()`` can calculate the different ``minmass`` value to use (:issue:`239`)

--- a/doc/releases/v0.3.0.txt
+++ b/doc/releases/v0.3.0.txt
@@ -10,15 +10,17 @@ Release v0.3.0 adds many important enhancements and fixes. Feature location is e
 Enhancements
 ~~~~~~~~~~~~
 
-- The feature-finding functionality was formerly limited to circular features, but now trackpy can locate anisotropic N-dimensional features. Their size is specified as a tuple of odd integers instead of a single odd integer. See the new 3D tutorial for details. (:issue:`239`)
+- The feature-finding functionality was formerly limited to circular features, but now trackpy can locate anisotropic N-dimensional features. Their size is specified as a tuple of odd integers instead of a single odd integer. See the new 3D tutorial for details. (:issue:`162`, :issue:`239`)
 
-- The plotting and analysis tools, many of which were limited to 2D, have been extended to 3D.
+- The plotting and analysis tools, many of which were limited to 2D, have been extended to 3D. (:issue:`196`)
 
 - The numba engine for fast feature-finding has been extented to handle 3D images. (:issue:`242`)
 
+- Feature finding returns a new column ``raw_mass`` that is the sum of intensities inside the unprocessed image. For anisotropic feature detection, size and static errors are returned per dimension: ``size_x`` etc. and ``ep_x`` etc. (:issue:`239`)
+
 - A powerful new adaptive search feature gives much richer control of the tracking (trajectory-linking) process, and it makes formerly intractable scenarios possible to solve in a reasonable time. See the new tutorials, "Advanced Linking: Subnetworks and search_range" and "Adaptive Search: Changing search_range on the Fly," for details.
 
-- Uncertainty estimation is more accurate. See the docstring of ``trackpy.uncertainty.static_error`` for details. (:issue:`239`)
+- Uncertainty estimation is more accurate. See the docstring of ``trackpy.uncertainty.static_error`` for details. (:issue:`239`, :issue:`259`)
 
 - The linking functions can now collect data about how each particle was linked. See the tutorial "Obtaining Diagnostic Information from Linking."
 

--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -14,7 +14,7 @@ from .linking import HashTable, TreeFinder, Point, PointND, \
            link_df_iter, strip_diagnostics
 from .filtering import filter_stubs, filter_clusters, filter
 from .feature import locate, batch, percentile_threshold, local_maxima, \
-           refine, estimate_mass, estimate_size
+           refine, estimate_mass, estimate_size, minmass_version_change
 from .preprocessing import bandpass
 from .framewise_data import FramewiseData, PandasHDFStore, PandasHDFStoreBig, \
            PandasHDFStoreSingleNode

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -411,7 +411,7 @@ def _refine(raw_image, image, radius, coords, max_iterations,
         return np.column_stack([final_coords, mass, Rg, ecc, signal, raw_mass])
 
 
-def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
+def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
            noise_size=1, smoothing_size=None, threshold=None, invert=False,
            percentile=64, topn=None, preprocess=True, max_iterations=10,
            filter_before=True, filter_after=True,
@@ -434,9 +434,10 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
         same as the image shape, conventionally (z, y, x) or (y, x). The
         number(s) must be odd integers. When in doubt, round up.
     minmass : float
-        The minimum integrate brightness.
-        Default is 100, but a good value is often much higher. This is a
-        crucial parameter for elminating spurious features.
+        The minimum integrated brightness.
+        Default is 100 for integer images and 1 for float images, but a good
+        value is often much higher. This is a crucial parameter for eliminating
+        spurious features.
     maxsize : float
         maximum radius-of-gyration of brightness, default None
     separation : float or tuple
@@ -540,6 +541,12 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
         warnings.warn("I am interpreting the image as {0}-dimensional. "
                       "If it is actually a {1}-dimensional color image, "
                       "convert it to grayscale first.".format(dim, dim-1))
+
+    if minmass is None:
+        if np.issubdtype(raw_image.dtype, np.integer):
+            minmass = 100
+        else:
+            minmass = 1.
 
     # Determine `image`: the image to find the local maxima on
     if preprocess:

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -37,22 +37,27 @@ def minmass_version_change(raw_image, old_minmass, preprocess=True,
                            invert=False, noise_size=1, smoothing_size=None,
                            threshold=None):
     """From trackpy version 0.3.0, the mass calculation is changed. Before
-    version 0.3.0 the mass was calculated from a rescaled image: first the
-    image was bandpassed, then converted to integers. The rescaling was done
-    to use the full resolution of the integer dtype.
+    version 0.3.0 the mass was calculated from a rescaled image. From version
+    0.3.0, this rescaling is compensated at the end so that the mass reflects
+    the actual intensities in the image.
 
-    From version 0.3.0, this rescaling is compensated at the end so that the
-    mass reflect the actual intensities in the image.
-    
     This function calculates the scalefactor between the old and new mass
-    and applies it to calculate the new minmass from the old minmass
-    
+    and applies it to calculate the new minmass filter value.
+
     Parameters
     ----------
     raw_image : ndarray
     old_minmass : number
-    preprocess : boolean
-    
+    preprocess : boolean, optional
+        Defaults to True
+    invert : boolean, optional
+        Defaults to False
+    noise_size : number, optional
+        Defaults to 1
+    smoothing_size : number, optional
+        Required when preprocessing. In locate, it equals diameter by default.
+    threshold : number, optional
+
     Returns
     -------
     New minmass

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -33,6 +33,42 @@ def percentile_threshold(image, percentile):
     return np.percentile(not_black, percentile)
 
 
+def minmass_version_change(raw_image, old_minmass, preprocess=True):
+    """From trackpy version 0.3.0, the mass calculation is changed. Before
+    version 0.3.0 the mass was calculated from a rescaled image: first the
+    image was bandpassed, then converted to integers. The rescaling was done
+    to use the full resolution of the integer dtype.
+
+    From version 0.3.0, this rescaling is compensated at the end so that the
+    mass reflect the actual intensities in the image.
+    
+    This function calculates the scalefactor between the old and new mass
+    and applies it to calculate the new minmass from the old minmass
+    
+    Parameters
+    ----------
+    raw_image : ndarray
+    old_minmass : number
+    preprocess : boolean
+    
+    Returns
+    -------
+    New minmass
+    """
+    if np.issubdtype(raw_image.dtype, np.integer):
+        dtype = raw_image.dtype
+    else:
+        dtype = np.uint8
+
+    scale_factor = scalefactor_to_gamut(raw_image, dtype)
+
+    # in general the preprocessing reduces the max image intensity
+    if preprocess:
+        scale_factor *= 0.8
+
+    return old_minmass * scale_factor   
+
+
 def local_maxima(image, radius, percentile=64, margin=None):
     """Find local maxima whose brightness is above a given percentile.
 

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -36,7 +36,9 @@ def percentile_threshold(image, percentile):
 def minmass_version_change(raw_image, old_minmass, preprocess=True,
                            invert=False, noise_size=1, smoothing_size=None,
                            threshold=None):
-    """From trackpy version 0.3.0, the mass calculation is changed. Before
+    """Convert minmass value from v0.2.4 to v0.3.
+
+    From trackpy version 0.3.0, the mass calculation is changed. Before
     version 0.3.0 the mass was calculated from a rescaled image. From version
     0.3.0, this rescaling is compensated at the end so that the mass reflects
     the actual intensities in the image.
@@ -438,6 +440,7 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
         Default is 100 for integer images and 1 for float images, but a good
         value is often much higher. This is a crucial parameter for eliminating
         spurious features.
+        .. warning:: The mass value is changed since v0.3.0
     maxsize : float
         maximum radius-of-gyration of brightness, default None
     separation : float or tuple
@@ -488,6 +491,7 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
     See Also
     --------
     batch : performs location on many images in batch
+    minmass_version_change : to convert minmass from v0.2.4 to v0.3.0
 
     Notes
     -----
@@ -710,9 +714,11 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
         same as the image shape, conventionally (z, y, x) or (y, x). The
         number(s) must be odd integers. When in doubt, round up.
     minmass : float
-        The minimum integrate brightness.
-        Default is 100, but a good value is often much higher. This is a
-        crucial parameter for elminating spurious features.
+        The minimum integrated brightness.
+        Default is 100 for integer images and 1 for float images, but a good
+        value is often much higher. This is a crucial parameter for eliminating
+        spurious features.
+        .. warning:: The mass value was changed since v0.3.0
     maxsize : float
         maximum radius-of-gyration of brightness, default None
     separation : float or tuple
@@ -771,6 +777,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
     See Also
     --------
     locate : performs location on a single image
+    minmass_version_change : to convert minmass from v0.2.4 to v0.3.0
 
     Notes
     -----

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -169,7 +169,7 @@ def _set_labels(ax, label_format, pos_columns):
 @make_axes
 def scatter(centroids, mpp=None, cmap=None, ax=None, pos_columns=None,
             plot_style={}):
-    """Scatter plot of all points of each particle.
+    """Scatter plot of all particles.
 
     Parameters
     ----------
@@ -187,6 +187,10 @@ def scatter(centroids, mpp=None, cmap=None, ax=None, pos_columns=None,
     Returns
     -------
     Axes object
+    
+    See Also
+    --------
+    scatter3d : the 3D equivalent of `scatter`
     """
     import matplotlib as mpl
     import matplotlib.pyplot as plt
@@ -216,12 +220,32 @@ def scatter(centroids, mpp=None, cmap=None, ax=None, pos_columns=None,
 
 @make_axes3d
 def scatter3d(*args, **kwargs):
-    """3D extension of scatter"""
+    """The 3D equivalent of `scatter`.
+
+    Parameters
+    ----------
+    centroids : DataFrame
+        The DataFrame should include time and spatial coordinate columns.
+    mpp : float, optional
+        Microns per pixel. If omitted, the labels will have units of pixels.
+    cmap : colormap, optional
+        This is only used in colorby='frame' mode. Default = mpl.cm.winter
+    ax : matplotlib axes object, optional
+        Defaults to current axes
+    pos_columns : list of strings, optional
+        Dataframe column names for spatial coords. Default is ['x', 'y', 'z'].
+
+    Returns
+    -------
+    Axes object
+    
+    See Also
+    --------
+    scatter3d : the 3D equivalent of `scatter`
+    """
     if kwargs.get('pos_columns') is None:
         kwargs['pos_columns'] = ['x', 'y', 'z']
     return scatter(*args, **kwargs)
-
-scatter3d.__doc__ = scatter.__doc__
 
 
 @make_axes
@@ -256,6 +280,10 @@ def plot_traj(traj, colorby='particle', mpp=None, label=False,
     Returns
     -------
     Axes object
+    
+    See Also
+    --------
+    plot_traj3d : the 3D equivalent of `plot_traj`
     """
     import matplotlib as mpl
     import matplotlib.pyplot as plt
@@ -324,16 +352,44 @@ ptraj = plot_traj  # convenience alias
 
 @make_axes3d
 def plot_traj3d(*args, **kwargs):
-    """3D extension of plot_traj"""
+    """The 3D equivalent of `plot_traj`.
+    
+    Parameters
+    ----------
+    traj : DataFrame
+        The DataFrame should include time and spatial coordinate columns.
+    mpp : float, optional
+        Microns per pixel. If omitted, the labels will have units of pixels.
+    label : boolean, optional
+        Set to True to write particle ID numbers next to trajectories.
+    superimpose : ndarray, optional
+        Background image, default None
+    cmap : colormap, optional
+        This is only used in colorby='frame' mode. Default = mpl.cm.winter
+    ax : matplotlib axes object, optional
+        Defaults to current axes
+    t_column : string, optional
+        DataFrame column name for time coordinate. Default is 'frame'.
+    pos_columns : list of strings, optional
+        Dataframe column names for spatial coords. Default is ['x', 'y', 'z'].
+    plot_style : dictionary
+        Keyword arguments passed through to the `Axes.plot(...)` command
+
+    Returns
+    -------
+    Axes object
+
+    See Also
+    --------
+    plot_traj : plot 2D trajectories"""
+
     if kwargs.get('pos_columns') is None:
         kwargs['pos_columns'] = ['x', 'y', 'z']
     if kwargs.get('colorby') == 'frame':
         raise NotImplemented("3d trajectory plots cannot be colored by frame")
     return plot_traj(*args, **kwargs)
 
-plot_traj3d.__doc__ = plot_traj.__doc__
 ptraj3d = plot_traj3d
-
 
 @make_axes
 def annotate(centroids, image, circle_size=None, color=None,
@@ -366,7 +422,11 @@ def annotate(centroids, image, circle_size=None, color=None,
 
     Returns
     ------
-    axes
+    Axes object
+    
+    See Also
+    --------
+    annotate3d : The 3D equivalent that returns a scrollable stack.
     """
     import matplotlib.pyplot as plt
 
@@ -448,9 +508,39 @@ def annotate(centroids, image, circle_size=None, color=None,
 
 
 def annotate3d(centroids, image, **kwargs):
-    """
-    An extension of annotate that annotates a 3D image and returns a scrollable
-    stack for display in IPython. Parameters: see annotate.
+    """Annotates a 3D image and returns a scrollable stack for display in
+    IPython.
+    
+    Parameters
+    ----------
+    centroids : DataFrame including columns x and y
+    image : image array (or string path to image file)
+    circle_size : Deprecated.
+        This will be removed in a future version of trackpy.
+        Use `plot_style={'markersize': ...}` instead.
+    color : single matplotlib color or a list of multiple colors
+        default None
+    invert : If you give a filepath as the image, specify whether to invert
+        black and white. Default True.
+    ax : matplotlib axes object, defaults to current axes
+    split_category : string, parameter to use to split the data into sections
+        default None
+    split_thresh : single value or list of ints or floats to split
+        particles into sections for plotting in multiple colors.
+        List items should be ordered by increasing value.
+        default None
+    imshow_style : dictionary of keyword arguments passed through to
+        the `Axes.imshow(...)` command the displays the image
+    plot_style : dictionary of keyword arguments passed through to
+        the `Axes.plot(...)` command that marks the features
+
+    Returns
+    -------
+    pims.Frame object containing a three-dimensional RGBA image
+
+    See Also
+    --------
+    annotate : annotation of 2D images
     """
     if plots_to_frame is None:
         raise ImportError('annotate3d requires pims 0.3 or later, please '
@@ -609,7 +699,10 @@ def plot_density_profile(f, binsize, blocks=None, mpp=None, fps=None,
         if true, the histogram is normalized
     t_column : string, default 'frame'
     pos_column : string, default 'z'
-
+    
+    Returns
+    -------
+    Axes object
     """
     import matplotlib as mpl
     lastframe = f[t_column].max()

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -14,7 +14,7 @@ from numpy.testing import (assert_almost_equal, assert_allclose,
                            assert_array_less)
 from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
-                                 assert_produces_warning, assert_equal)
+                                 assert_produces_warning)
 
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
@@ -70,7 +70,7 @@ class OldMinmass(unittest.TestCase):
         new_minmass = tp.minmass_version_change(im, old_minmass,
                                                 smoothing_size=self.tp_diameter)
         f = tp.locate(im, self.tp_diameter, minmass=new_minmass)
-        assert_equal(len(f), self.N)
+        assert len(f) == self.N
 
     def test_oldmass_12bit(self):
         old_minmass = 2800000
@@ -80,7 +80,7 @@ class OldMinmass(unittest.TestCase):
         new_minmass = tp.minmass_version_change(im, old_minmass,
                                                 smoothing_size=self.tp_diameter)
         f = tp.locate(im, self.tp_diameter, minmass=new_minmass)
-        assert_equal(len(f), self.N)
+        assert len(f) == self.N
 
     def test_oldmass_16bit(self):
         old_minmass = 2800000
@@ -90,7 +90,7 @@ class OldMinmass(unittest.TestCase):
         new_minmass = tp.minmass_version_change(im, old_minmass,
                                                 smoothing_size=self.tp_diameter)
         f = tp.locate(im, self.tp_diameter, minmass=new_minmass)
-        assert_equal(len(f), self.N)
+        assert len(f) == self.N
 
     def test_oldmass_float(self):
         old_minmass = 5500
@@ -101,7 +101,7 @@ class OldMinmass(unittest.TestCase):
         new_minmass = tp.minmass_version_change(im, old_minmass,
                                                 smoothing_size=self.tp_diameter)
         f = tp.locate(im, self.tp_diameter, minmass=new_minmass)
-        assert_equal(len(f), self.N)
+        assert len(f) == self.N
         
     def test_oldmass_invert(self):
         old_minmass = 2800000
@@ -112,7 +112,7 @@ class OldMinmass(unittest.TestCase):
         new_minmass = tp.minmass_version_change(im, old_minmass, invert=True,
                                                 smoothing_size=self.tp_diameter)
         f = tp.locate(im, self.tp_diameter, minmass=new_minmass, invert=True)
-        assert_equal(len(f), self.N)
+        assert len(f) == self.N
 
 
 class CommonFeatureIdentificationTests(object):


### PR DESCRIPTION
`tp.minmass_version_change` now converts old minmass to new minmass values. It actually repeats the bandpass filter or else I couldn't get it to work. There are also some tests with it.