### PR TITLE
TST Pillow>=3.0.0, increase pims dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow<3 pandas=0.13.0 scikit-image=0.9 pyyaml pytables pyfftw"
+      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow==2.1 pandas=0.13.0 scikit-image=0.9 pyyaml pytables pyfftw"
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pillow<3 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables pyfftw"
+      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pillow==2.5.1 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables pyfftw"
     # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
-      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow<3 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
+      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==2.9 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.4"
-      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow<3 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
+      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==3.0 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.5"
-      env: DEPS="numpy scipy matplotlib pillow<3 pandas!=0.18.0 scikit-image pyyaml pytables numba"
+      env: DEPS="numpy scipy matplotlib pillow pandas!=0.18.0 scikit-image pyyaml pytables numba"
 
 install:
   # See:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup_parameters = dict(
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
     install_requires = ['numpy>=1.7', 'scipy>=0.12', 'six>=1.8',
-	                    'pandas>=0.13', 'pims',
+	                    'pandas>=0.13', 'pims>=0.3.3',
                         'pyyaml', 'matplotlib'],
     packages = ['trackpy'],
     long_description = descr,


### PR DESCRIPTION
To solve issues with Pillow>=3.0.0, pims needs to be >= 0.3.3.
Added tests for Pillow versions ~~2.0, 2.5~~, 2.9, 3.0 and latest.

edit: 2.1 and 2.5.1 because 2.0 and 2.5 do not exist on conda.