### PR TITLE
FIX Gaps in frames are not ignored anymore

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -801,7 +801,7 @@ def _gen_levels_df(df, pos_columns, t_column, diagnostics=False):
     """
     grouped = iter(df.groupby(t_column))
     cur_frame, frame = next(grouped)
-    cur_frame += 1
+    cur_frame += 1.5  # set counter to 1.5 for issues with e.g. 1.000001
     yield _build_level(frame, pos_columns, t_column, diagnostics)
 
     for frame_no, frame in grouped:

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -209,16 +209,19 @@ class CommonTrackingTests(object):
         assert_frame_equal(actual, expected)
 
     def test_blank_frame_no_memory(self):
-        # Using link_df, the particle will be given a new ID after the gap.
-        # link_df_iter will assume that the iterable
-        # One 1D stepper
         N = 5
         f = DataFrame({'x': np.arange(N), 'y': np.ones(N),
                       'frame': [0, 1, 2, 4, 5]})
         expected = f.copy()
+
+        # Using link_df, the particle will be given a new ID after the gap.
         expected['particle'] = np.array([0, 0, 0, 1, 1], dtype=np.float64)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
+
+        # link_df_iter will (in this test suite) iterate over only the frames
+        # present in the dataframe, so the gap will be ignored.
+        expected['particle'] = 0.0
         actual = self.link_df_iter(f, 5, hash_size=(10, 10))
         assert_frame_equal(actual, expected)
 

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -209,19 +209,19 @@ class CommonTrackingTests(object):
         assert_frame_equal(actual, expected)
 
     def test_blank_frame_no_memory(self):
+        # Using link_df, the particle will be given a new ID after the gap.
+        # link_df_iter will assume that the iterable
         # One 1D stepper
         N = 5
         f = DataFrame({'x': np.arange(N), 'y': np.ones(N),
                       'frame': [0, 1, 2, 4, 5]})
         expected = f.copy()
-        expected['particle'] = np.zeros(N)
+        expected['particle'] = np.array([0, 0, 0, 1, 1], dtype=np.float64)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual = self.link_df_iter(f, 5, hash_size=(10, 10))
         assert_frame_equal(actual, expected)
-        # This doesn't error, but we might wish it would
-        # give the particle a new ID after the gap. It just
-        # ignores the missing frame.
+
 
     def test_real_data_that_causes_duplicate_bug(self):
         filename = 'reproduce_duplicate_track_assignment.df'


### PR DESCRIPTION
Fixes #292 , but not yet for `link_df_iter`. There is an exception because I only changed the `levels` generator and in `link_df_iter`, this is zipped together with the original iterable, which is unchaged.

Do you agree on the approach?

Another approach would be `link_iter` checking on the framenumbers.