### PR TITLE
Fix pandas017 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "3.4"
       env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.5"
-      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.17 scikit-image=0.11 pyyaml pytables"
+      env: DEPS="numpy scipy matplotlib pandas=0.17 scikit-image pyyaml pytables"
 
 install:
   # See:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "3.4"
       env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.5"
-      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.16 scikit-image=0.11 pyyaml pytables"
+      env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pandas=0.17 scikit-image=0.11 pyyaml pytables"
 
 install:
   # See:

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -14,7 +14,7 @@ from scipy.spatial import cKDTree
 import pandas as pd
 
 from .try_numba import try_numba_autojit, NUMBA_AVAILABLE
-from .utils import is_pandas_recent
+from .utils import is_pandas_since_016, pandas_sort
 
 logger = logging.getLogger(__name__)
 
@@ -551,7 +551,7 @@ def link_df(features, search_range, memory=0,
 
     # Check if DataFrame is writeable.
     # I don't know how to do this for pandas < 0.16.
-    if (is_pandas_recent and features.is_copy is not None and
+    if (is_pandas_since_016 and features.is_copy is not None and
             not copy_features):
         warn('The features DataFrame is a view, so it is not writeable. '
              'The results will be output to a copy. Use copy_features='
@@ -603,7 +603,7 @@ def link_df(features, search_range, memory=0,
         features.index = orig_index
         # And don't bother to sort -- user must be doing something special.
     else:
-        features.sort(['particle', t_column], inplace=True)
+        pandas_sort(features, ['particle', t_column], inplace=True)
         features.reset_index(drop=True, inplace=True)
     return features
 
@@ -743,7 +743,7 @@ def link_df_iter(features, search_range, memory=0,
             features.index = old_index
             # TODO: don't run index.copy() even when retain_index is false
         else:
-            features.sort('particle', inplace=True)
+            pandas_sort(features, 'particle', inplace=True)
             features.reset_index(drop=True, inplace=True)
 
         logger.info("Frame %d: %d trajectories present", frame_no, len(labels))

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -49,7 +49,7 @@ def msd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=['x', 'y']):
     results['msd'] = mpp**2*(disp**2).mean(level=0).sum(1) # <r^2>
     # Estimated statistically independent measurements = 2N/t
     if detail:
-        results['N'] = 2*disp.icol(0).count(level=0).div(Series(lagtimes))   
+        results['N'] = 2*disp.iloc[:,0].count(level=0).div(Series(lagtimes))
     results['lagt'] = results.index.values/fps
     return results[:-1]
 

--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -21,8 +21,8 @@ def bandpass(image, lshort, llong, threshold=None, truncate=4):
     is the fastest way known to the authors of performing a bandpass in
     Python.
 
-    Parmeters
-    ---------
+    Parameters
+    ----------
     image : ndarray
     lshort : small-scale cutoff (noise)
     llong : large-scale cutoff
@@ -114,8 +114,8 @@ def legacy_bandpass(image, lshort, llong, threshold=None):
     In benchmarks using typical inputs, it was found to be slower than the
     ``bandpass`` function in this module.
 
-    Parmeters
-    ---------
+    Parameters
+    ----------
     image : ndarray
     lshort : small-scale cutoff (noise)
     llong : large-scale cutoff
@@ -172,8 +172,8 @@ def legacy_bandpass_fftw(image, lshort, llong, threshold=None):
     In benchmarks using typical inputs, it was found to be slower than the
     ``bandpass`` function in this module.
 
-    Parmeters
-    ---------
+    Parameters
+    ----------
     image : ndarray
     lshort : small-scale cutoff (noise)
     llong : large-scale cutoff

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 from copy import deepcopy
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -300,8 +301,11 @@ class CommonTrackingTests(object):
         # When DataFrame is actually a view, link_df should produce a warning
         # and then copy the DataFrame. This only happens for pandas >= 0.16.
         if is_pandas_recent:
-            with assert_produces_warning(UserWarning):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('ignore')
+                warnings.simplefilter('always', UserWarning)
                 actual = self.link_df(f[f['frame'] > 0], 5)
+                assert len(w) == 1
             assert 'particle' not in f.columns
 
         # Should copy

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -18,7 +18,7 @@ from pandas.util.testing import (assert_series_equal, assert_frame_equal,
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking import PointND, link, Hash_table
-from trackpy.utils import is_pandas_recent
+from trackpy.utils import is_pandas_since_016
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()
@@ -300,7 +300,7 @@ class CommonTrackingTests(object):
 
         # When DataFrame is actually a view, link_df should produce a warning
         # and then copy the DataFrame. This only happens for pandas >= 0.16.
-        if is_pandas_recent:
+        if is_pandas_since_016:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('ignore')
                 warnings.simplefilter('always', UserWarning)


### PR DESCRIPTION
Addresses #295 by testing on Pandas 0.17 and fixing the failure. It also eliminates the top sources of Pandas 0.17 FutureWarnings.  I see this as a band-aid for #299 and #282 also. PRs against this one (or following this one) are welcome to fix the rest of the FutureWarnings.