### PR TITLE
Replace pd.DataFrame.sort by pd.DataFrame.sort_values

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -603,7 +603,7 @@ def link_df(features, search_range, memory=0,
         features.index = orig_index
         # And don't bother to sort -- user must be doing something special.
     else:
-        features.sort(['particle', t_column], inplace=True)
+        features.sort_values(by=['particle', t_column], inplace=True)
         features.reset_index(drop=True, inplace=True)
     return features
 
@@ -743,7 +743,7 @@ def link_df_iter(features, search_range, memory=0,
             features.index = old_index
             # TODO: don't run index.copy() even when retain_index is false
         else:
-            features.sort('particle', inplace=True)
+            features.sort_values(by='particle', inplace=True)
             features.reset_index(drop=True, inplace=True)
 
         logger.info("Frame %d: %d trajectories present", frame_no, len(labels))

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -49,7 +49,7 @@ def msd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=['x', 'y']):
     results['msd'] = mpp**2*(disp**2).mean(level=0).sum(1) # <r^2>
     # Estimated statistically independent measurements = 2N/t
     if detail:
-        results['N'] = 2*disp.icol(0).count(level=0).div(Series(lagtimes))   
+        results['N'] = 2*disp.iloc[:, 0].count(level=0).div(Series(lagtimes))
     results['lagt'] = results.index.values/fps
     return results[:-1]
 

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -20,7 +20,7 @@ import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point,
                                 gen_nonoverlapping_locations)
-                                
+
 from scipy.spatial import cKDTree
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
@@ -39,8 +39,8 @@ def compare(shape, count, radius, noise_level, engine):
     pos = gen_nonoverlapping_locations(shape, count, draw_range, margin)
     image = draw_spots(shape, pos, draw_range, noise_level)
     f = tp.locate(image, diameter, engine=engine)
-    actual = f[cols].sort(cols)
-    expected = DataFrame(pos, columns=cols).sort(cols)
+    actual = f[cols].sort_values(by=cols)
+    expected = DataFrame(pos, columns=cols).sort_values(by=cols)
     return actual, expected
 
 
@@ -53,7 +53,7 @@ def sort_positions(actual, expected):
 class OldMinmass(unittest.TestCase):
     def check_skip(self):
         pass
-    
+
     def setUp(self):
         self.shape = (128, 128)
         self.pos = gen_nonoverlapping_locations(self.shape, 10, separation=20,
@@ -61,7 +61,7 @@ class OldMinmass(unittest.TestCase):
         self.N = len(self.pos)
         self.draw_diameter = 25
         self.tp_diameter = 15
-    
+
     def test_oldmass_8bit(self):
         old_minmass = 11000
         im = draw_spots(self.shape, self.pos, self.draw_diameter, bitdepth=8,
@@ -102,7 +102,7 @@ class OldMinmass(unittest.TestCase):
                                                 smoothing_size=self.tp_diameter)
         f = tp.locate(im, self.tp_diameter, minmass=new_minmass)
         assert len(f) == self.N
-        
+
     def test_oldmass_invert(self):
         old_minmass = 2800000
         im = draw_spots(self.shape, self.pos, self.draw_diameter, bitdepth=12,
@@ -469,15 +469,15 @@ class CommonFeatureIdentificationTests(object):
         draw_point(image, pos3, 80)
         actual = tp.locate(image, 5, 1, topn=2, preprocess=False,
                            engine=self.engine)[cols]
-        actual = actual.sort(['x', 'y'])  # sort for reliable comparison
-        expected = DataFrame([pos1, pos2], columns=cols).sort(['x', 'y'])
+        actual = actual.sort_values(by=['x', 'y'])  # sort for reliable comparison
+        expected = DataFrame([pos1, pos2], columns=cols).sort_values(by=['x', 'y'])
         assert_allclose(actual, expected, atol=PRECISION)
 
         # top 1
         actual = tp.locate(image, 5, 1, topn=1, preprocess=False,
                            engine=self.engine)[cols]
-        actual = actual.sort(['x', 'y'])  # sort for reliable comparison
-        expected = DataFrame([pos1], columns=cols).sort(['x', 'y'])
+        actual = actual.sort_values(by=['x', 'y'])  # sort for reliable comparison
+        expected = DataFrame([pos1], columns=cols).sort_values(by=['x', 'y'])
         assert_allclose(actual, expected, atol=PRECISION)
 
     def test_minmass_maxsize(self):
@@ -502,22 +502,22 @@ class CommonFeatureIdentificationTests(object):
         # filter on mass
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
                            minmass=6500)[cols]
-        actual = actual.sort(cols)
-        expected = DataFrame([pos2, pos4], columns=cols).sort(cols)
+        actual = actual.sort_values(by=cols)
+        expected = DataFrame([pos2, pos4], columns=cols).sort_values(by=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         # filter on size
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
                            maxsize=3.0)[cols]
-        actual = actual.sort(cols)
-        expected = DataFrame([pos1, pos3], columns=cols).sort(cols)
+        actual = actual.sort_values(by=cols)
+        expected = DataFrame([pos1, pos3], columns=cols).sort_values(by=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         # filter on both mass and size
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
                            minmass=600, maxsize=4.0)[cols]
-        actual = actual.sort(cols)
-        expected = DataFrame([pos1, pos4], columns=cols).sort(cols)
+        actual = actual.sort_values(by=cols)
+        expected = DataFrame([pos1, pos4], columns=cols).sort_values(by=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
     def test_mass(self):
@@ -605,7 +605,7 @@ class CommonFeatureIdentificationTests(object):
         # ~0.02 precision, as long as the mask is large enough to cover
         # the whole object.
         self.check_skip()
-        L = 501 
+        L = 501
         dims = (L + 2, L)  # avoid square images in tests
         pos = [50, 55]
         cols = ['y', 'x']
@@ -749,7 +749,7 @@ class CommonFeatureIdentificationTests(object):
         # small bright spot surrounded by a dark annulus.
         draw_feature(image, pos, 6, max_value=-100)
         draw_feature(image, pos, 4, max_value=200)
-        
+
         actual = tp.locate(image, 9, 1, preprocess=False, engine=self.engine)
         assert np.allclose(actual[['x', 'y']], expected[['x', 'y']])
         assert np.isnan(np.asscalar(actual.ep))

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -33,7 +33,7 @@ np.random.seed(0)
 random_x = np.random.randn(5).cumsum()
 random_x -= random_x.min()  # All x > 0
 max_disp = np.diff(random_x).max()
-random_walk_legacy = lambda: [[PointND(t, (x, 5))] 
+random_walk_legacy = lambda: [[PointND(t, (x, 5))]
                               for t, x in enumerate(random_x)]
 
 
@@ -101,16 +101,16 @@ class CommonTrackingTests(object):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(f.sort_values(by='frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(f.sort_values(by='frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -125,17 +125,17 @@ class CommonTrackingTests(object):
     def test_two_isolated_steppers_one_gapped(self):
         N = 5
         Y = 25
-        # Begin second feature one frame later than the first, 
+        # Begin second feature one frame later than the first,
         # so the particle labeling (0, 1) is established and not arbitrary.
-        a = DataFrame({'x': np.arange(N), 'y': np.ones(N), 
+        a = DataFrame({'x': np.arange(N), 'y': np.ones(N),
                       'frame': np.arange(N)})
         a = a.drop(3).reset_index(drop=True)
-        b = DataFrame({'x': np.arange(1, N), 'y': Y + np.ones(N - 1), 
+        b = DataFrame({'x': np.arange(1, N), 'y': Y + np.ones(N - 1),
                       'frame': np.arange(1, N)})
         f = pd.concat([a, b])
         expected = f.copy()
         expected['particle'] = np.concatenate([np.array([0, 0, 0, 2]), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         expected.reset_index(drop=True, inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
@@ -145,9 +145,9 @@ class CommonTrackingTests(object):
         # not knowable from the first frame alone.
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(f.sort_values(by='frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(f.sort_values(by='frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -170,7 +170,7 @@ class CommonTrackingTests(object):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(2*M, Y + 2*M))
@@ -181,15 +181,15 @@ class CommonTrackingTests(object):
         initial_positions = [(100, 100), (200, 100), (100, 200), (200, 200)]
         import itertools
         c = itertools.count()
-        def walk(x, y): 
+        def walk(x, y):
             i = next(c)
-            return DataFrame({'x': x + random_walk(N - i), 
+            return DataFrame({'x': x + random_walk(N - i),
                               'y': y + random_walk(N - i),
                              'frame': np.arange(i, N)})
         f = pd.concat([walk(*pos) for pos in initial_positions])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([i*np.ones(N - i) for i in range(len(initial_positions))])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(200 + M, 200 + M))
@@ -199,7 +199,7 @@ class CommonTrackingTests(object):
         # One 1D stepper
         N = 5
         FIRST_FRAME = 3
-        f = DataFrame({'x': np.arange(N), 'y': np.ones(N), 
+        f = DataFrame({'x': np.arange(N), 'y': np.ones(N),
                       'frame': FIRST_FRAME + np.arange(N)})
         expected = f.copy()
         expected['particle'] = np.zeros(N)
@@ -253,7 +253,7 @@ class CommonTrackingTests(object):
             assert len(t2) == 1
             assert len(t1[0].points) == len(unit_steps())
             assert len(t2[0].points) == len(random_walk_legacy())
-    
+
     def test_easy_tracking(self):
         level_count = 5
         p_count = 16
@@ -268,14 +268,14 @@ class CommonTrackingTests(object):
         hash_generator = lambda: Hash_table((level_count + 1,
                                             p_count * 2 + 1), .5)
         tracks = self.link(levels, 1.5, hash_generator)
-    
+
         assert len(tracks) == p_count
-    
+
         for t in tracks:
             x, y = zip(*[p.pos for p in t])
             dx = np.diff(x)
             dy = np.diff(y)
-    
+
             assert np.sum(dx) == level_count - 1
             assert np.sum(dy) == 0
 
@@ -339,7 +339,7 @@ class CommonTrackingTests(object):
         features = args.pop(0)
         res = pd.concat(tp.link_df_iter(
             (df for fr, df in features.groupby('frame')), *args, **kwargs))
-        return res.sort(['particle', 'frame']).reset_index(drop=True)
+        return res.sort_values(by=['particle', 'frame']).reset_index(drop=True)
 
 
 class TestOnce(unittest.TestCase):
@@ -381,16 +381,16 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(f.sort_values(by='frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(f.sort_values(by='frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -424,7 +424,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.array([0, 0, 0, 2]), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         expected.reset_index(drop=True, inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
@@ -432,9 +432,9 @@ class SubnetNeededTests(CommonTrackingTests):
         assert_frame_equal(actual_iter, expected)
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(f.sort_values(by='frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(f.sort_values(by='frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -461,7 +461,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual = self.link_df_iter(f, 5, hash_size=(2*M, 2*M + Y))
@@ -481,7 +481,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([walk(*pos) for pos in initial_positions])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([i*np.ones(N - i) for i in range(len(initial_positions))])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual = self.link_df_iter(f, 5, hash_size=(2*M, 2*M))
@@ -559,7 +559,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.array([0, 0, 0, 0]), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        expected.sort_values(by=['particle', 'frame'], inplace=True)
         expected.reset_index(drop=True, inplace=True)
         actual = self.link_df(f, 5, memory=1)
         assert_frame_equal(actual, expected)
@@ -571,11 +571,11 @@ class SubnetNeededTests(CommonTrackingTests):
             assert 'diag_remembered' in self.diag.columns
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5, memory=1)
+        actual = self.link_df(f.sort_values(by='frame'), 5, memory=1)
         assert_frame_equal(actual, expected)
         if self.do_diagnostics:
             assert 'diag_remembered' in self.diag.columns
-        actual_iter = self.link_df_iter(f.sort('frame'), 5,
+        actual_iter = self.link_df_iter(f.sort_values(by='frame'), 5,
                                         memory=1, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
         if self.do_diagnostics:

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -12,7 +12,7 @@ from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_almost_equal)
 
-import trackpy as tp 
+import trackpy as tp
 from trackpy.utils import suppress_plotting
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
@@ -23,7 +23,7 @@ def random_walk(N):
 
 def conformity(df):
     "Organize toy data to look like real data."
-    return df.set_index('frame', drop=False).sort(['frame', 'particle']). \
+    return df.set_index('frame', drop=False).sort_values(by=['frame', 'particle']). \
         astype('float64')
 
 class TestDrift(unittest.TestCase):
@@ -31,23 +31,23 @@ class TestDrift(unittest.TestCase):
     def setUp(self):
         N = 10
         Y = 1
-        a = DataFrame({'x': np.zeros(N), 'y': np.zeros(N), 
+        a = DataFrame({'x': np.zeros(N), 'y': np.zeros(N),
                       'frame': np.arange(N), 'particle': np.zeros(N)})
-        b = DataFrame({'x': np.zeros(N - 1), 'y': Y + np.zeros(N - 1), 
+        b = DataFrame({'x': np.zeros(N - 1), 'y': Y + np.zeros(N - 1),
                        'frame': np.arange(1, N), 'particle': np.ones(N - 1)})
         self.dead_still = conformity(pd.concat([a, b]))
 
         P = 1000 # particles
         A = 0.00001 # step amplitude
         np.random.seed(0)
-        particles = [DataFrame({'x': A*random_walk(N), 
-            'y': A*random_walk(N), 
+        particles = [DataFrame({'x': A*random_walk(N),
+            'y': A*random_walk(N),
             'frame': np.arange(N), 'particle': i}) for i in range(P)]
         self.many_walks = conformity(pd.concat(particles))
 
-        a = DataFrame({'x': np.arange(N), 'y': np.zeros(N), 
+        a = DataFrame({'x': np.arange(N), 'y': np.zeros(N),
                       'frame': np.arange(N), 'particle': np.zeros(N)})
-        b = DataFrame({'x': np.arange(1, N), 'y': Y + np.zeros(N - 1), 
+        b = DataFrame({'x': np.arange(1, N), 'y': Y + np.zeros(N - 1),
                        'frame': np.arange(1, N), 'particle': np.ones(N - 1)})
         self.steppers = conformity(pd.concat([a, b]))
 
@@ -78,7 +78,7 @@ class TestDrift(unittest.TestCase):
 
     def test_subtract_zero_drift(self):
         N = 10
-        drift = DataFrame(np.zeros((N - 1, 2)), 
+        drift = DataFrame(np.zeros((N - 1, 2)),
                           index=np.arange(1, N)).astype('float64')
         drift.columns = ['x', 'y']
         drift.index.name = 'frame'
@@ -91,9 +91,9 @@ class TestDrift(unittest.TestCase):
 
     def test_subtract_constant_drift(self):
         N = 10
-        # Add a constant drift here, and then use subtract_drift to 
+        # Add a constant drift here, and then use subtract_drift to
         # subtract it.
-        drift = DataFrame(np.outer(np.arange(N - 1), [1, 1]), 
+        drift = DataFrame(np.outer(np.arange(N - 1), [1, 1]),
                           index=np.arange(1, N))
         drift.columns = ['x', 'y']
         drift.index.name = 'frame'
@@ -155,7 +155,7 @@ class TestMSD(unittest.TestCase):
         assert_series_equal(np.round(actual), expected)
 
 class TestSpecial(unittest.TestCase):
-    
+
     def setUp(self):
         N = 10
         Y = 1


### PR DESCRIPTION
Replace pd.DataFrame.sort by pd.DataFrame.sort_values. Supress deprecated warning.

I also noticed a lot of 

```
/home/hadim/local/conda/envs/st/lib/python3.4/site-packages/PIL/Image.py:1130: ResourceWarning: unclosed file <_io.BufferedReader name='/home/hadim/Insync/Documents/phd/dev/contrib/python/trackpy/trackpy/tests/video/image_sequence/T76S3F00001.png'>
```

Any idea how to fix that ?