### PR TITLE
DOC: Stop separating params into 'Other Parameters'

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -463,16 +463,6 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
     topn : integer
         Return only the N brightest features above minmass.
         If None (default), return all features above minmass.
-
-    Returns
-    -------
-    DataFrame([x, y, mass, size, ecc, signal])
-        where mass means total integrated brightness of the blob,
-        size means the radius of gyration of its Gaussian-like profile,
-        and ecc is its eccentricity (0 is circular).
-
-    Other Parameters
-    ----------------
     preprocess : boolean
         Set to False to turn off bandpass preprocessing.
     max_iterations : integer
@@ -487,6 +477,13 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
     characterize : boolean
         Compute "extras": eccentricity, signal, ep. True by default.
     engine : {'auto', 'python', 'numba'}
+
+    Returns
+    -------
+    DataFrame([x, y, mass, size, ecc, signal])
+        where mass means total integrated brightness of the blob,
+        size means the radius of gyration of its Gaussian-like profile,
+        and ecc is its eccentricity (0 is circular).
 
     See Also
     --------
@@ -748,16 +745,6 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
     topn : integer
         Return only the N brightest features above minmass.
         If None (default), return all features above minmass.
-
-    Returns
-    -------
-    DataFrame([x, y, mass, size, ecc, signal])
-        where mass means total integrated brightness of the blob,
-        size means the radius of gyration of its Gaussian-like profile,
-        and ecc is its eccentricity (0 is circular).
-
-    Other Parameters
-    ----------------
     preprocess : boolean
         Set to False to turn off bandpass preprocessing.
     max_iterations : integer
@@ -780,6 +767,13 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
         If specified, information relevant to reproducing this batch is saved
         as a YAML file, a plain-text machine- and human-readable format.
         By default, this is None, and no file is saved.
+
+    Returns
+    -------
+    DataFrame([x, y, mass, size, ecc, signal])
+        where mass means total integrated brightness of the blob,
+        size means the radius of gyration of its Gaussian-like profile,
+        and ecc is its eccentricity (0 is circular).
 
     See Also
     --------

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -507,16 +507,6 @@ def link_df(features, search_range, memory=0,
         becomes <= adaptive_stop, give up and raise a SubnetOversizeException.
     adaptive_step : float, optional
         Reduce search_range by multiplying it by this factor.
-
-    Returns
-    -------
-    trajectories : DataFrame
-        This is the input features DataFrame, now with a new column labeling
-        each particle with an ID number. This is not a copy; the original
-        features DataFrame is modified.
-
-    Other Parameters
-    ----------------
     copy_features : boolean
         Leave the original features DataFrame intact (slower, uses more memory)
     diagnostics : boolean
@@ -539,6 +529,13 @@ def link_df(features, search_range, memory=0,
     retain_index : boolean
         By default, the index is reset to be sequential. To keep the original
         index, set to True. Default is fine unless you devise a special use.
+
+    Returns
+    -------
+    trajectories : DataFrame
+        This is the input features DataFrame, now with a new column labeling
+        each particle with an ID number. This is not a copy; the original
+        features DataFrame is modified.
     """
     # Assign defaults. (Do it here to avoid "mutable defaults" issue.)
     if pos_columns is None:
@@ -646,15 +643,6 @@ def link_df_iter(features, search_range, memory=0,
         becomes <= adaptive_stop, give up and raise a SubnetOversizeException.
     adaptive_step : float, optional
         Reduce search_range by multiplying it by this factor.
-
-    Returns
-    -------
-    trajectories : DataFrame
-        This is the input features DataFrame, now with a new column labeling
-        each particle with an ID number for each frame.
-
-    Other Parameters
-    ----------------
     diagnostics : boolean
         Collect details about how each particle was linked, and return as
         columns in the output DataFrame.
@@ -674,6 +662,12 @@ def link_df_iter(features, search_range, memory=0,
     retain_index : boolean
         By default, the index is reset to be sequential. To keep the original
         index, set to True. Default is fine unless you devise a special use.
+
+    Returns
+    -------
+    trajectories : DataFrame
+        This is the input features DataFrame, now with a new column labeling
+        each particle with an ID number for each frame.
     """
     # Assign defaults. (Do it here to avoid "mutable defaults" issue.)
     if pos_columns is None:
@@ -833,6 +827,13 @@ def link_iter(levels, search_range, memory=0,
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses numba if available
         'drop' causes particles in subnetworks to go unlinked
+    hash_size : sequence
+        For 'BTree' mode only. Define the shape of the search region.
+        (Higher-level wrappers of link infer this from the data.)
+    box_size : sequence
+        For 'BTree' mode only. Define the parition size to optimize
+        performance. If None (default), the search_range is used, which is
+        a reasonable guess for best performance.
     predictor : function, optional
         Improve performance by guessing where a particle will be in the
         next frame.
@@ -843,27 +844,17 @@ def link_iter(levels, search_range, memory=0,
         becomes <= adaptive_stop, give up and raise a SubnetOversizeException.
     adaptive_step : float, optional
         Reduce search_range by multiplying it by this factor.
-
-    Returns
-    -------
-    cur_level : iterable of Point objects
-        The labeled points at each level.
-
-    Other Parameters
-    ----------------
-    hash_size : sequence
-        For 'BTree' mode only. Define the shape of the search region.
-        (Higher-level wrappers of link infer this from the data.)
-    box_size : sequence
-        For 'BTree' mode only. Define the parition size to optimize
-        performance. If None (default), the search_range is used, which is
-        a reasonable guess for best performance.
     track_cls : class, optional
         for special uses, you can specify a custom class that holds
         each Track
     hash_generator : function, optional
         a function that returns a HashTable, included for legacy support.
         Specifying hash_size and box_size (above) fully defined a HashTable.
+
+    Returns
+    -------
+    cur_level : iterable of Point objects
+        The labeled points at each level.
     """
     linker = Linker(search_range, memory=memory, neighbor_strategy=neighbor_strategy,
                  link_strategy=link_strategy, hash_size=hash_size,

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -769,9 +769,6 @@ def plot_displacements(t, frame1, frame2, scale=1, ax=None, pos_columns=None,
         destination; if any other number arrows are rescaled
     pos_columns : list of strings, optional
         Dataframe column names for spatial coordinates. Default is ['x', 'y'].
-
-    Other Parameters
-    ----------------
     ax : matplotlib axes (optional)
 
     Any other keyword arguments will pass through to matplotlib's `annotate`.


### PR DESCRIPTION
This removes 'Other Parameters' from the five docstrings where it was being used and makes some corrections to the order, which should obviously match the function signature.

Closes #305