### PR TITLE
Scipy 0.18.0 bug workaround

### DIFF
--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -2,8 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import numpy as np
-from scipy.spatial import cKDTree
-from trackpy.utils import validate_tuple
+from trackpy.utils import validate_tuple, cKDTree
 
 
 def draw_point(image, pos, value):

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -7,11 +7,10 @@ import logging
 import numpy as np
 import pandas as pd
 from scipy import ndimage
-from scipy.spatial import cKDTree
 from pandas import DataFrame
 
 from .preprocessing import bandpass, scale_to_gamut, scalefactor_to_gamut
-from .utils import record_meta, validate_tuple
+from .utils import record_meta, validate_tuple, cKDTree
 from .masks import (binary_mask, N_binary_mask, r_squared_mask,
                     x_squared_masks, cosmask, sinmask)
 from .uncertainty import _static_error, measure_noise

--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -10,11 +10,10 @@ import functools
 from collections import deque
 
 import numpy as np
-from scipy.spatial import cKDTree
 import pandas as pd
 
 from .try_numba import try_numba_autojit, NUMBA_AVAILABLE
-from .utils import is_pandas_since_016, pandas_sort
+from .utils import is_pandas_since_016, pandas_sort, cKDTree
 
 logger = logging.getLogger(__name__)
 

--- a/trackpy/static.py
+++ b/trackpy/static.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
-from scipy.spatial import cKDTree
+from .utils import cKDTree
 import numpy as np
 from pandas import DataFrame
 from warnings import warn

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -20,9 +20,8 @@ import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point, draw_array,
                                 gen_nonoverlapping_locations)
-from trackpy.utils import pandas_sort
-                                
-from scipy.spatial import cKDTree
+from trackpy.utils import pandas_sort, cKDTree
+
 
 # Catch attempts to set values on an inadvertent copy of a Pandas object.
 tp.utils.make_pandas_strict()

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -43,8 +43,8 @@ except ValueError:  # Probably a development version
 
 if is_scipy_018:
     from scipy.spatial import KDTree as cKDTree
-    warnings.warn("Due to a bug in Scipy 0.18.0, the (faster) cKDTree cannot"
-                  "be used. Using KDTree. For better performance, upgrade or"
+    warnings.warn("Due to a bug in Scipy 0.18.0, the (faster) cKDTree cannot "
+                  "be used. For better linking performance, upgrade or "
                   "downgrade scipy.")
 else:
     from scipy.spatial import cKDTree

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -13,6 +13,7 @@ from distutils.version import LooseVersion
 
 import pandas as pd
 import numpy as np
+import scipy
 from scipy import stats
 import yaml
 
@@ -31,6 +32,22 @@ try:
                            LooseVersion('0.17.0'))
 except ValueError:  # Probably a development version
     is_pandas_since_017 = True
+
+
+# Wrap the scipy cKDTree to work around a bug in scipy 0.18.0
+try:
+    is_scipy_018 = LooseVersion(scipy.__version__) == LooseVersion('0.18.0')
+except ValueError:  # Probably a development version
+    is_scipy_018 = False
+
+
+if is_scipy_018:
+    from scipy.spatial import KDTree as cKDTree
+    warnings.warn("Due to a bug in Scipy 0.18.0, the (faster) cKDTree cannot"
+                  "be used. Using KDTree. For better performance, upgrade or"
+                  "downgrade scipy.")
+else:
+    from scipy.spatial import cKDTree
 
 
 def fit_powerlaw(data, plot=True, **kwargs):


### PR DESCRIPTION
This works around a bug in the recent scipy 0.18.0 (see https://github.com/scipy/scipy/pull/6431) by using the `scipy.spatial.KDTree` instead of the `scipy.spatial.cKDTree`. It hopefully solves the failed tests reported in master, #389 and #392. Locally, tests now also pass with scipy 0.18.0.

On trackpy import, there is a warning displayed if scipy == 0.18.0.  @kmdouglass @sciunto  could you check if this indeed solves your test issues?