### PR TITLE
FIX Ignore features that are in the margins in `find_link`

### DIFF
--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -390,6 +390,13 @@ class FindZipSpecialCases(unittest.TestCase):
         reader = CoordinateReader(f, shape, self.size)
         return find_link(reader, before_link=callback, **_kwargs)
 
+    def test_in_margin(self):
+        expected = DataFrame({'x': [12, 6], 'y': [12, 5],
+                              'frame': [0, 1], 'particle': [0, 0]})
+
+        actual = self.link(expected, shape=(24, 24))
+        assert_equal(len(actual), 1)
+
     def test_one(self):
         expected = DataFrame({'x': [8, 16], 'y': [16, 16],
                               'frame': [0, 1], 'particle': [0, 0]})


### PR DESCRIPTION
This fixes a rare exception that is raised when a feature that is outside the image margins is characterized.

Also rebased the `tp.feature.characterize` on `tp.refine.center_of_mass._refine`

This only touches code that was merged in #407, so I am inclined to self-merge. Please stop me if you disagree!