### PR TITLE
Fix one breaking py35 test; add py35 build to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.4"
       env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
+    - python: "3.5"
+      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml pytables"
 
 install:
   # See:

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -66,20 +66,20 @@ class TestPlots(unittest.TestCase):
         # Too many colors
         bad_call = lambda: plots.annotate(
             f, frame, split_category='mass', split_thresh=15, color=['r', 'g', 'b'])
-        self.assertRaises(bad_call)
+        self.assertRaises(ValueError, bad_call)
 
         # Not enough colors
         bad_call = lambda: plots.annotate(
             f, frame, split_category='mass', split_thresh=15, color=['r'])
-        self.assertRaises(bad_call)
+        self.assertRaises(ValueError, bad_call)
         bad_call = lambda: plots.annotate(
             f, frame, split_category='mass', split_thresh=15, color='r')
-        self.assertRaises(bad_call)
+        self.assertRaises(ValueError, bad_call)
 
         # Nonexistent column name for split_category
         bad_call = lambda: plots.annotate(
             f, frame, split_category='not a column', split_thresh=15, color='r')
-        self.assertRaises(bad_call)
+        self.assertRaises(ValueError, bad_call)
 
     def test_fit_powerlaw(self):
         # smoke test


### PR DESCRIPTION
Closes #288 (thanks, @sciunto) and includes adds a Python 3.5 build to Travis. For now, numba is not included since, as noted in #289, it is not yet available from official conda.