### PR TITLE
FIX Copy the features when trying to link a view

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -8,6 +8,7 @@ from copy import copy
 import itertools
 import functools
 from collections import deque
+from distutils.version import StrictVersion
 
 import numpy as np
 from scipy.spatial import cKDTree
@@ -547,7 +548,10 @@ def link_df(features, search_range, memory=0,
     if hash_size is None:
         MARGIN = 1  # avoid OutOfHashException
         hash_size = features[pos_columns].max() + MARGIN
-    if features.is_copy is not None and not copy_features:
+    # Check if DataFrame is writeable.
+    # I don't know how to do this for pandas < 0.16.
+    if (StrictVersion(pd.__version__) >= StrictVersion('0.16.0') and
+        features.is_copy is not None and not copy_features):
         warn('The features DataFrame is a view, so it is not writeable. '
              'The results will be output to a copy. Use copy_features='
              'True to prevent this warning message.')

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import zip, range
 import logging
+from warnings import warn
 from copy import copy
 import itertools
 import functools
@@ -546,6 +547,10 @@ def link_df(features, search_range, memory=0,
     if hash_size is None:
         MARGIN = 1  # avoid OutOfHashException
         hash_size = features[pos_columns].max() + MARGIN
+    if features.is_copy is not None and not copy_features:
+        warn('The features DataFrame is a view, so it is not writeable. '
+             'The results will be outputted to a copy.')
+        copy_features = True
 
     # Group the DataFrame by time steps and make a 'level' out of each
     # one, using the index to keep track of Points.

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -549,7 +549,8 @@ def link_df(features, search_range, memory=0,
         hash_size = features[pos_columns].max() + MARGIN
     if features.is_copy is not None and not copy_features:
         warn('The features DataFrame is a view, so it is not writeable. '
-             'The results will be outputted to a copy.')
+             'The results will be output to a copy. Use copy_features='
+             'True to prevent this warning message.')
         copy_features = True
 
     # Group the DataFrame by time steps and make a 'level' out of each


### PR DESCRIPTION
This solves #280: performance was greatly degraded when trying to link a filtered dataframe.