### PR TITLE
BUG: Fix dtype segfault in prediction

### DIFF
--- a/trackpy/predict.py
+++ b/trackpy/predict.py
@@ -101,7 +101,7 @@ class _RecentVelocityPredict(NullPredict):
             self.recent_frames.append(pframe)
             dt = 1. # Avoid dividing by zero
         else: # Not the first frame
-            dt = (self.recent_frames[-1][self.t_column].values[0] -
+            dt = float(self.recent_frames[-1][self.t_column].values[0] -
                  self.recent_frames[0][self.t_column].values[0])
 
         # Compute velocity field


### PR DESCRIPTION
This is the result of a morning spent tracking down a segfault. Apparently pandas doesn't like it when a `float64` DataFrame is divided by a scalar of dtype `numpy.uint32`. I am *planning* to create a pandas issue, but for now, this should be a harmless fix.

Further details to reproduce: trackpy 0.3.0, Ubuntu 64bit, dependencies as follows

```
OrderedDict([(u'six', '1.10.0'),
             (u'numpy', '1.10.4'),
             (u'scipy', '0.17.0'),
             (u'matplotlib', '1.5.1'),
             (u'pandas', u'0.18.1'),
             (u'scikit-image', None),
             (u'pyyaml', None),
             (u'pytables', None),
             (u'numba', '0.24.0'),
             (u'pyfftw', None),
             (u'python', u'2.7.11')])
```