### PR TITLE
Sum of Gaussian refinement

### DIFF
--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -17,9 +17,10 @@ from .linking import HashTable, TreeFinder, Point, PointND, \
 from .filtering import filter_stubs, filter_clusters, filter
 from .feature import locate, batch, percentile_threshold, local_maxima, \
            refine, estimate_mass, estimate_size, minmass_version_change
-from .preprocessing import bandpass
+from .preprocessing import bandpass, lowpass
 from .framewise_data import FramewiseData, PandasHDFStore, PandasHDFStoreBig, \
            PandasHDFStoreSingleNode
+from .gaussian import refine_gaussian, refine_gaussian_batch, find_clusters
 from . import utils
 from . import artificial
 from .utils import handle_logging, ignore_logging, quiet

--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -72,12 +72,6 @@ class SimulatedImage(object):
     image.add_noise(5)
     image()
     """
-    feat_hat = feat_hat
-    feat_gauss = feat_gauss
-    feat_ring = feat_ring
-    feat_step = feat_step
-    feat_gauss_edge = feat_gauss_edge
-
     def __init__(self, shape, size, dtype=np.uint8, saturation=None,
                  hard_radius=None, signal=None, noise=0,
                  feat_func=feat_gauss, **feat_kwargs):

--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -2,6 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import numpy as np
+import pandas as pd
+from pims import Frame
 from scipy.spatial import cKDTree
 from trackpy.utils import validate_tuple
 
@@ -40,6 +42,185 @@ def feat_hat(r, disc_size, value_at_edge=0.1):
 def feat_step(r):
     """ Solid disc. """
     return r <= 1
+
+
+class SimulatedImage(object):
+    """ This class makes it easy to generate artificial pictures.
+
+    Parameters
+    ----------
+    shape : tuple of int
+    dtype : numpy.dtype, default np.uint8
+    saturation : maximum value in image
+    hard_radius : default radius of particles, used for determining the
+                  distance between particles in clusters
+    feat_dict : dictionary of arguments passed to tp.artificial.draw_feature
+
+    Attributes
+    ----------
+    image : ndarray containing pixel values
+    center : the center [y, x] to use for radial coordinates
+
+    Examples
+    --------
+    image = SimulatedImage(shape=(50, 50), dtype=np.uint8, hard_radius=7,
+                           feat_dict={'diameter': 20, 'max_value': 100,
+                                      'feat_func': SimulatedImage.feat_hat,
+                                      'disc_size': 0.2})
+    image.draw_feature((10, 10))
+    image.draw_dimer((32, 35), angle=75)
+    image.add_noise(5)
+    image()
+    """
+    feat_hat = feat_hat
+    feat_gauss = feat_gauss
+    feat_ring = feat_ring
+    feat_step = feat_step
+    feat_gauss_edge = feat_gauss_edge
+
+    def __init__(self, shape, size, dtype=np.uint8, saturation=None,
+                 hard_radius=None, signal=None, noise=0,
+                 feat_func=feat_gauss, **feat_kwargs):
+        self.ndim = len(shape)
+        self.shape = shape
+        self.dtype = dtype
+        self.image = Frame(np.zeros(shape, dtype=dtype))
+        self.size = validate_tuple(size, self.ndim)
+        self.isotropic = np.all([self.size[1:] == self.size[:-1]])
+        self.feat_func = feat_func
+        self.feat_kwargs = feat_kwargs
+        self.feat_kwargs['rg'] = 0.25
+        self.noise = noise
+        if saturation is None and np.issubdtype(dtype, np.integer):
+            self.saturation = np.iinfo(dtype).max
+        elif saturation is None and np.issubdtype(dtype, np.float):
+            self.saturation = 1
+        else:
+            self.saturation = saturation
+        if signal is None:
+            self.signal = self.saturation
+        else:
+            self.signal = signal
+        self.center = tuple([s // 2 for s in shape])
+        self.hard_radius = hard_radius
+        self._coords = []
+        self.pos_columns = ['z', 'y', 'x'][-self.ndim:]
+        if self.isotropic:
+            self.size_columns = ['size']
+        else:
+            self.size_columns = ['size_z', 'size_y', 'size_x'][-self.ndim:]
+
+    def __call__(self):
+        # so that you can checkout the image with image() instead of image.image
+        return self.noisy_image(self.noise)
+
+    def clear(self):
+        """Clears the current image"""
+        self._coords = []
+        self.image = np.zeros_like(self.image)
+
+    def draw_feature(self, pos):
+        """Draws a feature at `pos`."""
+        pos = [float(p) for p in pos]
+        self._coords.append(pos)
+        draw_feature(self.image, pos, [s*8 for s in self.size], self.signal,
+                     self.feat_func, **self.feat_kwargs)
+
+    def draw_features(self, N, separation=0, margin=None):
+        """Draws N features at random locations, using minimum separation
+        and a margin. If separation > 0, less than N features may be drawn."""
+        if margin is None:
+            margin = self.hard_radius
+        if margin is None:
+            margin = 0
+        pos = gen_random_locations(self.shape, N, margin)
+        if separation > 0:
+            pos = eliminate_overlapping_locations(pos, separation)
+        for p in pos:
+            self.draw_feature(p)
+        return pos
+
+    def draw_feature_radial(self, r, angle, center=None):
+        """Draws a feature at radial coordinates `r`, `angle`. The center
+        of the radial coordinates system is determined by `center`. If this
+        is not given, self.center is used.
+
+        For 3D, angle has to be a tuple of length 2: (phi, theta), in which
+        theta is the angle with the positive z axis."""
+        if center is None:
+            center = self.center
+        if self.ndim == 2:
+            pos = (center[0] + self.size[0]*r*np.sin(angle*(np.pi/180)),
+                   center[1] + self.size[1]*r*np.cos(angle*(np.pi/180)))
+        elif self.ndim == 3:
+            if not hasattr(angle, '__iter__'):
+                angle = (angle, 0)
+            r_sin_theta = r*np.sin(angle[1]*(np.pi/180))
+            pos = (center[0] + self.size[0]*r*np.cos(angle[1]*(np.pi/180)),
+                   center[1] + self.size[1] * r_sin_theta * np.sin(angle[0]*(np.pi/180)),
+                   center[2] + self.size[2] * r_sin_theta * np.cos(angle[0]*(np.pi/180)))
+        else:
+            raise ValueError("Don't know how to draw in {} dimensions".format(self.ndim))
+        self.draw_feature(pos)
+        return pos
+
+    def draw_dimer(self, pos, angle, hard_radius=None):
+        """Draws a dimer at `pos` with angle `angle`. The distance
+        between particles is determined by 2*`hard_radius`. If this is not
+        given, self.separation is used."""
+        if hard_radius is None:
+            hard_radius = self.hard_radius
+        if self.ndim == 2:
+            angles = [angle, angle + 180]
+        if self.ndim == 3:
+            if not hasattr(angle, '__iter__'):
+                angle = (angle, 0)
+            angles = [angle, (angle[0] + 180, 180 - angle[1])]
+        res = [self.draw_feature_radial(hard_radius, a, pos) for a in angles]
+        return res
+    draw_dumbell = draw_dimer
+
+    def draw_trimer(self, pos, angle, hard_radius=None):
+        """Draws a trimer at `pos` with angle `angle`. The distance
+        between particles is determined by `separation`. If this is not
+        given, self.separation is used."""
+        if hard_radius is None:
+            hard_radius = self.hard_radius
+        d = hard_radius*2/3*np.sqrt(3)
+        y1, x1 = self.draw_feature_radial(d, angle, pos)
+        y2, x2 = self.draw_feature_radial(d, angle+120, pos)
+        y3, x3 = self.draw_feature_radial(d, angle+240, pos)
+        return [y1, x1], [y2, x2], [y3, x3]
+    draw_triangle = draw_trimer
+
+    def noisy_image(self, noise_level):
+        """Adds noise to the current image, uniformly distributed
+        between 0 and `noise_level`, not including noise_level."""
+        if noise_level <= 0:
+            return self.image
+        if np.issubdtype(self.dtype, np.integer):
+            noise = np.random.randint(0, noise_level, self.shape)
+        else:
+            noise = np.random.random(self.shape) * noise_level
+        noisy_image = np.clip(self.image + noise, 0, self.saturation)
+        return Frame(np.array(noisy_image, dtype=self.dtype))
+
+    @property
+    def coords(self):
+        if len(self._coords) == 0:
+            return np.zeros((0, self.ndim), dtype=np.float)
+        return np.array(self._coords)
+
+    def f(self, noise=0):
+        result = self.coords + np.random.random(self.coords.shape) * noise
+        result = pd.DataFrame(result, columns=self.pos_columns)
+        result['signal'] = float(self.signal)
+        if self.isotropic:
+            result[self.size_columns[0]] = float(self.size[0])
+        else:
+            for col, s in zip(self.size_columns, self.size):
+                result[col] = float(s)
+        return result
 
 
 def draw_feature(image, position, diameter, max_value=None,

--- a/trackpy/gaussian.py
+++ b/trackpy/gaussian.py
@@ -1,5 +1,4 @@
-from __future__ import (division, print_function, unicode_literals,
-                        absolute_import)
+from __future__ import division, print_function, absolute_import
 
 import six
 import logging

--- a/trackpy/gaussian.py
+++ b/trackpy/gaussian.py
@@ -1,0 +1,559 @@
+from __future__ import (division, print_function, unicode_literals,
+                        absolute_import)
+
+import six
+import logging
+from types import ModuleType
+
+import numpy as np
+import pandas as pd
+
+from .preprocessing import lowpass
+from .masks import slice_image, binary_mask_multiple
+from .utils import guess_pos_columns, validate_tuple
+
+from scipy.optimize import leastsq
+from scipy.spatial import cKDTree
+
+logger = logging.getLogger(__name__)
+
+T_COLUMN = 'frame'
+SIGNAL_COLUMN = 'signal'
+
+# make a dynamic module; run imports inside this module
+residuals = ModuleType('residuals')
+exec("from __future__ import division\nfrom numpy import exp",
+     residuals.__dict__)
+
+func_library = dict(
+    gauss2D=dict(params=['signal', 'size', 'y', 'x'],
+                 func='signal{i} * exp( -((x-x{i})**2 + '
+                                         '(y-y{i})**2) / (size{i}**2) )',
+                 dfunc=dict(signal='func{i} / signal{i}',
+                            size='2*((x-x{i})**2 + (y-y{i})**2) '
+                                 '/ size{i}**3*func{i}',
+                            y='2*(y-y{i}) / size{i}**2 * func{i}',
+                            x='2*(x-x{i}) / size{i}**2 * func{i}')),
+
+    gauss2D_a=dict(params=['signal', 'size_y', 'size_x', 'y', 'x'],
+                   func='signal{i} * exp( -(((x-x{i})/size_x{i})**2)'
+                        '                 -(((y-y{i})/size_y{i})**2) )',
+                   dfunc=dict(signal='func{i} / signal{i}',
+                              size_y='2*(y-y{i})**2 / size_y{i}**3 * func{i}',
+                              size_x='2*(x-x{i})**2 / size_x{i}**3 * func{i}',
+                              y='2*(y-y{i}) / size_y{i}**2 * func{i}',
+                              x='2*(x-x{i}) / size_x{i}**2 * func{i}')),
+
+
+    gauss3D=dict(params=['signal', 'size', 'z', 'y', 'x'],
+                 func='signal{i} * exp( -(3/2*((x-x{i})**2 + '
+                                              '(y-y{i})**2 + '
+                                              '(z-z{i})**2)) / size{i}**2 )',
+                 dfunc=dict(signal='func{i} / signal{i}',
+                            size='3*((x-x{i})**2 + (y-y{i})**2 + (z-z{i})**2) '
+                                 '/ size{i}**3 * func{i}',
+                            z='3*(z-z{i}) / size{i}**2 * func{i}',
+                            y='3*(y-y{i}) / size{i}**2 * func{i}',
+                            x='3*(x-x{i}) / size{i}**2 * func{i}')),
+
+    gauss3D_a=dict(params=['signal', 'size_z', 'size_y', 'size_x',
+                           'z', 'y', 'x'],
+                   func='signal{i} * exp( -(3/2*((x-x{i})/size_x{i})**2)'
+                        '                 -(3/2*((y-y{i})/size_y{i})**2)'
+                        '                 -(3/2*((z-z{i})/size_z{i})**2) )',
+                   dfunc=dict(signal='func{i} / signal{i}',
+                              size_z='3*(z-z{i})**2 / size_z{i}**3 * func{i}',
+                              size_y='3*(y-y{i})**2 / size_y{i}**3 * func{i}',
+                              size_x='3*(x-x{i})**2 / size_x{i}**3 * func{i}',
+                              z='3*(z-z{i}) / size_z{i}**2 * func{i}',
+                              y='3*(y-y{i}) / size_y{i}**2 * func{i}',
+                              x='3*(x-x{i}) / size_x{i}**2 * func{i}')))
+
+
+def generate_fit_function(n_func, name, ndim, isotropic, consts=None):
+    """Generates code that defines a fitting function that is the addition of
+    N functions as defined inside func_dict."""
+    name = '{name}{ndim}D'.format(name=name, ndim=ndim)
+    if not isotropic:
+        name += '_a'
+    func_dict = func_library[name]
+
+    if consts is None:
+        consts = []
+    func_name = name + '_' + '_'.join(consts)
+
+    var_params = []
+    const_params = []
+    for i in range(n_func):
+        for param in func_dict['params']:
+            if param in consts:
+                const_params.append(param + str(i))
+            else:
+                var_params.append(param + str(i))
+
+    coords = ['z', 'y', 'x'][-ndim:]
+    args = ', '.join(['vars', 'im'] + coords + ['consts'])
+    var_params = ', '.join(var_params)
+    const_params = ', '.join(const_params)
+    func = ' + '.join([func_dict['func'].format(i=i) for i in range(n_func)])
+
+    res = "def {func_name}_{n_func}({args}):"
+    res += "\n    {var_params} = vars"
+    if len(const_params) > 0:
+        res += "\n    {const_params} = consts"
+    res += "\n    return {func} - im\n"
+
+    if 'dfunc' in func_dict:
+        dfunc_list = []
+        for i in range(n_func):
+            for param in func_dict['params']:
+                if param not in consts:
+                    dfunc_list.append(func_dict['dfunc'][param].format(i=i))
+        dfunc = ', '.join(dfunc_list)
+
+        res += "\ndef {func_name}_{n_func}_dfunc({args}):"
+        res += "\n    {var_params} = vars"
+        if len(const_params) > 0:
+            res += "\n    {const_params} = consts"
+        if 'func0' in dfunc:
+            for i in range(n_func):
+                res += ("\n    func{i} = " + func_dict['func']).format(i=i)
+        res += "\n    return [{dfunc}]"
+
+    return res.format(**locals())
+
+
+def get_fit_function(n_func, name, ndim, isotropic, consts=None):
+    """Checks if the fitting function (=residual) was already generated before,
+    if not, generates it and adds it to the residuals library."""
+    lib_name = '{name}{ndim}D'.format(name=name, ndim=ndim)
+    if not isotropic:
+        lib_name += '_a'
+    if consts is None:
+        consts = []
+    residual_name = lib_name + '_' + '_'.join(consts) + '_' + str(n_func)
+
+    if not hasattr(residuals, residual_name):
+        exec(generate_fit_function(n_func, name, ndim, isotropic, consts),
+             residuals.__dict__)
+
+    dfunc_name = residual_name + '_dfunc'
+    if hasattr(residuals, dfunc_name):
+        return getattr(residuals, residual_name), getattr(residuals, dfunc_name)
+    else:
+        return getattr(residuals, residual_name), None
+
+
+def prepare_subimage(coords, image, radius, noise_size=None, threshold=None):
+    # slice region around cluster
+    im, origin = slice_image(coords, image, radius)
+
+    # do lowpass filter
+    if noise_size is not None:
+        if threshold is None:
+            threshold = 0
+        im = lowpass(im, noise_size, threshold)
+
+    # create the mask
+    coords_rel = coords - np.array(origin)[np.newaxis, :]
+    mask = binary_mask_multiple(coords_rel, im.shape, radius)
+
+    # create the coordinates
+    mesh = np.meshgrid(*[np.arange(o, o+s)
+                         for (o, s) in zip(origin, im.shape)], indexing='ij')
+    mesh = (m[mask].astype(np.float64) for m in mesh)
+
+    return im[mask].astype(np.float64), tuple(mesh), origin
+
+
+class Clusters(object):
+    def __init__(self, indices):
+        self._cl = {i: {i} for i in indices}
+        self._f = list(indices)
+
+    @property
+    def clusters(self):
+        return self._cl
+
+    def __iter__(self):
+        return (list(self._cl[k]) for k in self._cl)
+
+    def add(self, a, b):
+        i1 = self._f[a]
+        i2 = self._f[b]
+        if i1 != i2:  # if a and b are already clustered, do nothing
+            self._cl[i1] = self._cl[i1].union(self._cl[i2])
+            for f in self._cl[i2]:
+                self._f[f] = i1
+            del self._cl[i2]
+
+    @property
+    def cluster_id(self):
+        return self._f
+
+    @property
+    def cluster_size(self):
+        result = [None] * len(self._f)
+        for cluster in self:
+            for f in cluster:
+                result[f] = len(cluster)
+        return result
+
+
+def _find(f, separation):
+    """ Find clusters in a list or ndarray of coordinates.
+
+    Parameters
+    ----------
+    f: iterable of coordinates
+    separation: tuple of numbers
+        Separation distance below which particles are considered inside cluster
+
+    Returns
+    ----------
+    ids : ndarray of cluster IDs per particle
+    sizes : ndarray of cluster sizes
+    """
+    # kdt setup
+    pairs = cKDTree(np.array(f) / separation).query_pairs(1)
+
+    clusters = Clusters(range(len(f)))
+    for (a, b) in pairs:
+        clusters.add(a, b)
+
+    return clusters.cluster_id, clusters.cluster_size
+
+
+def find_iter(f, separation, pos_columns=None, t_column='frame'):
+    """ Find clusters in a DataFrame, returns generator iterating over frames.
+
+    Parameters
+    ----------
+    f: DataFrame
+        pandas DataFrame containing pos_columns and t_column
+    separation: number or tuple
+        Separation distance below which particles are considered inside cluster
+    pos_columns: list of strings, optional
+        Column names that contain the position coordinates.
+        Defaults to ['y', 'x'] (or ['z', 'y', 'x'] if 'z' exists)
+    t_column: string
+        Column name containing the frame number (Default: 'frame')
+
+    Returns
+    ----------
+    generator of:
+        frame_no
+        DataFrame with added cluster and cluster_size column
+    """
+    if pos_columns is None:
+        pos_columns = guess_pos_columns(f)
+
+    next_id = 0
+
+    for frame_no, f_frame in f.groupby(t_column):
+        ids, sizes = _find(f_frame[pos_columns].values, separation)
+        result = f_frame.copy()
+        result['cluster'] = ids
+        result['cluster_size'] = sizes
+        result['cluster'] += next_id
+        next_id = result['cluster'].max() + 1
+        yield frame_no, result
+
+
+def find_clusters(f, separation, pos_columns=None, t_column='frame'):
+    """ Find clusters in a DataFrame of points from several frames.
+
+    Parameters
+    ----------
+    f: DataFrame
+        pandas DataFrame containing pos_columns and t_column
+    separation: number or tuple
+        Separation distance below which particles are considered inside cluster
+    pos_columns: list of strings, optional
+        Column names that contain the position coordinates.
+        Defaults to ['y', 'x'] (or ['z', 'y', 'x'] if 'z' exists)
+    t_column: string
+        Column name containing the frame number (Default: 'frame')
+
+    Returns
+    ----------
+    DataFrame
+    """
+    if t_column not in f:
+        f[t_column] = 0
+        remove_t_column = True
+    else:
+        remove_t_column = False
+
+    result = pd.concat((x[1] for x in find_iter(f, separation,
+                                                pos_columns, t_column)))
+
+    if remove_t_column:
+        del f[t_column]
+
+    return result
+
+
+def mass_to_max(mass, size, ndim):
+    if hasattr(size, '__iter__'):
+        assert len(size) == ndim
+        return mass / (np.pi * np.prod(size))
+    else:
+        return mass / (np.pi * size**ndim)
+
+
+def max_to_mass(max_value, size, ndim):
+    if hasattr(size, '__iter__'):
+        assert len(size) == ndim
+        return max_value * (np.pi * np.prod(size))
+    else:
+        return max_value * (np.pi * size**ndim)
+
+
+class RefineException(Exception):
+    pass
+
+
+def _fit_gauss_iter(f, image, diameter, var_size=False, var_signal=False,
+                    pos_columns=None, ignore_single=False,
+                    noise_size=1, threshold=None, max_iter=10, max_shift=1):
+    """ Refines cluster coordinates using gaussian fits, returns generator
+    iterating over cluster IDs.
+
+    Parameters
+    ----------
+    f: DataFrame
+        pandas DataFrame containing coordinates of features
+        required columns: positions, 'signal', 'size', 'cluster', 'cluster_size'
+    image: ndarray
+        Image, containing only one channel
+    diameter: number or tuple
+        Determines mask size that is used on the image before fitting
+    var_size: boolean
+        Determines whether size is varied in fitting. Default False.
+    var_signal: boolean
+        Determines whether signal is varied in fitting. Default False.
+    pos_columns: list of strings, optional
+        Column names that contain the position coordinates.
+        Defaults to ['y', 'x'] (or ['z', 'y', 'x'] if 'z' exists)
+    ignore_single: boolean
+        Determines whether single particles are skipped. Default False.
+    noise_size: number
+        Noise size used in lowpass filter
+    threshold: number
+        Threshold used in lowpass filter
+    max_iter: int
+        Max number of whole-pixel shifts in refine.
+    max_shift: float
+        Maximum satisfactory out-of-center distance. When the fitted gaussian
+        is more out of center, do extra iteration. Default 1.
+
+
+    Returns
+    -------
+    iterable of new coordinates per cluster of particles
+    """
+    ndim = image.ndim
+    diameter = validate_tuple(diameter, ndim)
+    radius = tuple([x//2 for x in diameter])
+    isotropic = np.all(diameter[1:] == diameter[:-1])
+
+    assert SIGNAL_COLUMN in f
+    assert 'cluster' in f
+
+    if pos_columns is None:
+        pos_columns = ['z', 'y', 'x'][-ndim:]
+    for col in pos_columns:
+        assert col in f
+
+    if isotropic:
+        size_cols = ['size']
+    else:
+        size_cols = ['size_z', 'size_y', 'size_x'][-ndim:]
+    for col in size_cols:
+        assert col in f
+
+    var_param_cols = []
+    const_param_cols = []
+    if var_signal:
+        var_param_cols += [SIGNAL_COLUMN]
+    else:
+        const_param_cols += [SIGNAL_COLUMN]
+
+    if var_size:
+        var_param_cols += size_cols
+    else:
+        const_param_cols += size_cols
+
+    var_param_cols += pos_columns
+
+    for cluster_id, f_cluster in f.groupby('cluster'):
+        result = f_cluster.copy()
+        if ignore_single and len(f_cluster) == 1:
+            raise RefineException
+        try:
+            consts = (result[const_param_cols].values.ravel(),)
+            p0 = result[var_param_cols].values
+            if not (np.isfinite(consts[0]).all() and np.isfinite(p0).all()):
+                raise RefineException
+            for _ in range(max_iter):
+                im_masked, mesh, origin = prepare_subimage(p0[:, -ndim:], image,
+                                                           radius, noise_size,
+                                                           threshold)
+                if origin is None:  # coordinates are out of image bounds
+                    raise RefineException
+                residual, dfunc = get_fit_function(len(result), 'gauss',
+                                                   image.ndim, isotropic,
+                                                   const_param_cols)
+
+                fit_args = (im_masked,) + mesh + consts
+                try:
+                    x, cov_x, _, _, ier = leastsq(residual, list(p0.ravel()),
+                                                  fit_args, dfunc,
+                                                  col_deriv=True,
+                                                  full_output=True)
+                except ValueError or TypeError:
+                    raise RefineException
+
+                if ier in [1, 2, 3] and x is not None and cov_x is not None:
+                    new_coords = np.array(x).reshape(p0.shape)
+                    std = np.sqrt(np.diag(cov_x)).reshape(p0.shape)
+                else:
+                    raise RefineException
+
+                # check if found coords are inside the subimage
+                upper_bound = [int(m.max()) + 1 for m in mesh]
+                if (np.any(new_coords[:, -ndim:] < origin) or
+                        np.any(new_coords[:, -ndim:] >= upper_bound)):
+                    raise RefineException
+
+                # check if found coords are MAX_SHIFT px from image center.
+                shifts = np.abs(p0[:, -ndim:] - new_coords[:, -ndim:])
+                if np.sum(shifts**2) < max_shift**2:
+                    break  # stop iteration: accept result
+
+                p0 = new_coords.copy()
+
+            if np.any(std[:, -ndim:] > 1):  # more than one pixel variance
+                raise RefineException
+            if np.any(np.abs(std[:, :-ndim] / new_coords[:, :-ndim]) > 0.1):
+                raise RefineException
+            if var_size:  # size might be negative: take absolute value here
+                new_coords[:, :-ndim] = np.abs(new_coords[:, :-ndim])
+        except RefineException:
+            result['gaussian'] = False
+        else:
+            result[var_param_cols] = new_coords
+            result['gaussian'] = True
+
+        yield result
+
+
+def refine_gaussian(f, image, diameter, separation, var_size=False,
+                    var_signal=False, pos_columns=None, t_column='frame',
+                    ignore_single=False, noise_size=1, threshold=None,
+                    max_iter=10, max_shift=1):
+    """ Refines coordinates in a single image using gaussian fits.
+
+    Parameters
+    ----------
+    f: DataFrame
+        pandas DataFrame containing coordinates of features
+        required columns: positions, 'signal', 'size', 'cluster', 'cluster_size'
+    image: ndarray
+        Image, containing only one channel
+    diameter: number or tuple
+        Determines mask size that is used on the image before fitting
+    separation: number or tuple
+        Separation distance below which particles are considered inside cluster
+    var_size: boolean
+        Determines whether size is varied in fitting. Default False.
+    var_signal: boolean
+        Determines whether signal is varied in fitting. Default False.
+    pos_columns: list of strings, optional
+        Column names that contain the position coordinates.
+        Defaults to ['y', 'x'] (or ['z', 'y', 'x'] if 'z' exists)
+    t_column: string
+        Column name containing the frame number (Default: 'frame')
+    ignore_single: boolean
+        Determines whether single particles are skipped. Default False.
+    noise_size: number
+        Noise size used in lowpass filter
+    threshold: number
+        Threshold used in lowpass filter
+    max_iter: int
+        Max number of whole-pixel shifts in refine.
+    max_shift: float
+        Maximum satisfactory out-of-center distance. When the fitted gaussian
+        is more out of center, do extra iteration. Default 1.
+
+
+    Returns
+    -------
+    copy of input DataFrame, updated with the corrected coordinates
+    """
+    f = find_clusters(f, separation, pos_columns, t_column)
+    return pd.concat(_fit_gauss_iter(f, image, diameter, var_size, var_signal,
+                                     pos_columns, ignore_single, noise_size,
+                                     threshold, max_iter, max_shift))
+
+
+def refine_gaussian_batch(f, frames, diameter, separation, var_size=False,
+                          var_signal=False, pos_columns=None, t_column='frame',
+                          ignore_single=False, noise_size=1, threshold=None,
+                          max_iter=10, max_shift=1):
+    """ Refines coordinates in a sequence of images using gaussian fits.
+
+    Parameters
+    ----------
+    f: DataFrame
+        pandas DataFrame containing coordinates of features
+        required columns: positions, 'signal', 'size'
+    image: ndarray
+        Image, containing only one channel
+    diameter: number or tuple
+        Determines mask size that is used on the image before fitting
+    separation: number or tuple
+        Separation distance below which particles are considered inside cluster
+    var_size: boolean
+        Determines whether size is varied in fitting. Default False.
+    var_signal: boolean
+        Determines whether signal is varied in fitting. Default False.
+    pos_columns: list of strings, optional
+        Column names that contain the position coordinates.
+        Defaults to ['y', 'x'] (or ['z', 'y', 'x'] if 'z' exists)
+    t_column: string
+        Column name containing the frame number (Default: 'frame')
+    ignore_single: boolean
+        Determines whether single particles are skipped. Default False.
+    noise_size: number
+        Noise size used in lowpass filter
+    threshold: number
+        Threshold used in lowpass filter
+    max_iter: int
+        Max number of whole-pixel shifts in refine.
+    max_shift: float
+        Maximum satisfactory out-of-center distance. When the fitted gaussian
+        is more out of center, do extra iteration. Default 1.
+
+    Returns
+    ----------
+    copy of input DataFrame, updated with the corrected coordinates
+    """
+    result = []
+    skipped = 0
+    for frame_no, f_frame in find_iter(f, separation, pos_columns, t_column):
+        f_frame = pd.concat(_fit_gauss_iter(f_frame, frames[frame_no], diameter,
+                                            var_size, var_signal, pos_columns,
+                                            ignore_single, noise_size,
+                                            threshold, max_iter, max_shift))
+        result.append(f_frame)
+
+        failed = len(f_frame) - f_frame['gaussian'].sum()
+        if ignore_single:
+            skipped = np.sum(f_frame['cluster_size'].values == 1)
+            failed -= skipped
+        logger.info("Frame %d: refined %d of %d features, %d failed",
+                    frame_no, len(f_frame) - skipped, len(f_frame), failed)
+
+    return pd.concat(result)

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -94,3 +94,88 @@ def gaussian_kernel(sigma, truncate=4.0):
     x = np.arange(-lw, lw+1)
     result = np.exp(x**2/(-2*sigma**2))
     return result / np.sum(result)
+
+
+def _slice(lower, upper, shape):
+    ndim = len(shape)
+    origin = [None] * ndim
+    slices = [None] * ndim
+    for i, sh, low, up in zip(range(ndim), shape, lower, upper):
+        lower_bound_trunc = max(0, low)
+        upper_bound_trunc = min(sh, up)
+        slices[i] = slice(lower_bound_trunc, upper_bound_trunc)
+        origin[i] = lower_bound_trunc
+    return slices, origin
+
+
+def _in_bounds(coords, shape, radius):
+    ndim = len(shape)
+    in_bounds = np.array([(coords[:, i] >= -r) & (coords[:, i] < sh + r)
+                         for i, sh, r in zip(range(ndim), shape, radius)])
+    return coords[np.all(in_bounds, axis=0)]
+
+
+def slices_multiple(coords, shape, radius):
+    """Creates the smallest box so that every coord in `coords` is in the box
+    up to `radius` from the coordinate."""
+    ndim = len(shape)
+    radius = validate_tuple(radius, ndim)
+    coords = np.atleast_2d(np.round(coords).astype(np.int))
+    coords = _in_bounds(coords, shape, radius)
+
+    if len(coords) == 0:
+        return [slice(None, 0)] * ndim, None
+
+    return _slice(coords.min(axis=0) - radius,
+                  coords.max(axis=0) + radius + 1, shape)
+
+
+def slice_image(coords, image, radius):
+    """Creates the smallest box so that every coord in `coords` is in the box
+    up to `radius` from the coordinate."""
+    slices, origin = slices_multiple(coords, image.shape, radius)
+    return image[slices], origin  # mask origin
+
+
+def binary_mask_multiple(coords_rel, shape, radius, include_edge=True):
+    """Creates multiple elliptical masks.
+
+    Parameters
+    ----------
+    coords_rel : ndarray (N x 2 or N x 3)
+        coordinates
+    shape : tuple
+        shape of the image
+    radius : number or tuple of number
+        size of the masks
+    """
+    ndim = len(shape)
+    radius = validate_tuple(radius, ndim)
+    coords_rel = np.atleast_2d(coords_rel)
+
+    if include_edge:
+        dist = [np.sum(((np.indices(shape).T - coord) / radius)**2, -1) <= 1
+                for coord in coords_rel]
+    else:
+        dist = [np.sum(((np.indices(shape).T - coord) / radius)**2, -1) < 1
+                for coord in coords_rel]
+    return np.any(dist, axis=0).T
+
+
+def mask_image(coords, image, radius, origin=None, invert=False):
+    """Masks an image with elliptical masks with size `radius`. At every coord
+    in `coords`, the mask is applied to the image. When invert=True, the coords
+    instead of the background will be made 0.
+    Optionally, specify the topleft coordinate (origin) of the image."""
+    if origin is not None:
+        coords_rel = coords - np.array(origin)[np.newaxis, :]
+    else:
+        coords_rel = coords
+
+    mask_cluster = binary_mask_multiple(coords_rel, image.shape, radius,
+                                        include_edge=(not invert))
+
+    if invert:
+        return image * ~mask_cluster
+    else:
+        return image * mask_cluster

--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -40,7 +40,7 @@ def bandpass(image, lshort, llong, threshold=None, truncate=4):
 
     See Also
     --------
-    legacy_bandpass, legacy_bandpass_fftw
+    lowpass, legacy_bandpass, legacy_bandpass_fftw
     """
     lshort = validate_tuple(lshort, image.ndim)
     llong = validate_tuple(llong, image.ndim)
@@ -62,6 +62,41 @@ def bandpass(image, lshort, llong, threshold=None, truncate=4):
             correlate1d(result, gaussian_kernel(sigma, truncate), axis,
                         output=result, mode='constant', cval=0.0)
     result -= boxcar
+    return np.where(result > threshold, result, 0)
+
+
+def lowpass(image, lshort, threshold=None):
+    """Convolve with a Gaussian to remove short-wavelength noise.
+
+    Parameters
+    ----------
+    image : ndarray
+    lshort : small-scale cutoff (noise)
+        give a tuple value for different sizes per dimension
+        give int value for same value for all dimensions
+    threshold : float or integer
+        By default, 1 for integer images and 1/256. for float images.
+
+    Returns
+    -------
+    result : array
+        the filtered image
+
+    See Also
+    --------
+    bandpass
+    """
+    lshort = validate_tuple(lshort, image.ndim)
+    if threshold is None:
+        if np.issubdtype(image.dtype, np.integer):
+            threshold = 1
+        else:
+            threshold = 1/256.
+    result = np.array(image, dtype=np.float)
+    for (axis, size) in enumerate(lshort):
+        if size > 0:
+            correlate1d(result, gaussian_kernel(size, 4), axis,
+                        output=result, mode='constant', cval=0.0)
     return np.where(result > threshold, result, 0)
 
 

--- a/trackpy/tests/test_gaussian.py
+++ b/trackpy/tests/test_gaussian.py
@@ -10,7 +10,7 @@ from scipy.spatial import cKDTree
 
 import trackpy as tp
 from trackpy.masks import slice_image, mask_image
-from trackpy.artificial import SimulatedImage
+from trackpy.artificial import SimulatedImage, feat_gauss, feat_hat
 
 
 def sort_positions(actual, expected):
@@ -390,7 +390,7 @@ def refine_single(im, diameter, separation, pos=None,
     return actual_pos - pos
 
 
-class TestSingle(object):
+class _RefineGaussianTsts(object):
     def setUp(self):
         self.separation = 100
         self.signal = 200
@@ -401,7 +401,7 @@ class TestSingle(object):
                 self.size = self.diameter / 8
         self.im = SimulatedImage(self.shape, self.size, dtype=np.uint8,
                                  signal=self.signal,
-                                 feat_func=SimulatedImage.feat_gauss)
+                                 feat_func=feat_gauss)
         self.N = 10
 
     def test_perfect_gaussian(self):
@@ -424,7 +424,7 @@ class TestSingle(object):
                           signal_rtol=1, size_rtol=1)
 
     def test_disc_like(self):
-        self.im.feat_func = SimulatedImage.feat_hat
+        self.im.feat_func = feat_hat
         pos_err = self.pos_err
         positions = self.im.center + \
                     np.random.random((self.N, self.im.ndim)) * pos_err * 2 - pos_err
@@ -497,7 +497,7 @@ class TestSingle(object):
         pass
 
 
-class TestFit_gauss2D(TestSingle, unittest.TestCase):
+class TestFit_gauss2D(_RefineGaussianTsts, unittest.TestCase):
     shape = (128, 128)
     fit_function = 'gauss'
     var_size = False
@@ -509,7 +509,7 @@ class TestFit_gauss2D(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss2D_a(TestSingle, unittest.TestCase):
+class TestFit_gauss2D_a(_RefineGaussianTsts, unittest.TestCase):
     shape = (128, 64)
     fit_function = 'gauss'
     var_size = False
@@ -521,7 +521,7 @@ class TestFit_gauss2D_a(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss2D_signal(TestSingle, unittest.TestCase):
+class TestFit_gauss2D_signal(_RefineGaussianTsts, unittest.TestCase):
     # in this test, the magnitude of signal is tested (5% tol)
     shape = (128, 128)
     fit_function = 'gauss'
@@ -534,7 +534,7 @@ class TestFit_gauss2D_signal(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss2D_a_signal(TestSingle, unittest.TestCase):
+class TestFit_gauss2D_a_signal(_RefineGaussianTsts, unittest.TestCase):
     shape = (128, 64)
     fit_function = 'gauss'
     var_size = False
@@ -546,7 +546,7 @@ class TestFit_gauss2D_a_signal(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss2D_size(TestSingle, unittest.TestCase):
+class TestFit_gauss2D_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (128, 128)
     fit_function = 'gauss'
     var_size = True
@@ -558,7 +558,7 @@ class TestFit_gauss2D_size(TestSingle, unittest.TestCase):
    # signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss2D_a_size(TestSingle, unittest.TestCase):
+class TestFit_gauss2D_a_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (128, 64)
     fit_function = 'gauss'
     var_size = True
@@ -570,7 +570,7 @@ class TestFit_gauss2D_a_size(TestSingle, unittest.TestCase):
    # signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss2D_signal_size(TestSingle, unittest.TestCase):
+class TestFit_gauss2D_signal_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (128, 128)
     fit_function = 'gauss'
     var_size = True
@@ -582,7 +582,7 @@ class TestFit_gauss2D_signal_size(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss2D_a_signal_size(TestSingle, unittest.TestCase):
+class TestFit_gauss2D_a_signal_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (128, 64)
     fit_function = 'gauss'
     var_size = True
@@ -594,7 +594,7 @@ class TestFit_gauss2D_a_signal_size(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss3D(TestSingle, unittest.TestCase):
+class TestFit_gauss3D(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 64)
     fit_function = 'gauss'
     var_size = False
@@ -606,7 +606,7 @@ class TestFit_gauss3D(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss3D_a(TestSingle, unittest.TestCase):
+class TestFit_gauss3D_a(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 32)
     fit_function = 'gauss'
     var_size = False
@@ -618,7 +618,7 @@ class TestFit_gauss3D_a(TestSingle, unittest.TestCase):
     signal_err_factor = [0.2, 5.]
 
 
-class TestFit_gauss3D_signal(TestSingle, unittest.TestCase):
+class TestFit_gauss3D_signal(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 64)
     fit_function = 'gauss'
     var_size = False
@@ -630,7 +630,7 @@ class TestFit_gauss3D_signal(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss3D_a_signal(TestSingle, unittest.TestCase):
+class TestFit_gauss3D_a_signal(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 32)
     fit_function = 'gauss'
     var_size = False
@@ -642,7 +642,7 @@ class TestFit_gauss3D_a_signal(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss3D_size(TestSingle, unittest.TestCase):
+class TestFit_gauss3D_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 64)
     fit_function = 'gauss'
     var_size = True
@@ -654,7 +654,7 @@ class TestFit_gauss3D_size(TestSingle, unittest.TestCase):
    # signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss3D_a_size(TestSingle, unittest.TestCase):
+class TestFit_gauss3D_a_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 32)
     fit_function = 'gauss'
     var_size = True
@@ -666,7 +666,7 @@ class TestFit_gauss3D_a_size(TestSingle, unittest.TestCase):
    # signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss3D_signal_size(TestSingle, unittest.TestCase):
+class TestFit_gauss3D_signal_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 64)
     fit_function = 'gauss'
     var_size = True
@@ -678,7 +678,7 @@ class TestFit_gauss3D_signal_size(TestSingle, unittest.TestCase):
     signal_err_factor = [0.1, 10.]
 
 
-class TestFit_gauss3D_a_signal_size(TestSingle, unittest.TestCase):
+class TestFit_gauss3D_a_signal_size(_RefineGaussianTsts, unittest.TestCase):
     shape = (64, 64, 32)
     fit_function = 'gauss'
     var_size = True

--- a/trackpy/tests/test_gaussian.py
+++ b/trackpy/tests/test_gaussian.py
@@ -1,0 +1,694 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import unittest
+import numpy as np
+
+from numpy.testing import assert_almost_equal, assert_allclose, assert_equal
+import pandas as pd
+
+from scipy.spatial import cKDTree
+
+import trackpy as tp
+from trackpy.masks import slice_image, mask_image
+from trackpy.artificial import SimulatedImage
+
+
+def sort_positions(actual, expected):
+    assert_equal(len(actual), len(expected))
+    tree = cKDTree(actual)
+    devs, argsort = tree.query([expected])
+    return devs, actual[argsort][0]
+
+
+def assert_coordinates_close(actual, expected, atol):
+    _, sorted_actual = sort_positions(actual, expected)
+    assert_allclose(sorted_actual, expected, atol)
+
+
+def dummy_cluster(N, center, separation, ndim=2):
+    devs = (np.random.random((N, ndim)) - 0.5) * separation / np.sqrt(ndim)
+    return np.array(center)[np.newaxis, :] + devs
+
+
+def dummy_clusters(N, max_size, separation, ndim=2):
+    center = [separation] * ndim
+    sizes = np.random.randint(1, max_size, N)
+    displ = (np.random.random((N, ndim)) + 2) * separation
+    res = []
+    for i, size in enumerate(sizes):
+        center += displ[i]
+        res.append(dummy_cluster(size, center, separation, ndim))
+    return res
+
+
+def pos_to_df(pos):
+    pos_a = np.concatenate(pos)
+    ndim = pos_a.shape[1]
+    pos_columns = ['z', 'y', 'x'][-ndim:]
+    return pd.DataFrame(pos_a, columns=pos_columns)
+
+
+class TestSlicing(unittest.TestCase):
+    def test_slicing_2D(self):
+        im = np.empty((9, 9))
+
+        # center
+        for radius in range(1, 5):
+            sli, origin = slice_image([4, 4], im, radius)
+            assert_equal(sli.shape, (radius*2+1,) * 2)
+            assert_equal(origin, (4 - radius,) * 2)
+
+        # edge
+        for radius in range(1, 5):
+            sli, origin = slice_image([0, 4], im, radius)
+            assert_equal(sli.shape, (radius + 1, radius*2+1))
+
+        # edge
+        for radius in range(1, 5):
+            sli, origin = slice_image([4, 0], im, radius)
+            assert_equal(sli.shape, (radius*2+1, radius + 1))
+
+        # corner
+        for radius in range(1, 5):
+            sli, origin = slice_image([0, 0], im, radius)
+            assert_equal(sli.shape, (radius+1, radius + 1))
+
+        # outside of image
+        for radius in range(2, 5):
+            sli, origin = slice_image([-1, 4], im, radius)
+            assert_equal(sli.shape, (radius, radius*2+1))
+
+        # outside of image
+        for radius in range(2, 5):
+            sli, origin = slice_image([-1, -1], im, radius)
+            assert_equal(sli.shape, (radius, radius))
+
+        # no slice
+        for radius in range(2, 5):
+            sli, origin = slice_image([-10, 20], im, radius)
+            assert_equal(sli.shape, (0, 0))
+
+
+    def test_slicing_3D(self):
+        im = np.empty((9, 9, 9))
+
+        # center
+        for radius in range(1, 5):
+            sli, origin = slice_image([4, 4, 4], im, radius)
+            assert_equal(sli.shape, (radius*2+1,) * 3)
+            assert_equal(origin, (4 - radius,) * 3)
+
+        # face
+        for radius in range(1, 5):
+            sli, origin = slice_image([0, 4, 4], im, radius)
+            assert_equal(sli.shape, (radius + 1, radius*2+1, radius*2+1))
+
+        # edge
+        for radius in range(1, 5):
+            sli, origin = slice_image([4, 0, 0], im, radius)
+            assert_equal(sli.shape, (radius*2+1, radius + 1, radius + 1))
+
+        # corner
+        for radius in range(1, 5):
+            sli, origin = slice_image([0, 0, 0], im, radius)
+            assert_equal(sli.shape, (radius+1, radius + 1, radius + 1))
+
+        # outside of image
+        for radius in range(2, 5):
+            sli, origin = slice_image([-1, 4, 4], im, radius)
+            assert_equal(sli.shape, (radius, radius*2+1, radius*2+1))
+
+        # outside of image
+        for radius in range(2, 5):
+            sli, origin = slice_image([-1, -1, 4], im, radius)
+            assert_equal(sli.shape, (radius, radius, radius*2+1))
+
+        # no slice
+        for radius in range(2, 5):
+            sli, origin = slice_image([-10, 20, 30], im, radius)
+            assert_equal(sli.shape, (0, 0, 0))
+
+    def test_slicing_2D_multiple(self):
+        im = np.empty((9, 9))
+        radius = 2
+
+        sli, origin = slice_image([[4, 4], [4, 4]], im, radius)
+        assert_equal(sli.shape, (5, 5))
+        assert_equal(origin, (2, 2))
+
+        sli, origin = slice_image([[4, 2], [4, 6]], im, radius)
+        assert_equal(sli.shape, (5, 9))
+        assert_equal(origin, (2, 0))
+
+        sli, origin = slice_image([[2, 4], [6, 4]], im, radius)
+        assert_equal(sli.shape, (9, 5))
+        assert_equal(origin, (0, 2))
+
+        sli, origin = slice_image([[2, 4], [6, 4], [-10, 20]], im, radius)
+        assert_equal(sli.shape, (9, 5))
+        assert_equal(origin, (0, 2))
+
+    def test_slicing_3D_multiple(self):
+        im = np.empty((9, 9, 9))
+        radius = 2
+
+        sli, origin = slice_image([[4, 4, 4], [4, 4, 4]], im, radius)
+        assert_equal(sli.shape, (5, 5, 5))
+        assert_equal(origin, (2, 2, 2))
+
+        sli, origin = slice_image([[4, 2, 4], [4, 6, 4]], im, radius)
+        assert_equal(sli.shape, (5, 9, 5))
+        assert_equal(origin, (2, 0, 2))
+
+        sli, origin = slice_image([[4, 2, 6], [4, 6, 2]], im, radius)
+        assert_equal(sli.shape, (5, 9, 9))
+        assert_equal(origin, (2, 0, 0))
+
+        sli, origin = slice_image([[4, 2, 4], [4, 6, 4], [-10, 4, 4]], im, radius)
+        assert_equal(sli.shape, (5, 9, 5))
+        assert_equal(origin, (2, 0, 2))
+
+
+class TestMasking(unittest.TestCase):
+    def test_masking_single_2D(self):
+        im = np.ones((9, 9))
+        radius = 1  # N pix is 5
+
+        sli = mask_image([4, 4], im, radius)
+        assert_equal(sli.sum(), 5)
+        assert_equal(sli.shape, im.shape)
+
+        sli = mask_image([0, 4], im, radius)
+        assert_equal(sli.sum(), 4)
+
+        sli = mask_image([4, 0], im, radius)
+        assert_equal(sli.sum(), 4)
+
+        sli = mask_image([0, 0], im, radius)
+        assert_equal(sli.sum(), 3)
+
+        sli = mask_image([-1, 4], im, radius)
+        assert_equal(sli.sum(), 1)
+
+        sli = mask_image([-1, -1], im, radius)
+        assert_equal(sli.sum(), 0)
+
+
+    def test_masking_multiple_2D(self):
+        im = np.ones((9, 9))
+        radius = 1  # N pix is 5
+
+        sli = mask_image([[4, 2], [4, 6]], im, radius)
+        assert_equal(sli.sum(), 10)
+
+        sli = mask_image([[4, 4], [4, 4]], im, radius)
+        assert_equal(sli.sum(), 5)
+
+        sli = mask_image([[0, 4], [4, 4]], im, radius)
+        assert_equal(sli.sum(), 9)
+
+        sli = mask_image([[-1, 4], [4, 4]], im, radius)
+        assert_equal(sli.sum(), 6)
+
+        sli = mask_image([[-20, 40], [4, 4]], im, radius)
+        assert_equal(sli.sum(), 5)
+
+    def test_masking_single_3D(self):
+        im = np.ones((9, 9, 9))
+        radius = 1  # N pix is 7
+
+        sli = mask_image([4, 4, 4], im, radius)
+        assert_equal(sli.sum(), 7)
+        assert_equal(sli.shape, im.shape)
+
+        sli = mask_image([0, 4, 4], im, radius)
+        assert_equal(sli.sum(), 6)
+
+        sli = mask_image([4, 0, 0], im, radius)
+        assert_equal(sli.sum(), 5)
+
+        sli = mask_image([0, 0, 0], im, radius)
+        assert_equal(sli.sum(), 4)
+
+        sli = mask_image([-1, 4, 4], im, radius)
+        assert_equal(sli.sum(), 1)
+
+        sli = mask_image([-1, -1, -1], im, radius)
+        assert_equal(sli.sum(), 0)
+
+    def test_masking_multiple_3D(self):
+        im = np.ones((9, 9, 9))
+        radius = 1  # N pix is 7
+
+        sli = mask_image([[4, 4, 4], [4, 4, 4]], im, radius)
+        assert_equal(sli.sum(), 7)
+        assert_equal(sli.shape, im.shape)
+
+        sli = mask_image([[4, 4, 6], [4, 4, 2]], im, radius)
+        assert_equal(sli.sum(), 14)
+
+        sli = mask_image([[4, 4, 0], [4, 4, 4]], im, radius)
+        assert_equal(sli.sum(), 13)
+
+
+class TestFindClusters(unittest.TestCase):
+    def setUp(self):
+        self.N = 10
+
+    def test_single_cluster_2D(self):
+        separation = np.random.random(self.N) * 10
+        for sep in separation:
+            pos = dummy_clusters(1, 10, sep)
+            df = pos_to_df(pos)
+            df = tp.find_clusters(df, sep)
+            assert_equal(df['cluster_size'].values, len(pos[0]))
+
+    def test_multiple_clusters_2D(self):
+        numbers = np.random.randint(1, 10, self.N)
+        for number in numbers:
+            pos = dummy_clusters(number, 10, 1)
+            df = pos_to_df(pos)
+            df = tp.find_clusters(df, 1)
+            assert_equal(df['cluster'].nunique(), number)
+
+    def test_single_cluster_3D(self):
+        separation = np.random.random(self.N) * 10
+        for sep in separation:
+            pos = dummy_clusters(1, 10, sep, 3)
+            df = pos_to_df(pos)
+            df = tp.find_clusters(df, sep)
+            assert_equal(df['cluster_size'].values, len(pos[0]))
+
+    def test_multiple_clusters_3D(self):
+        numbers = np.random.randint(1, 10, self.N)
+        for number in numbers:
+            pos = dummy_clusters(number, 10, 1, 3)
+            df = pos_to_df(pos)
+            df = tp.find_clusters(df, 1)
+            assert_equal(df['cluster'].nunique(), number)
+
+    def test_line_cluster(self):
+        separation = np.random.random(self.N) * 10
+        angle = np.random.random(self.N) * 2 * np.pi
+        ds = np.array([np.cos(angle), np.sin(angle)]).T
+        for vec, sep in zip(ds, separation):
+            pos = np.arange(10)[:, np.newaxis] * vec[np.newaxis, :] * sep
+            df = pos_to_df([pos])
+            df = tp.find_clusters(df, sep*1.1)
+            assert_equal(df['cluster_size'].values, 10)
+            df = tp.find_clusters(df, sep*0.9)
+            assert_equal(df['cluster_size'].values, 1)
+
+            df = pos_to_df([pos[::-1]])
+            df = tp.find_clusters(df, sep*1.1)
+            assert_equal(df['cluster_size'].values, 10)
+            df = tp.find_clusters(df, sep*0.9)
+            assert_equal(df['cluster_size'].values, 1)
+
+            ind = np.arange(10)
+            np.random.shuffle(ind)
+            pos = ind[:, np.newaxis] * vec[np.newaxis, :] * sep
+            df = pos_to_df([pos])
+            df = tp.find_clusters(df, sep*1.1)
+            assert_equal(df['cluster_size'].values, 10)
+            df = tp.find_clusters(df, sep*0.9)
+            assert_equal(df['cluster_size'].values, 1)
+
+    def test_line_cluster_3D(self):
+        separation = np.random.random(self.N) * 10
+        phi = np.random.random(self.N) * 2 * np.pi
+        theta = np.random.random(self.N) * np.pi
+        ds = np.array([np.cos(theta),
+                       np.cos(phi)*np.sin(theta),
+                       np.sin(phi)*np.sin(theta)]).T
+        for vec, sep in zip(ds, separation):
+            pos = np.arange(10)[:, np.newaxis] * vec[np.newaxis, :] * sep
+            df = pos_to_df([pos])
+            df = tp.find_clusters(df, sep*1.1)
+            assert_equal(df['cluster_size'].values, 10)
+            df = tp.find_clusters(df, sep*0.9)
+            assert_equal(df['cluster_size'].values, 1)
+
+            df = pos_to_df([pos[::-1]])
+            df = tp.find_clusters(df, sep*1.1)
+            assert_equal(df['cluster_size'].values, 10)
+            df = tp.find_clusters(df, sep*0.9)
+            assert_equal(df['cluster_size'].values, 1)
+
+            ind = np.arange(10)
+            np.random.shuffle(ind)
+            pos = ind[:, np.newaxis] * vec[np.newaxis, :] * sep
+            df = pos_to_df([pos])
+            df = tp.find_clusters(df, sep*1.1)
+            assert_equal(df['cluster_size'].values, 10)
+            df = tp.find_clusters(df, sep*0.9)
+            assert_equal(df['cluster_size'].values, 1)
+
+
+
+def refine_single(im, diameter, separation, pos=None,
+                  var_size=False, var_signal=False,
+                  p0_pos=None, p0_size=None, p0_signal=None,
+                  pos_atol=0.1, signal_rtol=0.05, size_rtol=0.05,
+                  noise_size=None, threshold=None):
+    if pos is None:
+        pos = im.center
+    im.clear()
+    im.draw_feature(pos)
+    f0 = im.f()
+    if p0_pos is not None:
+        f0[im.pos_columns] = p0_pos
+    if p0_size is not None:
+        if im.isotropic:
+            try:
+                f0[im.size_columns[0]] = p0_size[0]
+            except TypeError:
+                f0[im.size_columns[0]] = p0_size
+        else:
+            f0[im.size_columns] = p0_size
+
+    if p0_signal is not None:
+        f0['signal'] = p0_signal
+
+    actual = tp.refine_gaussian(f0, im(), diameter, separation, var_size,
+                                var_signal, im.pos_columns, 'frame', False,
+                                noise_size, threshold)
+    assert actual['gaussian'].iloc[0]
+    if var_signal:
+        assert_allclose(actual['signal'].iloc[0], im.signal, rtol=signal_rtol)
+    if var_size:
+        if im.isotropic:
+            assert_allclose(actual[im.size_columns[0]].iloc[0], im.size[0],
+                            rtol=size_rtol)
+        else:
+            assert_allclose(actual[im.size_columns].iloc[0], im.size,
+                            rtol=size_rtol)
+
+    actual_pos = actual[im.pos_columns].iloc[0].values
+    assert_allclose(actual_pos, np.array(pos), atol=pos_atol)
+
+    return actual_pos - pos
+
+
+class TestSingle(object):
+    def setUp(self):
+        self.separation = 100
+        self.signal = 200
+        if not hasattr(self, 'size'):
+            if hasattr(self.diameter, '__iter__'):
+                self.size = tuple([d / 8 for d in self.diameter])
+            else:
+                self.size = self.diameter / 8
+        self.im = SimulatedImage(self.shape, self.size, dtype=np.uint8,
+                                 signal=self.signal,
+                                 feat_func=SimulatedImage.feat_gauss)
+        self.N = 10
+
+    def test_perfect_gaussian(self):
+        pos_err = self.pos_err
+        positions = self.im.center + \
+                    np.random.random((self.N, self.im.ndim)) * pos_err * 2 - pos_err
+        for i, pos in enumerate(positions):
+            refine_single(self.im, self.diameter, self.separation, pos,
+                          self.var_size, self.var_signal, self.im.center)
+
+    def test_perfect_gaussian_noisy(self):
+        pos_err = self.pos_err
+        self.im.noise = 20
+        positions = self.im.center + \
+                    np.random.random((self.N, self.im.ndim)) * pos_err * 2 - pos_err
+        for i, pos in enumerate(positions):
+            refine_single(self.im, self.diameter, self.separation, pos,
+                          self.var_size, self.var_signal, self.im.center,
+                          noise_size=1, threshold=20, pos_atol=0.1,
+                          signal_rtol=1, size_rtol=1)
+
+    def test_disc_like(self):
+        self.im.feat_func = SimulatedImage.feat_hat
+        pos_err = self.pos_err
+        positions = self.im.center + \
+                    np.random.random((self.N, self.im.ndim)) * pos_err * 2 - pos_err
+        for i, pos in enumerate(positions):
+            for disc_size in [0.1, 0.2]:
+                self.im.feat_kwargs = dict(disc_size=disc_size)
+                refine_single(self.im, self.diameter, self.separation, pos,
+                              self.var_size, self.var_signal, self.im.center,
+                              pos_atol=0.2, signal_rtol=10, size_rtol=10)
+
+    def test_changing_size(self):
+        if not hasattr(self, 'size_err_factor'):
+            raise unittest.SkipTest()
+        size_min = self.size_err_factor[0]
+        size_range = self.size_err_factor[1] - size_min
+        size_err = np.random.random(self.N) * size_range + size_min
+        sizes = [[s * err for s in self.im.size] for err in size_err]
+
+        for i, size in enumerate(sizes):
+            # don't test signal, it will be different because of wrong size
+            refine_single(self.im, self.diameter, self.separation, None,
+                          self.var_size, self.var_signal, self.p0_pos, size,
+                          signal_rtol=10)
+
+    def test_changing_mass(self):
+        if not hasattr(self, 'signal_err_factor'):
+            raise unittest.SkipTest()
+        signal_min = self.signal_err_factor[0]
+        signal_range = self.signal_err_factor[1] - signal_min
+        signal_err = np.random.random(self.N) * signal_range + signal_min
+        signals = self.signal * signal_err
+        for i, signal in enumerate(signals):
+            refine_single(self.im, self.diameter, self.separation, None,
+                          self.var_size, self.var_signal, self.p0_pos, None,
+                          signal, size_rtol=1)
+
+    def test_dimer(self):
+        self.im.signal = 100
+        if self.im.ndim == 2:
+            angles = np.random.random(self.N) * 180
+        elif self.im.ndim == 3:
+            angles = np.random.random((self.N, 2)) * 180
+
+        for angle in angles:
+            for hard_radius in [0.8, 1., 1.2]:
+                self.im.clear()
+                self.im.draw_dimer(self.im.center, angle, hard_radius)
+
+                f0 = self.im.f(noise=1)
+                f0['cluster'] = 0
+                actual = tp.refine_gaussian(f0, self.im(), self.diameter,
+                                            self.separation, self.var_size,
+                                            self.var_signal,
+                                            self.im.pos_columns,
+                                            'frame', False, None)
+                assert np.all(actual['gaussian'])
+                assert_coordinates_close(actual[self.im.pos_columns].values,
+                                         self.im.coords, atol=0.1)
+                if self.var_signal:
+                    assert_allclose(actual['signal'], self.im.signal, rtol=0.05)
+                if self.var_size:
+                    if self.im.isotropic:
+                        assert_allclose(actual[self.im.size_columns[0]],
+                                        self.im.size[0], rtol=0.05)
+                    else:
+                        assert_allclose(actual[self.im.size_columns],
+                                        [self.im.size] * 2, rtol=0.05)
+
+    def tearDown(self):
+        pass
+
+
+class TestFit_gauss2D(TestSingle, unittest.TestCase):
+    shape = (128, 128)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = False
+    diameter = 21
+    pos_err = 7
+    p0_pos = [64.3, 64.9]
+    size_err_factor = [0.5, 2.]
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss2D_a(TestSingle, unittest.TestCase):
+    shape = (128, 64)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = False
+    diameter = (21, 15)
+    pos_err = [7, 4]
+    p0_pos = [64.3, 32.9]
+    size_err_factor = [0.8, 2.]
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss2D_signal(TestSingle, unittest.TestCase):
+    # in this test, the magnitude of signal is tested (5% tol)
+    shape = (128, 128)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = True
+    diameter = 21
+    pos_err = 9
+    p0_pos = [64.3, 64.9]
+    size_err_factor = [0.5, 2.]  # signal value is untested
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss2D_a_signal(TestSingle, unittest.TestCase):
+    shape = (128, 64)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = True
+    diameter = (21, 15)
+    pos_err = [9, 4]
+    p0_pos = [64.3, 32.9]
+    size_err_factor = [0.8, 2.]  # signal value is untested
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss2D_size(TestSingle, unittest.TestCase):
+    shape = (128, 128)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = False
+    diameter = 21
+    pos_err = 3  # size diverges easily when pos is not guessed accurately
+    p0_pos = [64.3, 64.9]
+    size_err_factor = [0.5, 2.]
+   # signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss2D_a_size(TestSingle, unittest.TestCase):
+    shape = (128, 64)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = False
+    diameter = (21, 15)
+    pos_err = [3, 1]  # size diverges easily when pos is not guessed accurately
+    p0_pos = [64.3, 32.9]
+    size_err_factor = [0.5, 2.]
+   # signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss2D_signal_size(TestSingle, unittest.TestCase):
+    shape = (128, 128)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = True
+    diameter = 21
+    pos_err = 2  # size diverges easily when pos is not guessed accurately
+    p0_pos = [64.3, 64.9]
+    size_err_factor = [0.5, 2.]
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss2D_a_signal_size(TestSingle, unittest.TestCase):
+    shape = (128, 64)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = True
+    diameter = (21, 15)
+    pos_err = [3, 1]  # size diverges easily when pos is not guessed accurately
+    p0_pos = [64.3, 32.9]
+    size_err_factor = [0.5, 2.]
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss3D(TestSingle, unittest.TestCase):
+    shape = (64, 64, 64)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = False
+    diameter = 21
+    pos_err = 5
+    p0_pos = [32.3, 32.9, 31.7]
+    size_err_factor = [0.5, 2.]
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss3D_a(TestSingle, unittest.TestCase):
+    shape = (64, 64, 32)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = False
+    diameter = (21, 21, 15)
+    pos_err = [5, 5, 2]
+    p0_pos = [32.3, 32.9, 16.7]
+    size_err_factor = [0.5, 2.]
+    signal_err_factor = [0.2, 5.]
+
+
+class TestFit_gauss3D_signal(TestSingle, unittest.TestCase):
+    shape = (64, 64, 64)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = True
+    diameter = 21
+    pos_err = 7
+    p0_pos = [32.3, 32.9, 31.7]
+    size_err_factor = [0.5, 2.] # signal value is untested
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss3D_a_signal(TestSingle, unittest.TestCase):
+    shape = (64, 64, 32)
+    fit_function = 'gauss'
+    var_size = False
+    var_signal = True
+    diameter = (21, 21, 15)
+    pos_err = [7, 7, 3]
+    p0_pos = [32.3, 32.9, 16.7]
+    size_err_factor = [0.8, 1.5] # signal value is untested
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss3D_size(TestSingle, unittest.TestCase):
+    shape = (64, 64, 64)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = False
+    diameter = 21
+    pos_err = 2
+    p0_pos = [32.3, 32.9, 31.7]
+    size_err_factor = [0.2, 5.]
+   # signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss3D_a_size(TestSingle, unittest.TestCase):
+    shape = (64, 64, 32)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = False
+    diameter = (21, 21, 15)
+    pos_err = [2, 2, 1]
+    p0_pos = [32.3, 32.9, 16.7]
+    size_err_factor = [0.5, 2]
+   # signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss3D_signal_size(TestSingle, unittest.TestCase):
+    shape = (64, 64, 64)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = True
+    diameter = 21
+    pos_err = 2
+    p0_pos = [32.3, 32.9, 31.7]
+    size_err_factor = [0.2, 5.]
+    signal_err_factor = [0.1, 10.]
+
+
+class TestFit_gauss3D_a_signal_size(TestSingle, unittest.TestCase):
+    shape = (64, 64, 32)
+    fit_function = 'gauss'
+    var_size = True
+    var_signal = True
+    diameter = (21, 21, 15)
+    pos_err = [2, 2, 1]
+    p0_pos = [32.3, 32.9, 16.7]
+    size_err_factor = [0.5, 2]
+    signal_err_factor = [0.1, 10.]
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb'], exit=False)

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -288,3 +288,11 @@ if is_pandas_since_017:
     pandas_sort = _pandas_sort_post_017
 else:
     pandas_sort = _pandas_sort_pre_017
+
+
+def guess_pos_columns(f):
+    if 'z' in f:
+        pos_columns = ['z', 'y', 'x']
+    else:
+        pos_columns = ['y', 'x']
+    return pos_columns


### PR DESCRIPTION
This implements feature or clusters of feature refinement by least-squares fitting to sums of Gaussians. The two most important routines are:

- `find_clusters`: Identify 'Clusters' in a DataFrame of features. Clusters are groups of features of which each feature overlaps with at least one of the other features.
- `refine_gaussian`: Apply least-squares Gaussian fits to single particles or clusters.

There are a couple of helper functions and tests in there, too.

It should be easy to extend the code to feature shapes other than Gaussians, as long as it has only two shape parameters: `signal` and `size`. This partially addresses #297.

