### PR TITLE
PERF Grey dilation

### DIFF
--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import warnings
 
+from .find import percentile_threshold, grey_dilation
 from .motion import msd, imsd, emsd, compute_drift, subtract_drift, \
            proximity, vanhove, relate_frames, velocity_corr, \
            direction_corr, is_typical, diagonal_size
@@ -15,7 +16,7 @@ from .linking import HashTable, TreeFinder, Point, PointND, \
            SubnetOversizeException, link, link_df, link_iter, \
            link_df_iter, strip_diagnostics
 from .filtering import filter_stubs, filter_clusters, filter
-from .feature import locate, batch, percentile_threshold, local_maxima, \
+from .feature import locate, batch, local_maxima, \
            refine, estimate_mass, estimate_size, minmass_version_change
 from .preprocessing import bandpass
 from .framewise_data import FramewiseData, PandasHDFStore, PandasHDFStoreBig, \

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -547,10 +547,10 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
     #   - Invalid output of the bandpass step ("smoothing_size")
     margin = tuple([max(rad, sep // 2 - 1, sm // 2) for (rad, sep, sm) in
                     zip(radius, separation, smoothing_size)])
-    # Find features with minimum separation distance of `diameter`. This enables
-    # detection of small features close to large, bright features using the
-    # `maxsize` argument.
-    coords = grey_dilation(image, diameter, percentile, margin, precise=False)
+    # Find features with minimum separation distance of `separation`. This
+    # excludes detection of small features close to large, bright features
+    # using the `maxsize` argument.
+    coords = grey_dilation(image, separation, percentile, margin, precise=False)
     count_maxima = coords.shape[0]
 
     if count_maxima == 0:

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -82,20 +82,23 @@ def minmass_version_change(raw_image, old_minmass, preprocess=True,
 
 def local_maxima(image, radius, percentile=64, margin=None):
     """Find local maxima whose brightness is above a given percentile.
+    This function has been deprecated. Please use the routines in trackpy.find,
+    with the minimum separation between features as second argument.
 
     Parameters
     ----------
     image : ndarray
         For best performance, provide an integer-type array. If the type is not
         of integer-type, the image will be normalized and coerced to uint8.
-    radius : integer definition of "local" in "local maxima"
+    radius : the radius of the circular grey dilation kernel, which is the
+        minimum separation between maxima
     percentile : chooses minimum grayscale value for a local maximum
     margin : zone of exclusion at edges of image. Defaults to radius.
             A smarter value is set by locate().
     """
     warnings.warn("Local_maxima will be deprecated: please use routines in "
                   "trackpy.find", DeprecationWarning)
-    return grey_dilation(image, [r * 2 + 1 for r in radius], percentile, margin)
+    return grey_dilation(image, radius, percentile, margin)
 
 
 def estimate_mass(image, radius, coord):
@@ -544,7 +547,10 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
     #   - Invalid output of the bandpass step ("smoothing_size")
     margin = tuple([max(rad, sep // 2 - 1, sm // 2) for (rad, sep, sm) in
                     zip(radius, separation, smoothing_size)])
-    coords = grey_dilation(image, separation, percentile, margin)
+    # Find features with minimum separation distance of `diameter`. This enables
+    # detection of small features close to large, bright features using the
+    # `maxsize` argument.
+    coords = grey_dilation(image, diameter, percentile, margin, precise=False)
     count_maxima = coords.shape[0]
 
     if count_maxima == 0:

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -6,7 +6,6 @@ import logging
 
 import numpy as np
 import pandas as pd
-from scipy import ndimage
 from pandas import DataFrame
 
 from .preprocessing import (bandpass, convert_to_int, invert_image,
@@ -82,7 +81,7 @@ def minmass_version_change(raw_image, old_minmass, preprocess=True,
 
 def local_maxima(image, radius, percentile=64, margin=None):
     """Find local maxima whose brightness is above a given percentile.
-    This function has been deprecated. Please use the routines in trackpy.find,
+    This function will be deprecated. Please use the routines in trackpy.find,
     with the minimum separation between features as second argument.
 
     Parameters
@@ -97,7 +96,7 @@ def local_maxima(image, radius, percentile=64, margin=None):
             A smarter value is set by locate().
     """
     warnings.warn("Local_maxima will be deprecated: please use routines in "
-                  "trackpy.find", DeprecationWarning)
+                  "trackpy.find", PendingDeprecationWarning)
     return grey_dilation(image, radius, percentile, margin)
 
 

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -544,7 +544,7 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
     #   - Invalid output of the bandpass step ("smoothing_size")
     margin = tuple([max(rad, sep // 2 - 1, sm // 2) for (rad, sep, sm) in
                     zip(radius, separation, smoothing_size)])
-    coords = grey_dilation(image, radius, percentile, margin)
+    coords = grey_dilation(image, separation, percentile, margin)
     count_maxima = coords.shape[0]
 
     if count_maxima == 0:

--- a/trackpy/find.py
+++ b/trackpy/find.py
@@ -44,7 +44,7 @@ def where_close(pos, separation, intensity=None):
         if np.any(edge_cases):
             index_0 = index_0[edge_cases]
             index_1 = index_1[edge_cases]
-            to_drop[edge_cases] = np.where(np.sum(pos_rescaled[index_0], 1) <
+            to_drop[edge_cases] = np.where(np.sum(pos_rescaled[index_0], 1) >
                                            np.sum(pos_rescaled[index_1], 1),
                                            index_1, index_0)
     return np.unique(to_drop)

--- a/trackpy/find.py
+++ b/trackpy/find.py
@@ -1,0 +1,162 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import six
+import warnings
+import logging
+
+import numpy as np
+from scipy import ndimage
+from scipy.spatial import cKDTree
+
+from .utils import validate_tuple
+
+from .masks import binary_mask
+
+logger = logging.getLogger(__name__)
+
+
+def where_close(pos, separation, intensity=None):
+    """ Returns indices of features that are closer than separation from other
+    features. When intensity is given, the one with the lowest intensity is
+    returned: else the most topleft is returned (to avoid randomness)"""
+    if len(pos) == 0:
+        return []
+    separation = validate_tuple(separation, pos.shape[1])
+    if any([s == 0 for s in separation]):
+        return []
+    # Rescale positions, so that pairs are identified below a distance
+    # of 1.
+    pos_rescaled = pos / separation
+    duplicates = cKDTree(pos_rescaled, 30).query_pairs(1)
+    if len(duplicates) == 0:
+        return []
+    index_0 = np.fromiter((x[0] for x in duplicates), dtype=int)
+    index_1 = np.fromiter((x[1] for x in duplicates), dtype=int)
+    if intensity is None:
+        to_drop = np.where(np.sum(pos_rescaled[index_0], 1) >
+                           np.sum(pos_rescaled[index_1], 1),
+                           index_1, index_0)
+    else:
+        intensity_0 = intensity[index_0]
+        intensity_1 = intensity[index_1]
+        to_drop = np.where(intensity_0 > intensity_1, index_1, index_0)
+        edge_cases = intensity_0 == intensity_1
+        if np.any(edge_cases):
+            index_0 = index_0[edge_cases]
+            index_1 = index_1[edge_cases]
+            to_drop[edge_cases] = np.where(np.sum(pos_rescaled[index_0], 1) <
+                                           np.sum(pos_rescaled[index_1], 1),
+                                           index_1, index_0)
+    return np.unique(to_drop)
+
+
+def drop_close(pos, separation, intensity=None):
+    """ Removes features that are closer than separation from other features.
+    When intensity is given, the one with the lowest intensity is dropped:
+    else the most topleft is dropped (to avoid randomness)"""
+    to_drop = where_close(pos, separation, intensity)
+    return np.delete(pos, to_drop, axis=0)
+
+
+def percentile_threshold(image, percentile):
+    """Find grayscale threshold based on distribution in image."""
+
+    not_black = image[np.nonzero(image)]
+    if len(not_black) == 0:
+        return np.nan
+    return np.percentile(not_black, percentile)
+
+
+def grey_dilation(image, separation, percentile=64, margin=None):
+    """Find local maxima whose brightness is above a given percentile.
+
+    Parameters
+    ----------
+    separation : minimum separation between maxima
+    percentile : chooses minimum grayscale value for a local maximum
+    margin : zone of exclusion at edges of image. Defaults to separation.
+            A smarter value is set by locate().
+    """
+    if not np.issubdtype(image.dtype, np.integer):
+        factor = 255 / image.max()
+        image = (factor * image.clip(min=0.)).astype(np.uint8)
+
+    ndim = image.ndim
+    separation = validate_tuple(separation, ndim)
+    if margin is None:
+        margin = tuple([int(s / 2) for s in separation])
+
+    # Compute a threshold based on percentile.
+    threshold = percentile_threshold(image, percentile)
+    if np.isnan(threshold):
+        warnings.warn("Image is completely black.", UserWarning)
+        return np.empty((0, ndim))
+
+    # Find the smallest box that fits inside the ellipse given by separation
+    size = [int(s / np.sqrt(ndim)) for s in separation]
+
+    # The intersection of the image with its dilation gives local maxima.
+    dilation = ndimage.grey_dilation(image, size, mode='constant')
+    maxima = (image == dilation) & (image > threshold)
+    if np.sum(maxima) == 0:
+        warnings.warn("Image contains no local maxima.", UserWarning)
+        return np.empty((0, ndim))
+
+    pos = np.vstack(np.where(maxima)).T
+
+    # Do not accept peaks near the edges.
+    shape = np.array(image.shape)
+    near_edge = np.any((pos < margin) | (pos > (shape - margin - 1)), 1)
+    pos = pos[~near_edge]
+
+    if len(pos) == 0:
+        warnings.warn("All local maxima were in the margins.", UserWarning)
+        return np.empty((0, ndim))
+
+    # Remove local maxima that are too close to each other
+    pos = drop_close(pos, separation, image[maxima][~near_edge])
+
+    return pos
+
+
+def grey_dilation_legacy(image, radius, percentile=64, margin=None):
+    """Find local maxima whose brightness is above a given percentile.
+
+    Parameters
+    ----------
+    radius : integer definition of "local" in "local maxima"
+    percentile : chooses minimum grayscale value for a local maximum
+    margin : zone of exclusion at edges of image. Defaults to radius.
+            A smarter value is set by locate().
+    """
+    if margin is None:
+        margin = radius
+
+    ndim = image.ndim
+    # Compute a threshold based on percentile.
+    threshold = percentile_threshold(image, percentile)
+    if np.isnan(threshold):
+        warnings.warn("Image is completely black.", UserWarning)
+        return np.empty((0, ndim))
+
+    # The intersection of the image with its dilation gives local maxima.
+    if not np.issubdtype(image.dtype, np.integer):
+        raise TypeError("Perform dilation on exact (i.e., integer) data.")
+    footprint = binary_mask(radius, ndim)
+    dilation = ndimage.grey_dilation(image, footprint=footprint,
+                                     mode='constant')
+    maxima = np.vstack(np.where((image == dilation) & (image > threshold))).T
+    if not np.size(maxima) > 0:
+        warnings.warn("Image contains no local maxima.", UserWarning)
+        return np.empty((0, ndim))
+
+    # Do not accept peaks near the edges.
+    shape = np.array(image.shape)
+    near_edge = np.any((maxima < margin) | (maxima > (shape - margin - 1)), 1)
+    maxima = maxima[~near_edge]
+    if not np.size(maxima) > 0:
+        warnings.warn("All local maxima were in the margins.", UserWarning)
+
+    # Return coords in as a numpy array shaped so it can be passed directly
+    # to the DataFrame constructor.
+    return maxima

--- a/trackpy/find.py
+++ b/trackpy/find.py
@@ -93,7 +93,7 @@ def grey_dilation(image, separation, percentile=64, margin=None):
         return np.empty((0, ndim))
 
     # Find the smallest box that fits inside the ellipse given by separation
-    size = [int(s / np.sqrt(ndim)) for s in separation]
+    size = [int(2 * s / np.sqrt(ndim)) for s in separation]
 
     # The intersection of the image with its dilation gives local maxima.
     dilation = ndimage.grey_dilation(image, size, mode='constant')
@@ -124,8 +124,9 @@ def grey_dilation_legacy(image, radius, percentile=64, margin=None):
 
     Parameters
     ----------
-    radius : integer definition of "local" in "local maxima"
-    percentile : chooses minimum grayscale value for a local maximum
+    radius : the radius of the circular grey dilation kernel, half the minimum
+        separation between maxima
+    percentile : chooses minimum greyscale value for a local maximum
     margin : zone of exclusion at edges of image. Defaults to radius.
             A smarter value is set by locate().
     """

--- a/trackpy/find.py
+++ b/trackpy/find.py
@@ -159,9 +159,11 @@ def grey_dilation_legacy(image, separation, percentile=64, margin=None):
         warnings.warn("Image is completely black.", UserWarning)
         return np.empty((0, ndim))
 
-    # The intersection of the image with its dilation gives local maxima.
     if not np.issubdtype(image.dtype, np.integer):
-        raise TypeError("Perform dilation on exact (i.e., integer) data.")
+        factor = 255 / image.max()
+        image = (factor * image.clip(min=0.)).astype(np.uint8)
+
+    # The intersection of the image with its dilation gives local maxima
     footprint = binary_mask(separation, ndim)
     dilation = ndimage.grey_dilation(image, footprint=footprint,
                                      mode='constant')

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 from numpy.testing import (assert_almost_equal, assert_allclose,
-                           assert_array_less)
+                           assert_array_less, assert_equal)
 from numpy.testing.decorators import slow
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_produces_warning)
@@ -51,6 +51,12 @@ def sort_positions(actual, expected):
         raise AssertionError("Position sorting failed. At least one feature is "
                              "very far from where it should be.")
     return deviations, actual[argsort][0]
+
+
+def assert_coordinates_close(actual, expected, atol):
+    assert_equal(len(actual), len(expected))
+    _, sorted_actual = sort_positions(actual, expected)
+    assert_allclose(sorted_actual, expected, atol)
 
 
 class OldMinmass(unittest.TestCase):

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -528,21 +528,21 @@ class CommonFeatureIdentificationTests(object):
 
         # filter on mass
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
-                           minmass=6500)[cols]
+                           minmass=6500, separation=10)[cols]
         actual = pandas_sort(actual, cols)
         expected = pandas_sort(DataFrame([pos2, pos4], columns=cols), cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         # filter on size
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
-                           maxsize=3.0)[cols]
+                           maxsize=3.0, separation=10)[cols]
         actual = pandas_sort(actual, cols)
         expected = pandas_sort(DataFrame([pos1, pos3], columns=cols), cols)
         assert_allclose(actual, expected, atol=PRECISION)
 
         # filter on both mass and size
         actual = tp.locate(image, 15, engine=self.engine, preprocess=False,
-                           minmass=600, maxsize=4.0)[cols]
+                           minmass=600, maxsize=4.0, separation=10)[cols]
         actual = pandas_sort(actual, cols)
         expected = pandas_sort(DataFrame([pos1, pos4], columns=cols), cols)
         assert_allclose(actual, expected, atol=PRECISION)

--- a/trackpy/tests/test_find.py
+++ b/trackpy/tests/test_find.py
@@ -79,6 +79,23 @@ class TestFindGreyDilation(unittest.TestCase):
             f = grey_dilation(im, (11, 21))
             assert_coordinates_close(f, pos[1:], atol=1)
 
+    def test_float_image(self):
+        separation = 20
+        angle = 45
+        im = np.zeros((128, 128), dtype=np.float64)
+        pos = [[64, 64], [64 + separation * np.sin(angle/180*np.pi),
+                          64 + separation * np.cos(angle/180*np.pi)]]
+
+        # setup features: features with equal signal will always be
+        # detected by a grey dilation, so make them unequal
+        draw_feature(im, pos[0], 15, 240)
+        draw_feature(im, pos[1], 15, 250)
+
+        # find both of them
+        f = grey_dilation(im, separation - 1, precise=False)
+        assert_coordinates_close(f, pos, atol=1)
+
+
 
 class TestFindGreyDilationLegacy(unittest.TestCase):
     def test_separation(self):

--- a/trackpy/tests/test_find.py
+++ b/trackpy/tests/test_find.py
@@ -1,0 +1,108 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import six
+import unittest
+import numpy as np
+
+import trackpy as tp
+from trackpy.artificial import draw_feature
+from trackpy.tests.test_feature import assert_coordinates_close
+from trackpy.find import grey_dilation, grey_dilation_legacy
+from pandas.util.testing import assert_produces_warning
+
+class TestFindGreyDilation(unittest.TestCase):
+    def test_separation_fast(self):
+        separation = 20
+        for angle in np.arange(0, 360, 15):
+            im = np.zeros((128, 128), dtype=np.uint8)
+            pos = [[64, 64], [64 + separation * np.sin(angle/180*np.pi),
+                              64 + separation * np.cos(angle/180*np.pi)]]
+
+            # setup features: features with equal signal will always be
+            # detected by a grey dilation, so make them unequal
+            draw_feature(im, pos[0], 15, 240)
+            draw_feature(im, pos[1], 15, 250)
+
+            # find both of them
+            f = grey_dilation(im, separation - 1, precise=False)
+            assert_coordinates_close(f, pos, atol=1)
+
+            # find only the brightest
+            if angle in [45, 135, 225, 315]:
+                # for unprecise, a too small square kernel is used, which is
+                # perfect for 45-degree angles
+                f = grey_dilation(im, separation + 1, precise=False)
+                assert_coordinates_close(f, pos[1:], atol=1)
+            else:
+                # but too small by a factor of sqrt(ndim) for 90-degree angles
+                f = grey_dilation(im, separation*np.sqrt(2) + 1, precise=False)
+                assert_coordinates_close(f, pos[1:], atol=1)
+
+
+    def test_separation(self):
+        separation = 20
+        for angle in np.arange(0, 360, 15):
+            im = np.zeros((128, 128), dtype=np.uint8)
+            pos = [[64, 64], [64 + separation * np.sin(angle/180*np.pi),
+                              64 + separation * np.cos(angle/180*np.pi)]]
+
+            # setup features: features with equal signal will always be
+            # detected by a grey dilation, so make them unequal
+            draw_feature(im, pos[0], 15, 240)
+            draw_feature(im, pos[1], 15, 250)
+
+            # find both of them
+            f = grey_dilation(im, separation - 1)
+            assert_coordinates_close(f, pos, atol=1)
+
+            # find only the brightest
+            f = grey_dilation(im, separation + 1)
+            assert_coordinates_close(f, pos[1:], atol=1)
+
+    def test_separation_anisotropic(self):
+        separation = (10, 20)
+        for angle in np.arange(0, 360, 15):
+            im = np.zeros((128, 128), dtype=np.uint8)
+            pos = [[64, 64], [64 + separation[0] * np.sin(angle/180*np.pi),
+                              64 + separation[1] * np.cos(angle/180*np.pi)]]
+
+            # setup features: features with equal signal will always be
+            # detected by a grey dilation, so make them unequal
+            draw_feature(im, pos[0], 15, 240)
+            draw_feature(im, pos[1], 15, 250)
+
+            # find both of them
+            f = grey_dilation(im, (9, 19))
+            assert_coordinates_close(f, pos, atol=1)
+
+            # find only the brightest
+            f = grey_dilation(im, (11, 21))
+            assert_coordinates_close(f, pos[1:], atol=1)
+
+
+class TestFindGreyDilationLegacy(unittest.TestCase):
+    def test_separation(self):
+        separation = 20
+        for angle in np.arange(0, 360, 15):
+            im = np.zeros((128, 128), dtype=np.uint8)
+            pos = [[64, 64], [64 + separation * np.sin(angle/180*np.pi),
+                              64 + separation * np.cos(angle/180*np.pi)]]
+
+            # setup features: features with equal signal will always be
+            # detected by grey_dilation_legacy, so make them unequal
+            draw_feature(im, pos[0], 15, 240)
+            draw_feature(im, pos[1], 15, 250)
+
+            # find both of them
+            f = grey_dilation_legacy(im, separation - 1)
+            assert_coordinates_close(f, pos, atol=1)
+
+            # find only the brightest
+            f = grey_dilation_legacy(im, separation + 1)
+            assert_coordinates_close(f, pos[1:], atol=1)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)


### PR DESCRIPTION
As discussed, here a different `local_maxima` that does a grey dilation with a rectangular kernel, instead of a square one. Directly after, it eliminates duplicates using a KDTree.

I also refactored the code a bit in view of #257  : the `find_maxima` is renamed and moved to `find.py`.