### PR TITLE
BUG: Fix version check error for Pandas release candidates.

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -8,13 +8,13 @@ from copy import copy
 import itertools
 import functools
 from collections import deque
-from distutils.version import StrictVersion
 
 import numpy as np
 from scipy.spatial import cKDTree
 import pandas as pd
 
 from .try_numba import try_numba_autojit, NUMBA_AVAILABLE
+from .utils import is_pandas_recent
 
 logger = logging.getLogger(__name__)
 
@@ -548,10 +548,11 @@ def link_df(features, search_range, memory=0,
     if hash_size is None:
         MARGIN = 1  # avoid OutOfHashException
         hash_size = features[pos_columns].max() + MARGIN
+
     # Check if DataFrame is writeable.
     # I don't know how to do this for pandas < 0.16.
-    if (StrictVersion(pd.__version__) >= StrictVersion('0.16.0') and
-            features.is_copy is not None and not copy_features):
+    if (is_pandas_recent and features.is_copy is not None and
+            not copy_features):
         warn('The features DataFrame is a view, so it is not writeable. '
              'The results will be output to a copy. Use copy_features='
              'True to prevent this warning message.')

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 from copy import deepcopy
-from distutils.version import StrictVersion
 
 import numpy as np
 import pandas as pd
@@ -18,6 +17,7 @@ from pandas.util.testing import (assert_series_equal, assert_frame_equal,
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking import PointND, link, Hash_table
+from trackpy.utils import is_pandas_recent
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()
@@ -299,7 +299,7 @@ class CommonTrackingTests(object):
 
         # When DataFrame is actually a view, link_df should produce a warning
         # and then copy the DataFrame. This only happens for pandas >= 0.16.
-        if StrictVersion(pd.__version__) >= StrictVersion('0.16.0'):
+        if is_pandas_recent:
             with assert_produces_warning(UserWarning):
                 actual = self.link_df(f[f['frame'] > 0], 5)
             assert 'particle' not in f.columns

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -8,6 +8,7 @@ import re
 import sys
 import warnings
 from datetime import datetime, timedelta
+from distutils.version import StrictVersion
 
 import pandas as pd
 import numpy as np
@@ -15,6 +16,14 @@ from scipy import stats
 import yaml
 
 import trackpy
+
+# Set is_pandas_recent for use elsewhere.
+# Pandas >= 0.16.0 lets us check if a DataFrame is a view.
+try:
+    is_pandas_recent = (StrictVersion(pd.__version__) >=
+                        StrictVersion('0.16.0'))
+except ValueError:  # Probably a release candidate
+    is_pandas_recent = True
 
 
 def fit_powerlaw(data, plot=True, **kwargs):


### PR DESCRIPTION
Discovered while investigating #282. Apprently `StrictVersion` is… strict.