### PR TITLE
FIX Pandas indexing error in subtract_drift

### DIFF
--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -32,6 +32,7 @@ def conformity(df):
 
 
 def add_drift(df, drift):
+    df = df.copy()
     df['x'] = df['x'].add(drift['x'], fill_value=0)
     df['y'] = df['y'].add(drift['y'], fill_value=0)
     return df

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -7,6 +7,7 @@ import functools
 import re
 import sys
 import warnings
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from distutils.version import LooseVersion
 
@@ -288,3 +289,21 @@ if is_pandas_since_017:
     pandas_sort = _pandas_sort_post_017
 else:
     pandas_sort = _pandas_sort_pre_017
+
+@contextmanager
+def dataframe_reindex(df, column):
+    """Temporarily replace the index with `column`."""
+    old_index = df.index
+    df.set_index(column, drop=False, inplace=True)
+    yield df
+    df.set_index(old_index, drop=True)
+
+@contextmanager
+def dataframe_add_index(df, column):
+    """Add `column` as an extra index column, yielding a MultiIndex."""
+    if column in df.index.names:
+        yield df
+    else:
+        df.set_index(column, drop=False, inplace=True, append=True)
+        yield df
+        df.set_index(df.index.droplevel(column), drop=True, inplace=True)


### PR DESCRIPTION
By changing the indexing in #330, there was a bug introduced in `subtract_drift`:

    ValueError: cannot reindex from a duplicate axis

This solves the indexing problem by temporarily converting the dataframe to a MultiIndex using a context manager. I think this pattern might be used in other dataframe-related functions too.