### PR TITLE
DOC New zenodo badge and doc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 trackpy
 =======
 
-[![build status](https://travis-ci.org/soft-matter/trackpy.png?branch=master)](https://travis-ci.org/soft-matter/trackpy) [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.34028.svg)](http://dx.doi.org/10.5281/zenodo.34028)
+[![build status](https://travis-ci.org/soft-matter/trackpy.png?branch=master)](https://travis-ci.org/soft-matter/trackpy) [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.55143.svg)](http://dx.doi.org/10.5281/zenodo.55143)
 
 What is it?
 -----------

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -73,6 +73,7 @@ please include a link to the github repository:
 ================= ================================================= ====================
 Release (version) Zenodo Record Pages with info and citations       DOI
 ================= ================================================= ====================
+v0.3.1            `Record Page <https://zenodo.org/record/55143>`__ 10.5281/zenodo.55143
 v0.3.0            `Record Page <https://zenodo.org/record/34028>`__ 10.5281/zenodo.34028
 v0.2.4            `Record Page <https://zenodo.org/record/12255>`__ 10.5281/zenodo.12255
 v0.2.3            `Record Page <https://zenodo.org/record/11956>`__ 10.5281/zenodo.11956


### PR DESCRIPTION
We have to start doing before the release or else it will not be incorporated in the doc build. I am actually in favor of doing this manually anyway because it allows for correctly mentioning all the contributors. I turned the zenodo webhooks off for now.