### PR TITLE
BUG: characterize=False

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -642,8 +642,9 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
         return DataFrame(columns=columns)
 
     # Refine their locations and characterize mass, size, etc.
-    refined_coords = refine(raw_image, image, radius, coords, separation,
-                            max_iterations, engine, characterize)
+    refined_coords = refine(raw_image, image, radius, coords,
+                            separation=separation, max_iterations=max_iterations,
+                            engine=engine, characterize=characterize)
     # mass and signal values has to be corrected due to the rescaling
     # raw_mass was obtained from raw image; size and ecc are scale-independent
     refined_coords[:, MASS_COLUMN_INDEX] *= 1. / scale_factor

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -428,6 +428,15 @@ class CommonFeatureIdentificationTests(object):
         expected = DataFrame(np.asarray(pos).reshape(1, -1), columns=cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
+    def test_nocharacterize(self):
+        pos = gen_nonoverlapping_locations((200, 300), 9, 5)
+        image = draw_spots((200, 300), pos, 5)
+        f_c = tp.locate(image, 5, engine=self.engine, characterize=True)
+        f_nc = tp.locate(image, 5, engine=self.engine, characterize=False)
+
+        assert len(f_nc.columns) == 3
+        assert_allclose(f_c.values[:, :3], f_nc.values)
+
     def test_multiple_simple_sparse(self):
         self.check_skip()
         actual, expected = compare((200, 300), 4, 2, noise_level=0,


### PR DESCRIPTION
When `locate()` called `refine()`, it assumed a certain order of keyword args. At some point `refine()` was changed. The result is that the value of `characterize` was not getting passed.

This PR adds a failing test, then fixes the bug.

This is arguably a fix that should be included in v0.3.