### PR TITLE
in Compute_drift, sort traj to get it robust

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -258,7 +258,7 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
         pos_columns = ['x', 'y']
     # the groupby...diff works only if the trajectory Dataframe is sorted along frame
     # I do here a copy because a "inplace=True" would sort the original "traj" which is perhaps unwanted/unexpected
-    traj = traj.sort_values('frame')
+    traj = pandas_sort(traj,'frame')
     # Probe by particle, take the difference between frames.
     delta = traj.groupby('particle').apply(lambda x :
                                     x.set_index('frame', drop=False).diff())

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -258,9 +258,9 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
         pos_columns = ['x', 'y']
     # the groupby...diff works only if the trajectory Dataframe is sorted along frame
     # I do here a copy because a "inplace=True" would sort the original "traj" which is perhaps unwanted/unexpected
-    traj = pandas_sort(traj,'frame')
+    traj = pandas_sort(traj, 'frame')
     # Probe by particle, take the difference between frames.
-    delta = traj.groupby('particle',sort=False).apply(lambda x :
+    delta = traj.groupby('particle', sort=False).apply(lambda x :
                                     x.set_index('frame', drop=False).diff())
     # Keep only deltas between frames that are consecutive.
     delta = delta[delta['frame'] == 1]

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -256,6 +256,9 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
     """
     if pos_columns is None:
         pos_columns = ['x', 'y']
+    # the groupby...diff works only if the trajectory Dataframe is sorted along frame
+    # I do here a copy because a "inplace=True" would sort the original "traj" which is perhaps unwanted/unexpected
+    traj = traj.sort_values('frame')
     # Probe by particle, take the difference between frames.
     delta = traj.groupby('particle').apply(lambda x :
                                     x.set_index('frame', drop=False).diff())

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -233,7 +233,7 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
 
 
 def compute_drift(traj, smoothing=0, pos_columns=None):
-    """Return the ensemble drift, x(t).
+    """Return the ensemble drift, xy(t).
 
     Parameters
     ----------
@@ -248,8 +248,8 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
 
     Examples
     --------
-    >>> compute_drift(traj).plot() # Default smoothing usually smooths too much.
-    >>> compute_drift(traj, 0).plot() # not smoothed
+    >>> compute_drift(traj).plot()
+    >>> compute_drift(traj, 0, ['x', 'y']).plot() # not smoothed, equivalent to default.
     >>> compute_drift(traj, 15).plot() # Try various smoothing values.
     >>> drift = compute_drift(traj, 15) # Save good drift curves.
     >>> corrected_traj = subtract_drift(traj, drift) # Apply them.

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -260,7 +260,7 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
     # I do here a copy because a "inplace=True" would sort the original "traj" which is perhaps unwanted/unexpected
     traj = pandas_sort(traj,'frame')
     # Probe by particle, take the difference between frames.
-    delta = traj.groupby('particle').apply(lambda x :
+    delta = traj.groupby('particle',sort=False).apply(lambda x :
                                     x.set_index('frame', drop=False).diff())
     # Keep only deltas between frames that are consecutive.
     delta = delta[delta['frame'] == 1]


### PR DESCRIPTION
compute_drift does NOT work if the trajectory Dataframe is not sorted by frame.
the line `delta = traj.groupby('particle').apply(lambda x :x.set_index('frame', drop=False).diff())` expect that the frames are sorted. if not, the "delta.frame" will be relatively random (could even be negative), and the next line "delta = delta[delta['frame'] == 1]" will discard lots of (and sometimes all) lines.
So here is my correction proposition.

I'm not sure if it is preferred to make a copy or a "inplace" sort. 
"trajc.sort_values('frame',inplace=True)"  would also work, but then the trajectory Dataframe passed by the user will be changed, which is perhaps unwanted by the majority