### PR TITLE
BLD: Add test env representing "clean Anaconda"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ install:
   # If you're reading this, good luck out there. I'm not sure what to tell you.
   - conda update --yes conda
   - conda config --add channels soft-matter
-  - if [ $BUILD_CONDA_PKG ]; then conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
+  # Set version and build package while we're still in the root env.
+  - if [ $BUILD_CONDA_PKG ]; then python setup.py build; conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
   - conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # for debugging...

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ before_install:
   - ./miniconda.sh -b -p /home/travis/mc
   - export PATH=/home/travis/mc/bin:$PATH
 
-script: nosetests --nologcapture -a '!slow'
+script: cd trackpy/tests; nosetests --nologcapture -a '!slow'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,27 @@ install:
   # If you're reading this, good luck out there. I'm not sure what to tell you.
   - conda update --yes conda
   - conda config --add channels soft-matter
+  - |
+        if [ ! $BUILD_CONDA_PKG ]; then
+            conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
+            source activate testenv
+            # for debugging...
+            echo $PATH
+            which python
+        fi
+  - if [ ! $BUILD_CONDA_PKG ]; then conda info; fi
+  - if [ ! $BUILD_CONDA_PKG ]; then conda list; fi
+  - if [ ! $BUILD_CONDA_PKG ]; then python setup.py install; fi
+  ### If we are building the conda package:
   # Make this a non-shallow repository, to satisfy conda-build.
   # Then set the version and build the package while we're still in the root env.
-  - if [ $BUILD_CONDA_PKG ]; then git fetch --unshallow; conda install --yes conda-build pip setuptools; python setup.py build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
-  - conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
-  - source activate testenv
-  # for debugging...
-  - echo $PATH
-  - which python
-  - conda info
-  - conda list
-  - if [ $BUILD_CONDA_PKG ]; then conda install --yes --use-local trackpy; conda list; else python setup.py install; fi
+  # The package recipe will run nosetests.
+  - |
+        if [ $BUILD_CONDA_PKG ]; then
+            git fetch --unshallow
+            conda install --yes conda-build pip setuptools
+            python setup.py build
+        fi
 
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh; fi
@@ -44,4 +54,10 @@ before_install:
   - ./miniconda.sh -b -p /home/travis/mc
   - export PATH=/home/travis/mc/bin:$PATH
 
-script: cd trackpy/tests; nosetests --nologcapture -a '!slow'
+script:
+  - |
+        if [ $BUILD_CONDA_PKG ]; then
+            conda build --python $TRAVIS_PYTHON_VERSION conda-recipe
+        else
+            cd trackpy/tests; nosetests --nologcapture -a '!slow'
+        fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ install:
   # If you're reading this, good luck out there. I'm not sure what to tell you.
   - conda update --yes conda
   - conda config --add channels soft-matter
-  # Set version and build package while we're still in the root env.
-  - if [ $BUILD_CONDA_PKG ]; then python setup.py build; conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
+  # Make this a non-shallow repository, to fool conda-build.
+  # Then build the package while we're still in the root env.
+  - if [ $BUILD_CONDA_PKG ]; then rm .git/shallow; conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
   - conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # for debugging...

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - python: "3.5"
       env: DEPS="numpy scipy matplotlib pillow<3 pandas scikit-image pyyaml pytables numba"
     - python: "3.5"
-      env: DEPS="conda-build" BUILD_CONDA_PKG=yes
+      env: BUILD_CONDA_PKG=yes
 
 install:
   # See:
@@ -26,6 +26,7 @@ install:
   # If you're reading this, good luck out there. I'm not sure what to tell you.
   - conda update --yes conda
   - conda config --add channels soft-matter
+  - if [ $BUILD_CONDA_PKG ]; then conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
   - conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # for debugging...
@@ -33,7 +34,7 @@ install:
   - which python
   - conda info
   - conda list
-  - if [ $BUILD_CONDA_PKG ]; then conda build conda-recipe; conda create -n pkgtest --use-local trackpy; source activate pkgtest; else python setup.py install; fi
+  - if [ $BUILD_CONDA_PKG ]; then conda build conda-recipe; conda install --yes --use-local trackpy; conda list; else python setup.py install; fi
 
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - conda config --add channels soft-matter
   # Make this a non-shallow repository, to satisfy conda-build.
   # Then set the version and build the package while we're still in the root env.
-  - if [ $BUILD_CONDA_PKG ]; then git fetch --unshallow; python setup.py build; conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
+  - if [ $BUILD_CONDA_PKG ]; then git fetch --unshallow; conda install --yes conda-build pip setuptools; python setup.py build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
   - conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # for debugging...

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - python: "3.5"
       env: DEPS="numpy scipy matplotlib pillow<3 pandas scikit-image pyyaml pytables numba"
     - python: "3.5"
-      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba pims"
+      env: DEPS="conda-build" BUILD_CONDA_PKG=yes
 
 install:
   # See:
@@ -33,7 +33,7 @@ install:
   - which python
   - conda info
   - conda list
-  - python setup.py install
+  - if [ $BUILD_CONDA_PKG ]; then conda build conda-recipe; conda create -n pkgtest --use-local trackpy; source activate pkgtest; else python setup.py install; fi
 
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - which python
   - conda info
   - conda list
-  - if [ $BUILD_CONDA_PKG ]; then conda build conda-recipe; conda install --yes --use-local trackpy; conda list; else python setup.py install; fi
+  - if [ $BUILD_CONDA_PKG ]; then conda install --yes --use-local trackpy; conda list; else python setup.py install; fi
 
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       env: DEPS="numpy=1.9 scipy=0.16 matplotlib=1.4 pillow<3 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.5"
       env: DEPS="numpy scipy matplotlib pillow<3 pandas scikit-image pyyaml pytables numba"
+    - python: "3.5"
+      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba pims"
 
 install:
   # See:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ install:
   # If you're reading this, good luck out there. I'm not sure what to tell you.
   - conda update --yes conda
   - conda config --add channels soft-matter
-  # Make this a non-shallow repository, to fool conda-build.
-  # Then build the package while we're still in the root env.
-  - if [ $BUILD_CONDA_PKG ]; then rm .git/shallow; conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
+  # Make this a non-shallow repository, to satisfy conda-build.
+  # Then set the version and build the package while we're still in the root env.
+  - if [ $BUILD_CONDA_PKG ]; then git fetch --unshallow; python setup.py build; conda install --yes conda-build; conda build --python $TRAVIS_PYTHON_VERSION conda-recipe; fi
   - conda create -n testenv --yes $DEPS pip nose setuptools python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # for debugging...

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,6 +39,10 @@ requirements:
 test:
   imports:
     - trackpy
+  requires:
+    - nose
+  commands:
+    - nosetests --nologcapture -a '!slow' -w $SRC_DIR/trackpy/tests
 
 about:
   home: http://trackpy.readthedocs.org


### PR DESCRIPTION
This is a _possible_ way to check that the most basic installation instructions will work — that someone can simply install Anaconda and run `conda -c soft-matter install trackpy`. See https://github.com/soft-matter/pims/pull/200 and https://github.com/soft-matter/trackpy/issues/301#issuecomment-156223916
