### PR TITLE
ENH Annotate3d works with mpl notebook backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pandas=0.12.0 scikit-image=0.9 pyyaml pytables pyfftw"
+      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow<3 pandas=0.12.0 scikit-image=0.9 pyyaml pytables pyfftw"
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables pyfftw"
+      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pillow<3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables pyfftw"
     # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
-      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
+      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pillow<3 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.4"
-      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
+      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pillow<3 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.5"
-      env: DEPS="numpy scipy matplotlib pandas=0.17 scikit-image pyyaml pytables"
+      env: DEPS="numpy scipy matplotlib pillow<3 pandas=0.17 scikit-image pyyaml pytables"
 
 install:
   # See:

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -563,32 +563,31 @@ def annotate3d(centroids, image, **kwargs):
     else:
         kwargs['imshow_style'] = imshow_style
 
-    # Suppress warning when >20 figures are opened
     max_open_warning = mpl.rcParams['figure.max_open_warning']
-    mpl.rc('figure', max_open_warning=0)
-
-    # Turn off interactive mode
-    if plt.isinteractive():
+    was_interactive = plt.isinteractive()
+    try:
+        # Suppress warning when many figures are opened
+        mpl.rc('figure', max_open_warning=0)
+        # Turn off interactive mode (else the closed plots leave emtpy space)
         plt.ioff()
-        was_interactive = True
-    else:
-        was_interactive = False
 
-    figures = []
-    for i, imageZ in enumerate(normalized):
-        fig = plt.figure()
-        kwargs['ax'] = fig.gca()
-        centroidsZ = centroids[(centroids['z'] > i - 0.5) &
-                               (centroids['z'] < i + 0.5)]
-        annotate(centroidsZ, imageZ, **kwargs)
-        figures.append(fig)
+        figures = [None] * len(normalized)
+        for i, imageZ in enumerate(normalized):
+            fig = plt.figure()
+            kwargs['ax'] = fig.gca()
+            centroidsZ = centroids[(centroids['z'] > i - 0.5) &
+                                   (centroids['z'] < i + 0.5)]
+            annotate(centroidsZ, imageZ, **kwargs)
+            figures[i] = fig
 
-    result = plots_to_frame(figures, width=512, close_fig=True,
-                            bbox_inches='tight')
+        result = plots_to_frame(figures, width=512, close_fig=True,
+                                bbox_inches='tight')
+    finally:
+        # put matplotlib back in original state
+        if was_interactive:
+            plt.ion()
+        mpl.rc('figure', max_open_warning=max_open_warning)
 
-    mpl.rc('figure', max_open_warning=max_open_warning)
-    if was_interactive:
-        plt.ion()
     return result
 
 

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -566,6 +566,14 @@ def annotate3d(centroids, image, **kwargs):
     # Suppress warning when >20 figures are opened
     max_open_warning = mpl.rcParams['figure.max_open_warning']
     mpl.rc('figure', max_open_warning=0)
+
+    # Turn off interactive mode
+    if plt.isinteractive():
+        plt.ioff()
+        was_interactive = True
+    else:
+        was_interactive = False
+
     figures = []
     for i, imageZ in enumerate(normalized):
         fig = plt.figure()
@@ -575,11 +583,12 @@ def annotate3d(centroids, image, **kwargs):
         annotate(centroidsZ, imageZ, **kwargs)
         figures.append(fig)
 
-    result = plots_to_frame(figures, width=512, bbox_inches='tight')
+    result = plots_to_frame(figures, width=512, close_fig=True,
+                            bbox_inches='tight')
 
-    for fig in figures:
-        plt.close(fig)
     mpl.rc('figure', max_open_warning=max_open_warning)
+    if was_interactive:
+        plt.ion()
     return result
 
 

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -81,6 +81,25 @@ class TestPlots(unittest.TestCase):
             f, frame, split_category='not a column', split_thresh=15, color='r')
         self.assertRaises(ValueError, bad_call)
 
+        # 3D image
+        bad_call = lambda: plots.annotate(f, frame[np.newaxis, :, :])
+        self.assertRaises(ValueError, bad_call)
+
+    def test_annotate3d(self):
+        suppress_plotting()
+        f = DataFrame({'x': [0, 1], 'y': [0, 1], 'z': [0, 1], 'frame': [0, 0],
+                      'mass': [10, 20]})
+        frame = np.random.randint(0, 255, (5, 5, 5))
+
+        plots.annotate3d(f, frame)
+        plots.annotate3d(f, frame, color='r')
+
+        # 2D image
+        bad_call = lambda: plots.annotate3d(f, frame[0])
+        self.assertRaises(ValueError, bad_call)
+
+        # Rest of the functionality is covered by annotate tests
+
     def test_fit_powerlaw(self):
         # smoke test
         suppress_plotting()


### PR DESCRIPTION
This makes annotate3d work with the `%matplotlib notebook` backend. Before, you got a lot of whitespace above the real (scrollable) plot.