### PR TITLE
TST Be more picky about dtypes in motion.py

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -184,7 +184,10 @@ def subtract_drift(traj, drift=None):
 
     if drift is None:
         drift = compute_drift(traj)
-    return traj.set_index('frame', drop=False).sub(drift, fill_value=0)
+    traj.set_index('frame', inplace=True, drop=False)
+    for col in drift.columns:
+        traj[col] = traj[col].sub(drift[col], fill_value=0)
+    return traj
 
 
 def is_typical(msds, frame, lower=0.1, upper=0.9):

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -20,6 +20,7 @@ import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point,
                                 gen_nonoverlapping_locations)
+from trackpy.utils import pandas_sort
                                 
 from scipy.spatial import cKDTree
 
@@ -39,8 +40,8 @@ def compare(shape, count, radius, noise_level, engine):
     pos = gen_nonoverlapping_locations(shape, count, draw_range, margin)
     image = draw_spots(shape, pos, draw_range, noise_level)
     f = tp.locate(image, diameter, engine=engine)
-    actual = f[cols].sort(cols)
-    expected = DataFrame(pos, columns=cols).sort(cols)
+    actual = pandas_sort(f[cols], cols)
+    expected = pandas_sort(DataFrame(pos, columns=cols), cols)
     return actual, expected
 
 
@@ -478,15 +479,15 @@ class CommonFeatureIdentificationTests(object):
         draw_point(image, pos3, 80)
         actual = tp.locate(image, 5, 1, topn=2, preprocess=False,
                            engine=self.engine)[cols]
-        actual = actual.sort(['x', 'y'])  # sort for reliable comparison
-        expected = DataFrame([pos1, pos2], columns=cols).sort(['x', 'y'])
+        actual = pandas_sort(actual, ['x', 'y'])  # sort for reliable comparison
+        expected = pandas_sort(DataFrame([pos1, pos2], columns=cols), ['x', 'y'])
         assert_allclose(actual, expected, atol=PRECISION)
 
         # top 1
         actual = tp.locate(image, 5, 1, topn=1, preprocess=False,
                            engine=self.engine)[cols]
-        actual = actual.sort(['x', 'y'])  # sort for reliable comparison
-        expected = DataFrame([pos1], columns=cols).sort(['x', 'y'])
+        actual = pandas_sort(actual, ['x', 'y'])  # sort for reliable comparison
+        expected = pandas_sort(DataFrame([pos1], columns=cols), ['x', 'y'])
         assert_allclose(actual, expected, atol=PRECISION)
 
     def test_minmass_maxsize(self):
@@ -511,22 +512,22 @@ class CommonFeatureIdentificationTests(object):
         # filter on mass
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
                            minmass=6500)[cols]
-        actual = actual.sort(cols)
-        expected = DataFrame([pos2, pos4], columns=cols).sort(cols)
+        actual = pandas_sort(actual, cols)
+        expected = pandas_sort(DataFrame([pos2, pos4], columns=cols), cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         # filter on size
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
                            maxsize=3.0)[cols]
-        actual = actual.sort(cols)
-        expected = DataFrame([pos1, pos3], columns=cols).sort(cols)
+        actual = pandas_sort(actual, cols)
+        expected = pandas_sort(DataFrame([pos1, pos3], columns=cols), cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         # filter on both mass and size
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
                            minmass=600, maxsize=4.0)[cols]
-        actual = actual.sort(cols)
-        expected = DataFrame([pos1, pos4], columns=cols).sort(cols)
+        actual = pandas_sort(actual, cols)
+        expected = pandas_sort(DataFrame([pos1, pos4], columns=cols), cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
     def test_mass(self):

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -18,7 +18,7 @@ from pandas.util.testing import (assert_series_equal, assert_frame_equal,
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking import PointND, link, Hash_table
-from trackpy.utils import is_pandas_since_016
+from trackpy.utils import is_pandas_since_016, pandas_sort
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()
@@ -102,16 +102,16 @@ class CommonTrackingTests(object):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(pandas_sort(f, 'frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(pandas_sort(f, 'frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -136,7 +136,7 @@ class CommonTrackingTests(object):
         f = pd.concat([a, b])
         expected = f.copy()
         expected['particle'] = np.concatenate([np.array([0, 0, 0, 2]), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         expected.reset_index(drop=True, inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
@@ -146,9 +146,9 @@ class CommonTrackingTests(object):
         # not knowable from the first frame alone.
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(pandas_sort(f, 'frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(pandas_sort(f, 'frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -171,7 +171,7 @@ class CommonTrackingTests(object):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(2*M, Y + 2*M))
@@ -190,7 +190,7 @@ class CommonTrackingTests(object):
         f = pd.concat([walk(*pos) for pos in initial_positions])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([i*np.ones(N - i) for i in range(len(initial_positions))])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(200 + M, 200 + M))
@@ -343,7 +343,7 @@ class CommonTrackingTests(object):
         features = args.pop(0)
         res = pd.concat(tp.link_df_iter(
             (df for fr, df in features.groupby('frame')), *args, **kwargs))
-        return res.sort(['particle', 'frame']).reset_index(drop=True)
+        return pandas_sort(res, ['particle', 'frame']).reset_index(drop=True)
 
 
 class TestOnce(unittest.TestCase):
@@ -385,16 +385,16 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual_iter = self.link_df_iter(f, 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(pandas_sort(f, 'frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(pandas_sort(f, 'frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -428,7 +428,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.array([0, 0, 0, 2]), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         expected.reset_index(drop=True, inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
@@ -436,9 +436,9 @@ class SubnetNeededTests(CommonTrackingTests):
         assert_frame_equal(actual_iter, expected)
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5)
+        actual = self.link_df(pandas_sort(f, 'frame'), 5)
         assert_frame_equal(actual, expected)
-        actual_iter = self.link_df_iter(f.sort('frame'), 5, hash_size=(50, 50))
+        actual_iter = self.link_df_iter(pandas_sort(f, 'frame'), 5, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
 
         # Shuffle rows (crazy!)
@@ -465,7 +465,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.zeros(N), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual = self.link_df_iter(f, 5, hash_size=(2*M, 2*M + Y))
@@ -485,7 +485,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([walk(*pos) for pos in initial_positions])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([i*np.ones(N - i) for i in range(len(initial_positions))])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         actual = self.link_df(f, 5)
         assert_frame_equal(actual, expected)
         actual = self.link_df_iter(f, 5, hash_size=(2*M, 2*M))
@@ -563,7 +563,7 @@ class SubnetNeededTests(CommonTrackingTests):
         f = pd.concat([a, b])
         expected = f.copy().reset_index(drop=True)
         expected['particle'] = np.concatenate([np.array([0, 0, 0, 0]), np.ones(N - 1)])
-        expected.sort(['particle', 'frame'], inplace=True)
+        pandas_sort(expected, ['particle', 'frame'], inplace=True)
         expected.reset_index(drop=True, inplace=True)
         actual = self.link_df(f, 5, memory=1)
         assert_frame_equal(actual, expected)
@@ -575,11 +575,11 @@ class SubnetNeededTests(CommonTrackingTests):
             assert 'diag_remembered' in self.diag.columns
 
         # Sort rows by frame (normal use)
-        actual = self.link_df(f.sort('frame'), 5, memory=1)
+        actual = self.link_df(pandas_sort(f, 'frame'), 5, memory=1)
         assert_frame_equal(actual, expected)
         if self.do_diagnostics:
             assert 'diag_remembered' in self.diag.columns
-        actual_iter = self.link_df_iter(f.sort('frame'), 5,
+        actual_iter = self.link_df_iter(pandas_sort(f, 'frame'), 5,
                                         memory=1, hash_size=(50, 50))
         assert_frame_equal(actual_iter, expected)
         if self.do_diagnostics:

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -3,45 +3,47 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import unittest
 
-import nose
 import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
-from numpy.testing import assert_almost_equal, assert_allclose
-from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_almost_equal)
 
-import trackpy as tp 
-from trackpy.utils import suppress_plotting
+import trackpy as tp
+from trackpy.utils import pandas_sort
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()
 
+
+
 def random_walk(N):
     return np.cumsum(np.random.randn(N))
 
+
 def conformity(df):
-    "Organize toy data to look like real data."
+    """ Organize toy data to look like real data. Be strict about dtypes:
+    particle is a float and frame is an integer."""
     df['frame'] = df['frame'].astype(np.int)
     df['particle'] = df['particle'].astype(np.float)
     df['x'] = df['x'].astype(np.float)
     df['y'] = df['y'].astype(np.float)
     df.set_index('frame', drop=False, inplace=True)
-    return df.sort_values(by=['frame', 'particle'])
+    return pandas_sort(df, by=['frame', 'particle'])
+
 
 def add_drift(df, drift):
     df['x'] = df['x'].add(drift['x'], fill_value=0)
     df['y'] = df['y'].add(drift['y'], fill_value=0)
     return df
 
-class TestDrift(unittest.TestCase):
 
+class TestDrift(unittest.TestCase):
     def setUp(self):
         N = 10
         Y = 1
         a = DataFrame({'x': np.zeros(N), 'y': np.zeros(N), 
-                      'frame': np.arange(N), 'particle': np.zeros(N)})
+                       'frame': np.arange(N), 'particle': np.zeros(N)})
         b = DataFrame({'x': np.zeros(N - 1), 'y': Y + np.zeros(N - 1), 
                        'frame': np.arange(1, N), 'particle': np.ones(N - 1)})
         self.dead_still = conformity(pd.concat([a, b]))
@@ -49,13 +51,13 @@ class TestDrift(unittest.TestCase):
         P = 1000 # particles
         A = 0.00001 # step amplitude
         np.random.seed(0)
-        particles = [DataFrame({'x': A*random_walk(N), 
-            'y': A*random_walk(N), 
-            'frame': np.arange(N), 'particle': i}) for i in range(P)]
+        particles = [DataFrame({'x': A*random_walk(N), 'y': A*random_walk(N),
+                                'frame': np.arange(N), 'particle': i})
+                     for i in range(P)]
         self.many_walks = conformity(pd.concat(particles))
 
         a = DataFrame({'x': np.arange(N), 'y': np.zeros(N), 
-                      'frame': np.arange(N), 'particle': np.zeros(N)})
+                       'frame': np.arange(N), 'particle': np.zeros(N)})
         b = DataFrame({'x': np.arange(1, N), 'y': Y + np.zeros(N - 1), 
                        'frame': np.arange(1, N), 'particle': np.ones(N - 1)})
         self.steppers = conformity(pd.concat([a, b]))
@@ -113,8 +115,8 @@ class TestDrift(unittest.TestCase):
         actual = tp.subtract_drift(add_drift(self.steppers, drift), drift)
         assert_frame_equal(actual, self.steppers)
 
-class TestMSD(unittest.TestCase):
 
+class TestMSD(unittest.TestCase):
     def setUp(self):
         N = 10
         Y = 1
@@ -127,9 +129,9 @@ class TestMSD(unittest.TestCase):
         P = 50 # particles
         A = 1 # step amplitude
         np.random.seed(0)
-        particles = [DataFrame({'x': A*random_walk(N),
-            'y': A*random_walk(N),
-            'frame': np.arange(N), 'particle': i}) for i in range(P)]
+        particles = [DataFrame({'x': A*random_walk(N), 'y': A*random_walk(N),
+                                'frame': np.arange(N), 'particle': i})
+                     for i in range(P)]
         self.many_walks = conformity(pd.concat(particles))
 
         a = DataFrame({'x': np.arange(N), 'y': np.zeros(N),
@@ -154,15 +156,15 @@ class TestMSD(unittest.TestCase):
         a = np.arange(EARLY, dtype='float64')
         expected = Series(2*A*a, index=a).iloc[1:]
         expected.name = 'msd'
-        expected.index.name = 'lag time [s]'
+        expected.index.name = 'lagt'
         # HACK: Float64Index imprecision ruins index equality.
         # Test them separately. If that works, make them exactly the same.
         assert_almost_equal(actual.index.values, expected.index.values)
         actual.index = expected.index
         assert_series_equal(np.round(actual), expected)
 
+
 class TestSpecial(unittest.TestCase):
-    
     def setUp(self):
         N = 10
         Y = 1
@@ -176,6 +178,8 @@ class TestSpecial(unittest.TestCase):
         # just a smoke test
         theta_entropy = lambda x: tp.motion.theta_entropy(x, plot=False)
         self.steppers.groupby('particle').apply(theta_entropy)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
Pandas 0.17.1 triggered some failing tests. I fixed this by:

* fixing particle column dtype to float, frame to integer, x/y to float
* `subtract_drift` now only adapts the position columns, before it converted everything to float
* removed all references to `.sort` with `pandas_sort`, to fix the flood of deprecation messages

This fixes #329 