### PR TITLE
BUG: Prediction fails on empty frames

### DIFF
--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -86,6 +86,14 @@ class VelocityPredictTests(object):
                                 pred.link_df_iter, 0.45)
         assert all(ll.values == 3)
 
+    def test_empty_predict(self):
+        """Check what happens if there is an empty frame"""
+        pred = self.predict_class()
+        empty = pandas.DataFrame({'x': [], 'y': [], 'frame': []})
+        ll = get_linked_lengths((self.mkframe(0), self.mkframe(0.25), empty, self.mkframe(0.65)),
+                                pred.link_df_iter, 0.45)
+        assert all(ll.values == 3)
+
     def test_big_predict(self):
         Nside = Nside_oversize
         pred = self.predict_class()


### PR DESCRIPTION
This adds a test that points out an unwanted behavior: prediction fails on empty frames. It should at least print an informative error message; instead we just get an `IndexError` when `link()` tries to read the frame number by inspecting the first particle.

I am leaving this open without a fix for now, because I'd like to revisit it when I/we finish #333.