### PR TITLE
BLD Forced doc update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,9 @@ after_success:
         git checkout --orphan temp_branch
         git rm -rf ./dev
         mv $TRAVIS_BUILD_DIR/doc/_build/html ./dev
+        if [ -n "$TRAVIS_TAG" ]; then
+          cp -R dev $TRAVIS_TAG;
+        fi
         git add -A
         git commit -m "Docs build of trackpy commit $TRAVIS_COMMIT"
         git branch -D master

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,15 +63,18 @@ after_success:
         eval `ssh-agent -s`
         chmod 600 soft-matter-docs-deploy
         ssh-add soft-matter-docs-deploy
-        cd ..
-        git clone git@github.com:soft-matter/soft-matter.github.io.git ./doc-repo
-        cd doc-repo/trackpy
-        git rm -rf ./dev
-        mv $TRAVIS_BUILD_DIR/doc/_build/html ./dev
         git config --global user.email "Travis@nomail"
         git config --global user.name "Travis"
         git config --global push.default simple
-        git add .
+        cd ..
+        git clone git@github.com:soft-matter/soft-matter.github.io.git ./doc-repo
+        cd doc-repo/trackpy
+        git checkout --orphan temp_branch
+        git rm -rf ./dev
+        mv $TRAVIS_BUILD_DIR/doc/_build/html ./dev
+        git add -A
         git commit -m "Docs build of trackpy commit $TRAVIS_COMMIT"
-        git push --set-upstream origin master
+        git branch -D master
+        git branch -m master
+        git push --set-upstream origin master --force
       fi


### PR DESCRIPTION
This lets Travis wipe the doc history on each new build and finishes the automatic doc builds.

Generating the tutorials was a pain, I succeeded doing it by adapting the makefile for the notebooks (@danielballan). It now generates an html instead of an rst, together with a new rst that includes the html (see #364). In this way, the notebook gets converted to html in one step. I think this is better, but additionally it removes the need for pandoc on travis, which was problematic.

See for instance http://soft-matter.github.io/trackpy/dev/tutorial/walkthrough.html of the automatically generated notebook. The annoying thing is this `-e walkthrough` at the top, I can't get rid of it because Sphinx requires a title for each document.

I had to manually insert neat titles for each tutorial notebook, please check http://soft-matter.github.io/trackpy/dev/ and say if you agree on the titles.