### PR TITLE
FIX Major bugfix in python refinement

### DIFF
--- a/doc/releases/v0.3.1.txt
+++ b/doc/releases/v0.3.1.txt
@@ -16,6 +16,8 @@ Enhancements
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in the python refinement code was solved: feature finding with `engine='python'` is now more accurate.  (:issue:`#377`)
+
 - Error in `subtract_drift` is solved (:issue:`#351`)
 
 - Legends are disabled by default in plotting (:issue:`#357`)

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -316,7 +316,7 @@ def _refine(raw_image, image, radius, coords, max_iterations,
 
     ndim = image.ndim
     isotropic = np.all(radius[1:] == radius[:-1])
-    mask = binary_mask(radius, ndim)
+    mask = binary_mask(radius, ndim).astype(np.uint8)
     slices = [[slice(int(round(c - rad)), int(round(c + rad + 1)))
                for c, rad in zip(coord, radius)]
               for coord in coords]

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -317,7 +317,8 @@ def _refine(raw_image, image, radius, coords, max_iterations,
     ndim = image.ndim
     isotropic = np.all(radius[1:] == radius[:-1])
     mask = binary_mask(radius, ndim)
-    slices = [[slice(c - rad, c + rad + 1) for c, rad in zip(coord, radius)]
+    slices = [[slice(int(round(c - rad)), int(round(c + rad + 1)))
+               for c, rad in zip(coord, radius)]
               for coord in coords]
 
     # Declare arrays that we will fill iteratively through loop.
@@ -361,18 +362,19 @@ def _refine(raw_image, image, radius, coords, max_iterations,
                 upper_bound = np.array(image.shape) - 1 - radius
                 new_coord = np.clip(new_coord, radius, upper_bound).astype(int)
                 # Update slice to shifted position.
-                rect = [slice(c - rad, c + rad + 1)
+                rect = [slice(int(round(c - rad)), int(round(c + rad + 1)))
                         for c, rad in zip(new_coord, radius)]
                 neighborhood = mask*image[rect]
 
             # If we're off by less than half a pixel, interpolate.
             else:
-                # Here, coord is a float. We are off the grid.
-                neighborhood = ndimage.shift(neighborhood, -off_center,
-                                             order=2, mode='constant', cval=0)
-                new_coord = coord + off_center
-                # Disallow any whole-pixels moves on future iterations.
-                allow_moves = False
+                break
+                # # Here, coord is a float. We are off the grid.
+                # neighborhood = ndimage.shift(neighborhood, -off_center,
+                #                              order=2, mode='constant', cval=0)
+                # new_coord = coord + off_center
+                # # Disallow any whole-pixels moves on future iterations.
+                # allow_moves = False
 
             cm_n = _safe_center_of_mass(neighborhood, radius, ogrid)  # neighborhood
             cm_i = cm_n - radius + new_coord  # image coords

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -155,7 +155,7 @@ def _safe_center_of_mass(x, radius, grids):
 
 
 def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
-           engine='auto', shift_thresh=0.6, break_thresh=0.005,
+           engine='auto', shift_thresh=0.6, break_thresh=None,
            characterize=True, walkthrough=False):
     """Find the center of mass of a bright feature starting from an estimate.
 
@@ -184,14 +184,16 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
         shift mask to neighboring pixel. The new mask will be used for any
         remaining iterations.
     break_thresh : float, optional
-        Default: 0.005 (unit is pixels).
-        When the subpixel refinement along all dimensions is less than this
-        number, declare victory and stop refinement.
+        Deprecated
     characterize : boolean, True by default
         Compute and return mass, size, eccentricity, signal.
     walkthrough : boolean, False by default
         Print the offset on each loop and display final neighborhood image.
     """
+    if break_thresh is not None:
+        warnings.warn("break_threshold will be deprecated: shift_threshold is"
+                      "the only parameter that determines when to shift the"
+                      "mask.")
     # ensure that radius is tuple of integers, for direct calls to refine()
     radius = validate_tuple(radius, image.ndim)
     separation = validate_tuple(separation, image.ndim)
@@ -201,10 +203,13 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
             engine = 'numba'
         else:
             engine = 'python'
+
+    # In here, coord is an integer. Make a copy, will not modify inplace.
+    coords = np.round(coords).astype(np.int)
+
     if engine == 'python':
-        coords = np.array(coords)  # a copy, will not modify in place
         results = _refine(raw_image, image, radius, coords, max_iterations,
-                          shift_thresh, break_thresh, characterize, walkthrough)
+                          shift_thresh, characterize, walkthrough)
     elif engine == 'numba':
         if not NUMBA_AVAILABLE:
             warnings.warn("numba could not be imported. Without it, the "
@@ -217,7 +222,6 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
         if walkthrough:
             raise ValueError("walkthrough is not availabe in the numba engine")
         # Do some extra prep in pure Python that can't be done in numba.
-        coords = np.array(coords, dtype=np.float64)
         N = coords.shape[0]
         mask = binary_mask(radius, image.ndim)
         if image.ndim == 3:
@@ -238,34 +242,33 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
                                              dtype=np.int16)
             _numba_refine_3D(np.asarray(raw_image), np.asarray(image),
                              radius[0], radius[1], radius[2], coords, N,
-                             int(max_iterations), shift_thresh, break_thresh,
+                             int(max_iterations), shift_thresh,
                              characterize,
                              image.shape[0], image.shape[1], image.shape[2],
                              maskZ, maskY, maskX, maskX.shape[0],
                              r2_mask, z2_mask, y2_mask, x2_mask, results)
         elif not characterize:
-            mask_coordsY, mask_coordsX = np.asarray(mask.nonzero(), dtype=np.int16)
+            mask_coordsY, mask_coordsX = np.asarray(mask.nonzero(), np.int16)
             results = np.empty((N, 3), dtype=np.float64)
-            _numba_refine_2D(np.asarray(raw_image), np.asarray(image),
-                             radius[0], radius[1], coords, N,
-                             int(max_iterations), shift_thresh, break_thresh,
+            _numba_refine_2D(np.asarray(image), radius[0], radius[1], coords, N,
+                             int(max_iterations), shift_thresh,
                              image.shape[0], image.shape[1],
                              mask_coordsY, mask_coordsX, mask_coordsY.shape[0],
                              results)
         elif radius[0] == radius[1]:
-            mask_coordsY, mask_coordsX = np.asarray(mask.nonzero(), dtype=np.int16)
+            mask_coordsY, mask_coordsX = np.asarray(mask.nonzero(), np.int16)
             results = np.empty((N, 7), dtype=np.float64)
             r2_mask = r_squared_mask(radius, image.ndim)[mask]
             cmask = cosmask(radius)[mask]
             smask = sinmask(radius)[mask]
             _numba_refine_2D_c(np.asarray(raw_image), np.asarray(image),
                                radius[0], radius[1], coords, N,
-                               int(max_iterations), shift_thresh, break_thresh,
-                               image.shape[0], image.shape[1],
-                               mask_coordsY, mask_coordsX, mask_coordsY.shape[0],
+                               int(max_iterations), shift_thresh,
+                               image.shape[0], image.shape[1], mask_coordsY,
+                               mask_coordsX, mask_coordsY.shape[0],
                                r2_mask, cmask, smask, results)
         else:
-            mask_coordsY, mask_coordsX = np.asarray(mask.nonzero(), dtype=np.int16)
+            mask_coordsY, mask_coordsX = np.asarray(mask.nonzero(), np.int16)
             results = np.empty((N, 8), dtype=np.float64)
             x2_masks = x_squared_masks(radius, image.ndim)
             y2_mask = image.ndim * x2_masks[0][mask]
@@ -275,8 +278,8 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
             _numba_refine_2D_c_a(np.asarray(raw_image), np.asarray(image),
                                  radius[0], radius[1], coords, N,
                                  int(max_iterations), shift_thresh,
-                                 break_thresh, image.shape[0], image.shape[1],
-                                 mask_coordsY, mask_coordsX, mask_coordsY.shape[0],
+                                 image.shape[0], image.shape[1], mask_coordsY,
+                                 mask_coordsX, mask_coordsY.shape[0],
                                  y2_mask, x2_mask, cmask, smask, results)
     else:
         raise ValueError("Available engines are 'python' and 'numba'")
@@ -312,14 +315,12 @@ def refine(raw_image, image, radius, coords, separation=0, max_iterations=10,
 
 # (This is pure Python. A numba variant follows below.)
 def _refine(raw_image, image, radius, coords, max_iterations,
-            shift_thresh, break_thresh, characterize, walkthrough):
-
+            shift_thresh, characterize, walkthrough):
+    if not np.issubdtype(coords.dtype, np.int):
+        raise ValueError('The coords array should be of integer datatype')
     ndim = image.ndim
     isotropic = np.all(radius[1:] == radius[:-1])
     mask = binary_mask(radius, ndim).astype(np.uint8)
-    slices = [[slice(int(round(c - rad)), int(round(c + rad + 1)))
-               for c, rad in zip(coord, radius)]
-              for coord in coords]
 
     # Declare arrays that we will fill iteratively through loop.
     N = coords.shape[0]
@@ -337,48 +338,25 @@ def _refine(raw_image, image, radius, coords, max_iterations,
     ogrid = np.ogrid[[slice(0, i) for i in mask.shape]]  # for center of mass
     ogrid = [g.astype(float) for g in ogrid]
 
-    for feat in range(N):
-        coord = coords[feat]
-
-        # Define the circular neighborhood of (x, y).
-        rect = slices[feat]
-        neighborhood = mask*image[rect]
-        cm_n = _safe_center_of_mass(neighborhood, radius, ogrid)
-        cm_i = cm_n - radius + coord  # image coords
-        allow_moves = True
+    for feat, coord in enumerate(coords):
         for iteration in range(max_iterations):
+            # Define the circular neighborhood of (x, y).
+            rect = [slice(c - r, c + r + 1) for c, r in zip(coord, radius)]
+            neighborhood = mask*image[rect]
+            cm_n = _safe_center_of_mass(neighborhood, radius, ogrid)
+            cm_i = cm_n - radius + coord  # image coords
+
             off_center = cm_n - radius
             logger.debug('off_center: %f', off_center)
-            if np.all(np.abs(off_center) < break_thresh):
+            if np.all(np.abs(off_center) < shift_thresh):
                 break  # Accurate enough.
+            # If we're off by more than half a pixel in any direction, move..
+            coord[off_center > shift_thresh] += 1
+            coord[off_center < -shift_thresh] -= 1
+            # Don't move outside the image!
+            upper_bound = np.array(image.shape) - 1 - radius
+            coord = np.clip(coord, radius, upper_bound).astype(int)
 
-            # If we're off by more than half a pixel in any direction, move.
-            elif np.any(np.abs(off_center) > shift_thresh) & allow_moves:
-                # In here, coord is an integer.
-                new_coord = coord
-                new_coord[off_center > shift_thresh] += 1
-                new_coord[off_center < -shift_thresh] -= 1
-                # Don't move outside the image!
-                upper_bound = np.array(image.shape) - 1 - radius
-                new_coord = np.clip(new_coord, radius, upper_bound).astype(int)
-                # Update slice to shifted position.
-                rect = [slice(int(round(c - rad)), int(round(c + rad + 1)))
-                        for c, rad in zip(new_coord, radius)]
-                neighborhood = mask*image[rect]
-
-            # If we're off by less than half a pixel, interpolate.
-            else:
-                break
-                # # Here, coord is a float. We are off the grid.
-                # neighborhood = ndimage.shift(neighborhood, -off_center,
-                #                              order=2, mode='constant', cval=0)
-                # new_coord = coord + off_center
-                # # Disallow any whole-pixels moves on future iterations.
-                # allow_moves = False
-
-            cm_n = _safe_center_of_mass(neighborhood, radius, ogrid)  # neighborhood
-            cm_i = cm_n - radius + new_coord  # image coords
-            coord = new_coord
         # matplotlib and ndimage have opposite conventions for xy <-> yx.
         final_coords[feat] = cm_i[..., ::-1]
 

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -441,6 +441,15 @@ class CommonFeatureIdentificationTests(object):
         assert len(f_nc.columns) == 3
         assert_allclose(f_c.values[:, :3], f_nc.values)
 
+    def test_nocharacterize_a(self):
+        pos = gen_nonoverlapping_locations((200, 300), 9, 5)
+        image = draw_spots((200, 300), pos, (3, 5))
+        f_c = tp.locate(image, (3, 5), engine=self.engine, characterize=True)
+        f_nc = tp.locate(image, (3, 5), engine=self.engine, characterize=False)
+
+        assert len(f_nc.columns) == 3
+        assert_allclose(f_c.values[:, :3], f_nc.values)
+
     def test_multiple_simple_sparse(self):
         self.check_skip()
         actual, expected = compare((200, 300), 4, 2, noise_level=0,

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -666,7 +666,15 @@ class CommonFeatureIdentificationTests(object):
         # background average and standard deviation can be estimated within 1%
         # accuracy.
 
-        # The tolerance for ep in this test is 0.005 px.
+        # The tolerance for ep in this test is 0.001 px or 10%.
+        # This amounts to roughly the following rms error values:
+        # noise / signal = 0.01 : 0.004+-0.001px
+        # noise / signal = 0.02 : 0.008+-0.001 px
+        # noise / signal = 0.05 : 0.02+-0.002 px
+        # noise / signal = 0.1 : 0.04+-0.004 px
+        # noise / signal = 0.2 : 0.08+-0.008 px
+        # noise / signal = 0.3 : 0.12+-0.012 px
+        # noise / signal = 0.5 : 0.2+-0.02 px
         # Parameters are tweaked so that there is no deviation due to a too
         # small mask size. Noise/signal ratios up to 50% are tested.
         self.check_skip()
@@ -686,7 +694,7 @@ class CommonFeatureIdentificationTests(object):
 
             _, actual = sort_positions(f[['y', 'x']].values, expected)
             rms_dev = np.sqrt(np.mean(np.sum((actual-expected)**2, 1)))
-            assert_allclose(rms_dev, f['ep'].mean(), atol=0.005)
+            assert_allclose(rms_dev, f['ep'].mean(), rtol=0.1, atol=0.001)
 
             # Additionally test the measured noise
             actual_noise = tp.uncertainty.measure_noise(image, image_noisy,

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -666,7 +666,7 @@ class CommonFeatureIdentificationTests(object):
         # background average and standard deviation can be estimated within 1%
         # accuracy.
 
-        # The (relative) tolerance for ep in this test is 10% pixels.
+        # The tolerance for ep in this test is 0.005 px.
         # Parameters are tweaked so that there is no deviation due to a too
         # small mask size. Noise/signal ratios up to 50% are tested.
         self.check_skip()
@@ -686,7 +686,7 @@ class CommonFeatureIdentificationTests(object):
 
             _, actual = sort_positions(f[['y', 'x']].values, expected)
             rms_dev = np.sqrt(np.mean(np.sum((actual-expected)**2, 1)))
-            assert_allclose(rms_dev, f['ep'].mean(), rtol=0.1)
+            assert_allclose(rms_dev, f['ep'].mean(), atol=0.005)
 
             # Additionally test the measured noise
             actual_noise = tp.uncertainty.measure_noise(image, image_noisy,

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -665,9 +665,8 @@ class CommonFeatureIdentificationTests(object):
         locate_diameter = 21
         N = 200
         noise_expectation = np.array([1/2., np.sqrt(1/12.)])  # average, stdev
-
+        expected, image = draw_array(N, draw_diameter, bitdepth=12)
         for n, noise in enumerate([0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.5]):
-            expected, image = draw_array(N, draw_diameter, bitdepth=12)
             noise_level = int((2**12 - 1) * noise)
             image_noisy = image + np.array(np.random.randint(0, noise_level,
                                                              image.shape),


### PR DESCRIPTION
This removes any discrepancy between the python and numba engines:

 - the neighborhood should be calculated from rounded coordinates
 - the ndimage interpolation makes the code different from the numba engine and appears to add nothing in my tests

Fixes #376 