### PR TITLE
BLD: Drop numpy 1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.7.1 scipy=0.12.0 matplotlib=1.3 pandas=0.12.0 scikit-image=0.9 pyyaml pytables pyfftw"
+      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pandas=0.12.0 scikit-image=0.9 pyyaml pytables pyfftw"
     - python: "2.7"
-      env: DEPS="numpy=1.8.0 scipy=0.13.3 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables pyfftw"
+      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables pyfftw"
     # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
       env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -551,7 +551,7 @@ def link_df(features, search_range, memory=0,
     # Check if DataFrame is writeable.
     # I don't know how to do this for pandas < 0.16.
     if (StrictVersion(pd.__version__) >= StrictVersion('0.16.0') and
-        features.is_copy is not None and not copy_features):
+            features.is_copy is not None and not copy_features):
         warn('The features DataFrame is a view, so it is not writeable. '
              'The results will be output to a copy. Use copy_features='
              'True to prevent this warning message.')


### PR DESCRIPTION
This changes the "legacy" Travis build environments so that they work with the [new tifffile 0.7.0](
https://pypi.python.org/pypi/tifffile), which is a dependency of pims. The oldest tested version of numpy is now 1.8.2 (released in August 2014). For users with an older version of tifffile, trackpy should still be compatible with numpy 1.7.1 and 1.8.0 for now.

Additionally, this addresses @tacaswell 's whitespace issue in #281 (sorry for my premature merge there!).