### PR TITLE
FIX Check for right shape in locate

### DIFF
--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -14,7 +14,7 @@ from numpy.testing import (assert_almost_equal, assert_allclose,
                            assert_array_less)
 from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
-                                 assert_produces_warning, assertRaises)
+                                 assert_produces_warning)
 
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
@@ -105,24 +105,24 @@ class CommonFeatureIdentificationTests(object):
 
         # RGB-like
         image = np.random.randint(0, 100, (21, 23, 3)).astype(np.uint8)
-        with assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             tp.locate(image, 5)
 
         # RGBA-like
         image = np.random.randint(0, 100, (21, 23, 4)).astype(np.uint8)
-        with assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             tp.locate(image, 5)
 
         # multichannel-like
         image = np.random.randint(0, 100, (2, 21, 23)).astype(np.uint8)
-        with assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             tp.locate(image, 5)
 
     def test_exception_too_small(self):
         self.check_skip()
 
         image = np.random.randint(0, 100, (10, 50)).astype(np.uint8)
-        with assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             tp.locate(image, 11)
 
     def test_flat_peak(self):

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -14,7 +14,7 @@ from numpy.testing import (assert_almost_equal, assert_allclose,
                            assert_array_less)
 from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
-                                 assert_produces_warning)
+                                 assert_produces_warning, assertRaises)
 
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
@@ -100,18 +100,30 @@ class CommonFeatureIdentificationTests(object):
             f = tp.locate(black_image, 5, minmass=200,
                           engine=self.engine, preprocess=False)
 
-    def test_warn_color_image(self):
+    def test_exception_color_image(self):
         self.check_skip()
 
         # RGB-like
         image = np.random.randint(0, 100, (21, 23, 3)).astype(np.uint8)
-        with assert_produces_warning(UserWarning):
+        with assertRaises(ValueError):
             tp.locate(image, 5)
 
         # RGBA-like
         image = np.random.randint(0, 100, (21, 23, 4)).astype(np.uint8)
-        with assert_produces_warning(UserWarning):
+        with assertRaises(ValueError):
             tp.locate(image, 5)
+
+        # multichannel-like
+        image = np.random.randint(0, 100, (2, 21, 23)).astype(np.uint8)
+        with assertRaises(ValueError):
+            tp.locate(image, 5)
+
+    def test_exception_too_small(self):
+        self.check_skip()
+
+        image = np.random.randint(0, 100, (10, 50)).astype(np.uint8)
+        with assertRaises(ValueError):
+            tp.locate(image, 11)
 
     def test_flat_peak(self):
         # This tests the part of locate_maxima that eliminates multiple


### PR DESCRIPTION
This is an API change I would like to propose: instead of producing a warning message, locate will check at the start if the margins are larger than (half of the) image shape. If that is the case, no features can be found and an exception is raised.

I think it is good to have an exception instead of a warning, because in many cases users try to input RGB files (y, x, 3-4) or multichannel files (2-4, y, x). Then the file will be interpreted as 3D and it will take a long time to do the locate, while there are no features returned at all. I cannot think of any cases where the user would decide to ignore this situation. So an exception seems to be more in place.

The proposed changes are:
- shift the margin calculation to the front of locate
- check whether the margins are smaller then half the image shape
- the error message depends on whether the image looks suspiciously like RGB/RGBA/multichannel