### PR TITLE
BLD: Avoid buggy Pandas 0.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "3.4"
       env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow<3 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw"
     - python: "3.5"
-      env: DEPS="numpy scipy matplotlib pillow<3 pandas scikit-image pyyaml pytables numba"
+      env: DEPS="numpy scipy matplotlib pillow<3 pandas!=0.18.0 scikit-image pyyaml pytables numba"
 
 install:
   # See:


### PR DESCRIPTION
This is meant to address #354 and the problem in #352 by forbidding Pandas 0.18.0. See http://conda.pydata.org/docs/spec.html#build-version-spec