### PR TITLE
CLN Address the many warning messages in the tests

### DIFF
--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -19,7 +19,7 @@ from .linking import HashTable, TreeFinder, Point, PointND, \
 from .filtering import filter_stubs, filter_clusters, filter
 from .feature import locate, batch, local_maxima, \
            estimate_mass, estimate_size, minmass_version_change
-from .preprocessing import bandpass
+from .preprocessing import bandpass, invert_image
 from .framewise_data import FramewiseData, PandasHDFStore, PandasHDFStoreBig, \
            PandasHDFStoreSingleNode
 from .find_link import link_simple, link_simple_iter, find_link, find_link_iter

--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -166,7 +166,7 @@ def draw_spots(shape, positions, size, noise_level=0, bitdepth=8, **kwargs):
     else:
         raise ValueError('Bitdepth should be <= 32')
     np.random.seed(0)
-    image = np.zeros(shape, dtype=internaldtype)
+    image = np.zeros([int(s) for s in shape], dtype=internaldtype)
     if noise_level > 0:
         image += np.random.randint(0, noise_level + 1,
                                    shape).astype(internaldtype)

--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -4,6 +4,7 @@ import six
 import numpy as np
 import pandas as pd
 from pims import Frame, FramesSequence
+from trackpy.find import drop_close
 from trackpy.utils import validate_tuple, cKDTree
 from trackpy.preprocessing import bandpass
 
@@ -118,25 +119,6 @@ def gen_random_locations(shape, count, margin=0):
     return np.array(pos).T
 
 
-def eliminate_overlapping_locations(f, separation):
-    """ Makes sure that no position is within `separation` from each other, by
-    deleting one of the that are to close to each other.
-    """
-    separation = validate_tuple(separation, f.shape[1])
-    assert np.greater(separation, 0).all()
-    # Rescale positions, so that pairs are identified below a distance of 1.
-    f = f / separation
-    while True:
-        duplicates = cKDTree(f, 30).query_pairs(1)
-        if len(duplicates) == 0:
-            break
-        to_drop = []
-        for pair in duplicates:
-            to_drop.append(pair[1])
-        f = np.delete(f, to_drop, 0)
-    return f * separation
-
-
 def gen_nonoverlapping_locations(shape, count, separation, margin=0):
     """ Generates `count` number of positions within `shape`, that have minimum
     distance `separation` from each other. The number of positions returned may
@@ -145,7 +127,7 @@ def gen_nonoverlapping_locations(shape, count, separation, margin=0):
     Margin may be tuple-valued.
     """
     positions = gen_random_locations(shape, count, margin)
-    return eliminate_overlapping_locations(positions, separation)
+    return drop_close(positions, separation)
 
 
 def draw_spots(shape, positions, size, noise_level=0, bitdepth=8, **kwargs):
@@ -363,7 +345,7 @@ class SimulatedImage(object):
             margin = 0
         pos = gen_random_locations(self.shape, N, margin)
         if separation > 0:
-            pos = eliminate_overlapping_locations(pos, separation)
+            pos = drop_close(pos, separation)
         for p in pos:
             self.draw_feature(p)
         return pos
@@ -439,7 +421,7 @@ class SimulatedImage(object):
             margin = 0
         pos = gen_random_locations(self.shape, N, margin)
         if separation > 0:
-            pos = eliminate_overlapping_locations(pos, separation)
+            pos = drop_close(pos, separation)
 
         if self.ndim == 2:
             angles = np.random.uniform(0, 2*np.pi, N)

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -426,9 +426,8 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
 def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
           noise_size=1, smoothing_size=None, threshold=None, invert=False,
           percentile=64, topn=None, preprocess=True, max_iterations=10,
-          filter_before=None, filter_after=True,
-          characterize=True, engine='auto',
-          output=None, meta=None):
+          filter_before=None, filter_after=None, characterize=True,
+          engine='auto', output=None, meta=None):
     """Locate Gaussian-like blobs of some approximate size in a set of images.
 
     Preprocess the image by performing a band pass and a threshold.
@@ -480,8 +479,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
     filter_before : boolean
         filter_before is no longer supported as it does not improve performance.
     filter_after : boolean
-        Use final characterizations of mass and size to eliminate spurious
-        features. True by default.
+        This parameter has been deprecated: use minmass and maxsize.
     characterize : boolean
         Compute "extras": eccentricity, signal, ep. True by default.
     engine : {'auto', 'python', 'numba'}
@@ -532,8 +530,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
                      maxsize=maxsize, separation=separation,
                      noise_size=noise_size, smoothing_size=smoothing_size,
                      invert=invert, percentile=percentile, topn=topn,
-                     preprocess=preprocess, max_iterations=max_iterations,
-                     filter_before=filter_before, filter_after=filter_after)
+                     preprocess=preprocess, max_iterations=max_iterations)
 
     if meta:
         if isinstance(meta, six.string_types):

--- a/trackpy/find.py
+++ b/trackpy/find.py
@@ -10,6 +10,7 @@ from scipy.spatial import cKDTree
 
 from .utils import validate_tuple
 from .masks import binary_mask
+from .preprocessing import convert_to_int
 
 logger = logging.getLogger(__name__)
 
@@ -93,9 +94,8 @@ def grey_dilation(image, separation, percentile=64, margin=None, precise=True):
     drop_close : removes features that are too close to brighter features
     grey_dilation_legacy : local maxima finding routine used until trackpy v0.3
     """
-    if not np.issubdtype(image.dtype, np.integer):
-        factor = 255 / image.max()
-        image = (factor * image.clip(min=0.)).astype(np.uint8)
+    # convert to integer. does nothing if image is already of integer type
+    factor, image = convert_to_int(image, dtype=np.uint8)
 
     ndim = image.ndim
     separation = validate_tuple(separation, ndim)

--- a/trackpy/find_link.py
+++ b/trackpy/find_link.py
@@ -13,8 +13,7 @@ from scipy import ndimage
 from .masks import slice_image, mask_image
 from .find import grey_dilation, drop_close
 from .utils import (default_pos_columns, guess_pos_columns, is_isotropic,
-                    cKDTree, catch_keyboard_interrupt, validate_tuple,
-                    pandas_sort)
+                    cKDTree, validate_tuple, pandas_sort)
 from .preprocessing import bandpass
 from .refine import refine_com
 from .linking import (Point, TrackUnstored, TreeFinder, recursive_linker_obj,
@@ -223,7 +222,7 @@ def find_link(reader, search_range, separation, diameter=None, memory=0,
     generator = find_link_iter(reader, search_range, separation, diameter,
                                memory, percentile, minmass, proc_func,
                                before_link, after_link)
-    for frame_no, f_frame in catch_keyboard_interrupt(generator, logger=logger):
+    for frame_no, f_frame in generator:
         if f_frame is None:
             n_traj = 0
         else:

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -118,7 +118,8 @@ def get_slice(coords, shape, radius):
     for i, sh, low, up in zip(range(ndim), shape, lower, upper):
         lower_bound_trunc = max(0, low)
         upper_bound_trunc = min(sh, up)
-        slices[i] = slice(lower_bound_trunc, upper_bound_trunc)
+        slices[i] = slice(int(round(lower_bound_trunc)),
+                          int(round(upper_bound_trunc)))
         origin[i] = lower_bound_trunc
     return slices, origin
 

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -538,7 +538,8 @@ def shannon_entropy(x, bins):
     """Compute the Shannon entropy of the distribution of x."""
     hist = np.histogram(x, bins)[0]
     hist = hist.astype('float64')/hist.sum()  # normalize probablity dist.
-    entropy = -np.sum(np.nan_to_num(hist*np.log(hist)))
+    with np.errstate(all='ignore'):
+        entropy = -np.sum(np.nan_to_num(hist*np.log(hist)))
     return entropy
 
 

--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -170,7 +170,8 @@ def invert_image(raw_image, max_value=None):
 def convert_to_int(image, dtype='uint8'):
     """Convert the image to integer and normalize if applicable.
 
-    Does nothing if the image is already of integer type.
+    Clips all negative values to 0. Does nothing if the image is already
+    of integer type.
 
     Parameters
     ----------
@@ -187,7 +188,11 @@ def convert_to_int(image, dtype='uint8'):
         # Do nothing, image is already of integer type.
         return 1., image
     max_value = np.iinfo(dtype).max
-    scale_factor = max_value / image.max()
+    image_max = image.max()
+    if image_max == 0:  # protect against division by zero
+        scale_factor = 1.
+    else:
+        scale_factor = max_value / image_max
     return scale_factor, (scale_factor * image.clip(min=0.)).astype(dtype)
 
 

--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -9,6 +9,7 @@ from scipy.ndimage.fourier import fourier_gaussian
 
 from .utils import validate_tuple
 from .masks import gaussian_kernel
+from pims import pipeline
 
 
 def lowpass(image, sigma=1, truncate=4):
@@ -131,7 +132,7 @@ def bandpass(image, lshort, llong, threshold=None, truncate=4):
     result -= background
     return np.where(result >= threshold, result, 0)
 
-
+@pipeline
 def invert_image(raw_image, max_value=None):
     """Invert the image.
 

--- a/trackpy/refine/least_squares.py
+++ b/trackpy/refine/least_squares.py
@@ -812,7 +812,7 @@ def refine_leastsq(f, reader, diameter, separation=None, fit_function='gauss',
                              "per-trajectory optimization!")
 
     last_frame = None  # just for logging
-    for _, f_iter in catch_keyboard_interrupt(iterable, logger=logger):
+    for _, f_iter in iterable:
         # extract the initial parameters from the dataframe
         params = f_iter[ff.params].values
         if id_names is None:

--- a/trackpy/refine/least_squares.py
+++ b/trackpy/refine/least_squares.py
@@ -8,9 +8,8 @@ from scipy.optimize import minimize
 
 from ..static import cluster
 from ..masks import slice_image
-from ..utils import (guess_pos_columns, validate_tuple, is_isotropic,
-                     ReaderCached, catch_keyboard_interrupt,
-                     default_pos_columns, default_size_columns)
+from ..utils import (guess_pos_columns, validate_tuple, is_isotropic, safe_exp,
+                     ReaderCached, default_pos_columns, default_size_columns)
 from .center_of_mass import refine_com
 
 try:
@@ -1094,11 +1093,11 @@ def dr2_anisotropic_3d(mesh, p):
 
 
 def gauss_fun(r2, p, ndim):
-    return np.exp(-0.5*ndim*r2)
+    return safe_exp(-0.5*ndim*r2)
 
 
 def gauss_dfun(r2, p, ndim):
-    func = np.exp(-0.5*ndim*r2)
+    func = safe_exp(-0.5*ndim*r2)
     return func, [-0.5*ndim*func]
 
 
@@ -1110,22 +1109,22 @@ def disc_fun(r2, p, ndim):
     elif disc_size >= 1.:
         disc_size = 0.999
     mask = r2 > disc_size**2
-    result[mask] = np.exp(((r2[mask]**0.5 - disc_size)/(1 - disc_size))**2 *
-                          ndim/-2)
+    result[mask] = safe_exp(((r2[mask]**0.5 - disc_size)/(1 - disc_size))**2 *
+                            ndim/-2)
     return result
 
 
 def ring_fun(r2, p, ndim):
     t = p[0]
     r = r2**0.5
-    return np.exp(-0.5 * ndim * ((r - 1 + t)/t)**2)
+    return safe_exp(-0.5 * ndim * ((r - 1 + t)/t)**2)
 
 
 def ring_dfun(r2, p, ndim):
     t = p[0]
     r = r2**0.5
     num = r - 1 + t
-    func = np.exp(-0.5 * ndim * (num/t)**2)
+    func = safe_exp(-0.5 * ndim * (num/t)**2)
     return func, [func * (-0.5*ndim / (r*t**2)) * num,
                   func * ndim * (num**2/t**3 - num / t**2)]
 

--- a/trackpy/tests/common.py
+++ b/trackpy/tests/common.py
@@ -1,8 +1,21 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import unittest
+import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_array_equal
-from pandas.util.testing import assert_frame_equal
-from trackpy.utils import cKDTree, pandas_sort
+import trackpy as tp
+from trackpy.utils import cKDTree, pandas_sort, make_pandas_strict
+
+
+class StrictTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Suppress logging messages
+        tp.quiet()
+        # Catch attempts to set values on an inadvertent copy of a Pandas object.
+        make_pandas_strict()
+        # Make numpy strict
+        np.seterr('raise')
 
 
 def sort_positions(actual, expected):

--- a/trackpy/tests/test_correlations.py
+++ b/trackpy/tests/test_correlations.py
@@ -1,20 +1,18 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
-import unittest
 
 import nose
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_allclose
 from pandas import DataFrame, Series
+from trackpy.tests.common import StrictTestCase
 
 import trackpy as tp
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-tp.utils.make_pandas_strict()
 
-class TestCorrelations(unittest.TestCase):
+class TestCorrelations(StrictTestCase):
 
     def setUp(self):
         np.random.seed(0)

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import range
 import os
-import unittest
 import warnings
 
 import nose
@@ -18,10 +17,9 @@ from trackpy.artificial import (draw_feature, draw_spots, draw_point, draw_array
                                 gen_nonoverlapping_locations)
 from trackpy.utils import pandas_sort
 from trackpy.refine import refine_com
-from trackpy.tests.common import sort_positions
+from trackpy.tests.common import sort_positions, StrictTestCase
+from trackpy.preprocessing import invert_image
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-tp.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 
@@ -42,7 +40,7 @@ def compare(shape, count, radius, noise_level, engine):
     return actual, expected
 
 
-class OldMinmass(unittest.TestCase):
+class OldMinmass(StrictTestCase):
     def check_skip(self):
         pass
     
@@ -768,14 +766,14 @@ class CommonFeatureIdentificationTests(object):
 
 
 class TestFeatureIdentificationWithVanillaNumpy(
-    CommonFeatureIdentificationTests, unittest.TestCase):
+    CommonFeatureIdentificationTests, StrictTestCase):
 
     def setUp(self):
         self.engine = 'python'
 
 
 class TestFeatureIdentificationWithNumba(
-    CommonFeatureIdentificationTests, unittest.TestCase):
+    CommonFeatureIdentificationTests, StrictTestCase):
 
     def setUp(self):
         self.engine = 'numba'

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -101,7 +101,8 @@ class OldMinmass(StrictTestCase):
 
         new_minmass = tp.minmass_version_change(im, old_minmass, invert=True,
                                                 smoothing_size=self.tp_diameter)
-        f = tp.locate(im, self.tp_diameter, minmass=new_minmass, invert=True)
+
+        f = tp.locate(invert_image(im), self.tp_diameter, minmass=new_minmass)
         assert len(f) == self.N
 
 
@@ -119,12 +120,12 @@ class CommonFeatureIdentificationTests(object):
         # simple "smoke" test to see if numba explodes
         dummy_image = np.random.randint(0, 100, SHAPE).astype(np.uint8)
         tp.locate(dummy_image, 5, engine=self.engine)
-        tp.locate(dummy_image, 5, invert=True, engine=self.engine)
+        tp.locate(invert_image(dummy_image), 5, engine=self.engine)
 
         # Check float types
         dummy_image = np.random.rand(*SHAPE)
         tp.locate(dummy_image, 5, engine=self.engine)
-        tp.locate(dummy_image, 5, invert=True, engine=self.engine)
+        tp.locate(invert_image(dummy_image), 5, engine=self.engine)
 
     def test_black_image(self):
         self.check_skip()

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import functools
-import unittest
 import nose
 import warnings
 import os
@@ -13,11 +12,10 @@ from numpy.testing.decorators import slow
 import pandas
 from pandas.util.testing import (assert_series_equal, assert_frame_equal)
 
-import trackpy as tp 
+import trackpy as tp
+from trackpy.tests.common import StrictTestCase
 from pims import ImageSequence
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-tp.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 
@@ -84,14 +82,14 @@ class FeatureSavingTester(object):
             os.remove(STORE_NAME)
 
 
-class TestPandasHDFStore(FeatureSavingTester, unittest.TestCase):
+class TestPandasHDFStore(FeatureSavingTester, StrictTestCase):
     def setUp(self):
         _skip_if_no_pytables()
         self.prepare()
         self.storage_class = tp.PandasHDFStore
 
 
-class TestPandasHDFStoreBig(FeatureSavingTester, unittest.TestCase):
+class TestPandasHDFStoreBig(FeatureSavingTester, StrictTestCase):
     def setUp(self):
         _skip_if_no_pytables()
         self.prepare()
@@ -145,7 +143,7 @@ class TestPandasHDFStoreBig(FeatureSavingTester, unittest.TestCase):
             os.remove(STORE_NAME)
 
 
-class TestPandasHDFStoreBigCompressed(FeatureSavingTester, unittest.TestCase):
+class TestPandasHDFStoreBigCompressed(FeatureSavingTester, StrictTestCase):
     def setUp(self):
         _skip_if_no_pytables()
         self.prepare()
@@ -154,7 +152,7 @@ class TestPandasHDFStoreBigCompressed(FeatureSavingTester, unittest.TestCase):
             fletcher32=True)
 
 
-class TestPandasHDFStoreSingleNode(FeatureSavingTester, unittest.TestCase):
+class TestPandasHDFStoreSingleNode(FeatureSavingTester, StrictTestCase):
     def setUp(self):
         _skip_if_no_pytables()
         self.prepare()
@@ -162,7 +160,7 @@ class TestPandasHDFStoreSingleNode(FeatureSavingTester, unittest.TestCase):
 
 
 class TestPandasHDFStoreSingleNodeCompressed(FeatureSavingTester,
-                                             unittest.TestCase):
+                                             StrictTestCase):
     def setUp(self):
         _skip_if_no_pytables()
         self.prepare()

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -44,10 +44,10 @@ def _skip_if_no_pytables():
 class FeatureSavingTester(object):
     def prepare(self):
         directory = os.path.join(path, 'video', 'image_sequence')
-        self.v = ImageSequence(os.path.join(directory, '*.png'))
+        self.v = tp.invert_image(ImageSequence(os.path.join(directory, '*.png')))
         # mass depends on pixel dtype, which differs per reader
         minmass = self.v[0].max() * 2
-        self.PARAMS = {'diameter': 11, 'minmass': minmass, 'invert': True}
+        self.PARAMS = {'diameter': 11, 'minmass': minmass}
         self.expected = tp.batch(self.v[[0, 1]], engine='python', meta=False,
                                  **self.PARAMS)
 

--- a/trackpy/tests/test_find.py
+++ b/trackpy/tests/test_find.py
@@ -1,16 +1,16 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
-import unittest
 import numpy as np
 
 import trackpy as tp
 from trackpy.artificial import draw_feature
-from trackpy.tests.common import assert_coordinates_close
+from trackpy.tests.common import assert_coordinates_close, StrictTestCase
 from trackpy.find import grey_dilation, grey_dilation_legacy
 from pandas.util.testing import assert_produces_warning
 
-class TestFindGreyDilation(unittest.TestCase):
+
+class TestFindGreyDilation(StrictTestCase):
     def test_separation_fast(self):
         separation = 20
         for angle in np.arange(0, 360, 15):
@@ -97,7 +97,7 @@ class TestFindGreyDilation(unittest.TestCase):
 
 
 
-class TestFindGreyDilationLegacy(unittest.TestCase):
+class TestFindGreyDilationLegacy(StrictTestCase):
     def test_separation(self):
         separation = 20
         for angle in np.arange(0, 360, 15):

--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -439,6 +439,9 @@ class FindLinkSpecialCases(StrictTestCase):
         _kwargs.update(kwargs)
         if remove is not None:
             callback_coords = f.loc[f['frame'] == 1, ['y', 'x']].values
+            remove = np.array(remove, dtype=np.int)
+            if np.any(remove < 0) or np.any(remove > len(callback_coords)):
+                raise RuntimeError('Invalid test: `remove` is out of bounds.')
             callback_coords = np.delete(callback_coords, remove, axis=0)
             def callback(image, coords, **unused_kwargs):
                 if image.frame_no == 1:
@@ -615,11 +618,6 @@ class FindLinkSpecialCases(StrictTestCase):
                                  'particle': [0, 1, 2, 3, 3]})
         actual = self.link(expected, shape=shape, remove=[0])
         assert_traj_equal(actual, expected)
-
-        for n in range(5):
-            for remove in itertools.combinations(range(4), n):
-                actual = self.link(expected, shape=shape, remove=remove)
-                assert_traj_equal(actual, expected)
 
     def test_multiple_lost_subnet(self):
         shape = (24, 48)

--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -7,23 +7,16 @@ import itertools
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
-import unittest
 import nose
 from numpy.testing import assert_equal
 
-from trackpy import quiet
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking import SubnetOversizeException
-from trackpy.utils import pandas_sort, make_pandas_strict
+from trackpy.utils import pandas_sort
 from trackpy.artificial import CoordinateReader
 from trackpy.find_link import find_link, link_simple
-from trackpy.tests.common import assert_traj_equal
+from trackpy.tests.common import assert_traj_equal, StrictTestCase
 from trackpy.tests.test_link import random_walk, contracting_grid
-
-quiet()
-
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-make_pandas_strict()
 
 
 def _skip_if_no_numba():
@@ -31,7 +24,7 @@ def _skip_if_no_numba():
         raise nose.SkipTest('numba not installed. Skipping.')
 
 
-class SimpleLinkingTests(unittest.TestCase):
+class SimpleLinkingTests(StrictTestCase):
     def setUp(self):
         self.linker_opts = dict()
 
@@ -429,7 +422,8 @@ class FindLinkManyFailedFindTests(FindLinkTests):
         self.linker_opts['before_link'] = callback
 
 
-class FindLinkSpecialCases(unittest.TestCase):
+class FindLinkSpecialCases(StrictTestCase):
+    # also, for paper images
     do_diagnostics = False  # Don't ask for diagnostic info from linker
     def setUp(self):
         self.linker_opts = dict()

--- a/trackpy/tests/test_leastsq.py
+++ b/trackpy/tests/test_leastsq.py
@@ -1,21 +1,18 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import unittest
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_allclose
-from trackpy import quiet
 from trackpy.utils import validate_tuple
 from trackpy.refine import refine_com, refine_leastsq
 from trackpy.artificial import (feat_gauss, rot_2d, rot_3d, draw_feature,
                                 draw_cluster, SimulatedImage)
 from trackpy.refine.least_squares import (dimer, trimer, tetramer, dimer_global,
                                           FitFunctions, vect_from_params)
-from trackpy.tests.common import assert_coordinates_close
+from trackpy.tests.common import assert_coordinates_close, StrictTestCase
 from scipy.optimize.slsqp import approx_jacobian
 from nose import SkipTest
 
-quiet()
 
 EPSILON = 1E-7
 ATOL = 0.001
@@ -60,6 +57,7 @@ class RefineTsts(object):
 
     @classmethod
     def setUpClass(cls):
+        super(RefineTsts, cls).setUpClass()
         cls.size = validate_tuple(cls.size, cls.ndim)
         if not hasattr(cls, 'diameter'):
             cls.diameter = tuple([int(s * 4) for s in cls.size])
@@ -691,35 +689,35 @@ class RefineTsts(object):
         self.assertLess(devs['pos'], self.precision_perfect)
 
 
-class TestFit_gauss2D(RefineTsts, unittest.TestCase):
+class TestFit_gauss2D(RefineTsts, StrictTestCase):
     size = SIZE_2D
     ndim = 2
     feat_func = 'gauss'
     fit_func = 'gauss'
 
 
-# class TestFit_gauss2D_a(RefineTsts, unittest.TestCase):
+# class TestFit_gauss2D_a(RefineTsts, StrictTestCase):
 #      size = SIZE_2D_ANISOTROPIC
 #      ndim = 2
 #      feat_func = 'gauss'
 #      fit_func = 'gauss'
 
 
-class TestFit_gauss3D(RefineTsts, unittest.TestCase):
+class TestFit_gauss3D(RefineTsts, StrictTestCase):
      size = SIZE_3D
      ndim = 3
      feat_func = 'gauss'
      fit_func = 'gauss'
 
 
-class TestFit_gauss3D_a(RefineTsts, unittest.TestCase):
+class TestFit_gauss3D_a(RefineTsts, StrictTestCase):
      size = SIZE_3D_ANISOTROPIC
      ndim = 3
      feat_func = 'gauss'
      fit_func = 'gauss'
 
 
-class TestFit_disc2D(RefineTsts, unittest.TestCase):
+class TestFit_disc2D(RefineTsts, StrictTestCase):
     size = SIZE_2D
     ndim = 2
     feat_func = 'disc'
@@ -728,7 +726,7 @@ class TestFit_disc2D(RefineTsts, unittest.TestCase):
     fit_func = 'disc'
 
 
-# class TestFit_disc2D_a(RefineTsts, unittest.TestCase):
+# class TestFit_disc2D_a(RefineTsts, StrictTestCase):
 #     size = SIZE_2D_ANISOTROPIC
 #     ndim = 2
 #     feat_func = 'disc'
@@ -737,7 +735,7 @@ class TestFit_disc2D(RefineTsts, unittest.TestCase):
 #     fit_func = 'disc'
 #
 #
-# class TestFit_disc3D(RefineTsts, unittest.TestCase):
+# class TestFit_disc3D(RefineTsts, StrictTestCase):
 #     size = SIZE_3D
 #     ndim = 3
 #     feat_func = 'disc'
@@ -746,7 +744,7 @@ class TestFit_disc2D(RefineTsts, unittest.TestCase):
 #     fit_func = 'disc'
 #
 #
-# class TestFit_disc3D_a(RefineTsts, unittest.TestCase):
+# class TestFit_disc3D_a(RefineTsts, StrictTestCase):
 #     size = SIZE_3D_ANISOTROPIC
 #     ndim = 3
 #     feat_func = 'disc'
@@ -755,7 +753,7 @@ class TestFit_disc2D(RefineTsts, unittest.TestCase):
 #     fit_func = 'disc'
 
 
-class TestFit_ring2D(RefineTsts, unittest.TestCase):
+class TestFit_ring2D(RefineTsts, StrictTestCase):
     size = SIZE_2D
     ndim = 2
     feat_func = 'ring'
@@ -768,7 +766,7 @@ class TestFit_ring2D(RefineTsts, unittest.TestCase):
     size_dev = 0.05  #  5% of feature size
 
 
-# class TestFit_ring2D_a(RefineTsts, unittest.TestCase):
+# class TestFit_ring2D_a(RefineTsts, StrictTestCase):
 #     size = SIZE_2D_ANISOTROPIC
 #     ndim = 2
 #     feat_func = 'ring'
@@ -781,7 +779,7 @@ class TestFit_ring2D(RefineTsts, unittest.TestCase):
 #     size_dev = 0.05  #  5% of feature size
 #
 #
-# class TestFit_ring3D(RefineTsts, unittest.TestCase):
+# class TestFit_ring3D(RefineTsts, StrictTestCase):
 #     size = SIZE_3D
 #     ndim = 3
 #     feat_func = 'ring'
@@ -794,7 +792,7 @@ class TestFit_ring2D(RefineTsts, unittest.TestCase):
 #     size_dev = 0.05  #  5% of feature size
 #
 #
-# class TestFit_ring3D_a(RefineTsts, unittest.TestCase):
+# class TestFit_ring3D_a(RefineTsts, StrictTestCase):
 #     size = SIZE_3D_ANISOTROPIC
 #     ndim = 3
 #     feat_func = 'ring'
@@ -807,7 +805,7 @@ class TestFit_ring2D(RefineTsts, unittest.TestCase):
 #     size_dev = 0.05  #  5% of feature size
 
 
-class TestMultiple(unittest.TestCase):
+class TestMultiple(StrictTestCase):
     shape = (256, 256)
     pos_err = 3
     diameter = 21
@@ -916,7 +914,7 @@ class TestMultiple(unittest.TestCase):
         assert_allclose(result['size'].values, 5.25, atol=1)
 
 
-class TestFitFunctions(unittest.TestCase):
+class TestFitFunctions(StrictTestCase):
     repeats = 100
     def get_residual(self, ff, n, params, groups=None):
         if groups is None:

--- a/trackpy/tests/test_link.py
+++ b/trackpy/tests/test_link.py
@@ -7,24 +7,16 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from pandas import DataFrame, Series
-import unittest
+from pandas import DataFrame
 import nose
-from numpy.testing import assert_almost_equal, assert_allclose
-from numpy.testing.decorators import slow
-from pandas.util.testing import (assert_series_equal, assert_frame_equal,
-                                 assert_almost_equal, assert_produces_warning)
+from pandas.util.testing import assert_frame_equal
 
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking import PointND, Hash_table
 from trackpy.utils import is_pandas_since_016, pandas_sort, validate_tuple
+from trackpy.tests.common import StrictTestCase
 
-# suppress logging messages
-tp.quiet()
-
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-tp.utils.make_pandas_strict()
 
 path, _ = os.path.split(os.path.abspath(__file__))
 path = os.path.join(path, 'data')
@@ -353,7 +345,7 @@ class CommonTrackingTests(object):
         return pandas_sort(res, ['particle', 'frame']).reset_index(drop=True)
 
 
-class TestOnce(unittest.TestCase):
+class TestOnce(StrictTestCase):
     # simple API tests that need only run on one engine
     def setUp(self):
         N = 5
@@ -677,7 +669,7 @@ class NumbaOnlyTests(SubnetNeededTests):
             assert 'diag_subnet_iterations' in self.diag.columns
 
 
-class TestKDTreeWithDropLink(CommonTrackingTests, unittest.TestCase):
+class TestKDTreeWithDropLink(CommonTrackingTests, StrictTestCase):
     def setUp(self):
         self.linker_opts = dict(link_strategy='drop',
                                 neighbor_strategy='KDTree')
@@ -701,13 +693,13 @@ class TestKDTreeWithDropLink(CommonTrackingTests, unittest.TestCase):
         assert set(with_subnet.particle) == set((0, 1, 2))
 
 
-class TestBTreeWithRecursiveLink(SubnetNeededTests, unittest.TestCase):
+class TestBTreeWithRecursiveLink(SubnetNeededTests, StrictTestCase):
     def setUp(self):
         self.linker_opts = dict(link_strategy='recursive',
                                 neighbor_strategy='BTree')
 
 
-class TestBTreeWithNonrecursiveLink(SubnetNeededTests, unittest.TestCase):
+class TestBTreeWithNonrecursiveLink(SubnetNeededTests, StrictTestCase):
     def setUp(self):
         self.linker_opts = dict(link_strategy='nonrecursive',
                                 neighbor_strategy='BTree')
@@ -717,7 +709,7 @@ class TestBTreeWithNonrecursiveLinkDiag(DiagnosticsTests, TestBTreeWithNonrecurs
     pass
 
 
-class TestKDTreeWithRecursiveLink(SubnetNeededTests, unittest.TestCase):
+class TestKDTreeWithRecursiveLink(SubnetNeededTests, StrictTestCase):
     def setUp(self):
         self.linker_opts = dict(link_strategy='recursive',
                                 neighbor_strategy='KDTree')
@@ -727,13 +719,13 @@ class TestKDTreeWithRecursiveLinkDiag(DiagnosticsTests, TestKDTreeWithRecursiveL
     pass
 
 
-class TestKDTreeWithNonrecursiveLink(SubnetNeededTests, unittest.TestCase):
+class TestKDTreeWithNonrecursiveLink(SubnetNeededTests, StrictTestCase):
     def setUp(self):
         self.linker_opts = dict(link_strategy='nonrecursive',
                                 neighbor_strategy='KDTree')
 
 
-class TestKDTreeWithNumbaLink(NumbaOnlyTests, unittest.TestCase):
+class TestKDTreeWithNumbaLink(NumbaOnlyTests, StrictTestCase):
     def setUp(self):
         _skip_if_no_numba()
         self.linker_opts = dict(link_strategy='numba',
@@ -744,7 +736,7 @@ class TestKDTreeWithNumbaLinkDiag(DiagnosticsTests, TestKDTreeWithNumbaLink):
     pass
 
 
-class TestBTreeWithNumbaLink(NumbaOnlyTests, unittest.TestCase):
+class TestBTreeWithNumbaLink(NumbaOnlyTests, StrictTestCase):
     def setUp(self):
         _skip_if_no_numba()
         self.linker_opts = dict(link_strategy='numba',

--- a/trackpy/tests/test_mask.py
+++ b/trackpy/tests/test_mask.py
@@ -1,14 +1,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import unittest
 import numpy as np
 
 from numpy.testing import assert_equal
 
 from trackpy.masks import slice_image, mask_image
+from trackpy.tests.common import StrictTestCase
 
 
-class TestSlicing(unittest.TestCase):
+class TestSlicing(StrictTestCase):
     def test_slicing_2D(self):
         im = np.empty((9, 9))
 
@@ -129,7 +129,7 @@ class TestSlicing(unittest.TestCase):
         assert_equal(origin, (2, 0, 2))
 
 
-class TestMasking(unittest.TestCase):
+class TestMasking(StrictTestCase):
     def test_masking_single_2D(self):
         im = np.ones((9, 9))
         radius = 1  # N pix is 5

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -3,16 +3,16 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 import logging
-import unittest
 import warnings
 
 import pims
 import trackpy
 import trackpy.diag
+from trackpy.tests.common import StrictTestCase
 
 path, _ = os.path.split(os.path.abspath(__file__))
 
-class DiagTests(unittest.TestCase):
+class DiagTests(StrictTestCase):
     def test_performance_report(self):
         trackpy.diag.performance_report()
 
@@ -20,7 +20,7 @@ class DiagTests(unittest.TestCase):
         trackpy.diag.dependencies()
 
 
-class APITests(unittest.TestCase):
+class APITests(StrictTestCase):
     def test_pims_deprecation(self):
         """Using a pims class should work, but generate a warning.
 
@@ -39,7 +39,7 @@ class APITests(unittest.TestCase):
             assert len(w) == 1
 
 
-class LoggerTests(unittest.TestCase):
+class LoggerTests(StrictTestCase):
     def test_heirarchy(self):
         self.assertTrue(trackpy.linking.logger.parent is trackpy.logger)
         self.assertTrue(trackpy.feature.logger.parent is trackpy.logger)

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
-import unittest
 
 import numpy as np
 import pandas as pd
@@ -11,10 +10,7 @@ from pandas.util.testing import (assert_series_equal, assert_frame_equal,
 
 import trackpy as tp
 from trackpy.utils import pandas_sort
-
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-tp.utils.make_pandas_strict()
-
+from trackpy.tests.common import StrictTestCase
 
 def random_walk(N):
     return np.cumsum(np.random.randn(N))
@@ -42,7 +38,7 @@ def add_drift(df, drift):
     return df
 
 
-class TestDrift(unittest.TestCase):
+class TestDrift(StrictTestCase):
     def setUp(self):
         N = 10
         Y = 1
@@ -121,7 +117,7 @@ class TestDrift(unittest.TestCase):
         assert_traj_equal(actual, self.steppers)
 
 
-class TestMSD(unittest.TestCase):
+class TestMSD(StrictTestCase):
     def setUp(self):
         N = 10
         Y = 1
@@ -192,7 +188,7 @@ class TestMSD(unittest.TestCase):
         assert_series_equal(np.round(actual), expected)
 
 
-class TestSpecial(unittest.TestCase):
+class TestSpecial(StrictTestCase):
     def setUp(self):
         N = 10
         Y = 1

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -47,7 +47,7 @@ class TestDrift(StrictTestCase):
         b = DataFrame({'x': np.zeros(N - 1), 'y': Y + np.zeros(N - 1),
                        'frame': np.arange(1, N), 'particle': np.ones(N - 1)})
         self.dead_still = conformity(pd.concat([a, b]))
-        self.dead_still.sort_index(by=['frame', 'particle'], inplace=True)
+        pandas_sort(self.dead_still, ['frame', 'particle'], inplace=True)
 
         P = 1000 # particles
         A = 0.00001 # step amplitude

--- a/trackpy/tests/test_plot_traj_labeling.py
+++ b/trackpy/tests/test_plot_traj_labeling.py
@@ -1,23 +1,19 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
-import unittest
 import os
 
 from numpy.testing.decorators import slow
 import pandas as pd
 
-import trackpy
 from trackpy import ptraj
 from trackpy.utils import suppress_plotting
-
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-trackpy.utils.make_pandas_strict()
+from trackpy.tests.common import StrictTestCase
 
 path, _ = os.path.split(os.path.abspath(__file__))
 
 
-class TestLabeling(unittest.TestCase):
+class TestLabeling(StrictTestCase):
     def setUp(self):
         self.sparse = pd.read_pickle(os.path.join(path, 'data', 
                                            'sparse_trajectories.df'))

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -1,5 +1,4 @@
 
-import unittest
 from numpy.testing.decorators import slow
 import os
 
@@ -10,13 +9,11 @@ from pandas import Series, DataFrame
 import trackpy
 from trackpy import plots
 from trackpy.utils import suppress_plotting, fit_powerlaw
-
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-trackpy.utils.make_pandas_strict()
+from trackpy.tests.common import StrictTestCase
 
 path, _ = os.path.split(os.path.abspath(__file__))
 
-class TestPlots(unittest.TestCase):
+class TestPlots(StrictTestCase):
     def setUp(self):
         self.sparse = pd.read_pickle(os.path.join(path, 'data', 
                                            'sparse_trajectories.df'))

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -15,6 +15,8 @@ path, _ = os.path.split(os.path.abspath(__file__))
 
 class TestPlots(StrictTestCase):
     def setUp(self):
+        # older matplotlib may raise an invalid error
+        np.seterr(invalid='ignore')
         self.sparse = pd.read_pickle(os.path.join(path, 'data', 
                                            'sparse_trajectories.df'))
 

--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import functools
-import unittest
 
 import nose.tools
 import numpy as np
@@ -10,9 +9,8 @@ import pandas
 
 import trackpy
 from trackpy import predict
+from trackpy.tests.common import StrictTestCase
 
-# Catch attempts to set values on an inadvertent copy of a Pandas object.
-trackpy.utils.make_pandas_strict()
 
 def mkframe(n=1, Nside=3):
     xg, yg = np.mgrid[:Nside,:Nside]
@@ -33,7 +31,7 @@ def get_linked_lengths(frames, linker, *args, **kw):
 
 Nside_oversize = int(np.sqrt(100)) # Make subnet linker fail
 
-class BaselinePredictTests(unittest.TestCase):
+class BaselinePredictTests(StrictTestCase):
     def test_null_predict(self):
         """Make sure that a prediction of no motion does not interfere
         with normal tracking.
@@ -140,7 +138,7 @@ class VelocityPredictTests(object):
             assert np.all(d['particledf']['x_act'] == frames[i+1].x)
 
 
-class NearestVelocityPredictTests(VelocityPredictTests, unittest.TestCase):
+class NearestVelocityPredictTests(VelocityPredictTests, StrictTestCase):
     def setUp(self):
         self.predict_class = predict.NearestVelocityPredict
         self.instrumented_predict_class = \
@@ -157,7 +155,7 @@ class NearestVelocityPredictTests(VelocityPredictTests, unittest.TestCase):
                                 pred.link_df_iter, 0.45)
         assert all(ll.values == 3)
 
-class DriftPredictTests(VelocityPredictTests, unittest.TestCase):
+class DriftPredictTests(VelocityPredictTests, StrictTestCase):
     def setUp(self):
         self.predict_class = predict.DriftPredict
         self.instrumented_predict_class = \
@@ -173,7 +171,7 @@ class DriftPredictTests(VelocityPredictTests, unittest.TestCase):
         assert all(ll.values == 3)
 
 
-class ChannelPredictXTests(VelocityPredictTests, unittest.TestCase):
+class ChannelPredictXTests(VelocityPredictTests, StrictTestCase):
     def setUp(self):
         self.predict_class = functools.partial(
             predict.ChannelPredict,  3, minsamples=3)
@@ -200,13 +198,13 @@ class ChannelPredictXTests(VelocityPredictTests, unittest.TestCase):
         # with particle positions.
         pred = predict.ChannelPredict(1.1, minsamples=3,
                                       initial_profile_guess=initprof)
-        print(_shear_frame(1.))
+        # print(_shear_frame(1.))
         ll = get_linked_lengths((_shear_frame(0), _shear_frame(1.),
                                  _shear_frame(2), _shear_frame(3)),
                         pred.link_df_iter, 0.45)
         assert all(ll.values == 4)
 
-class ChannelPredictYTests(VelocityPredictTests, unittest.TestCase):
+class ChannelPredictYTests(VelocityPredictTests, StrictTestCase):
     def setUp(self):
         self.predict_class = functools.partial(
             predict.ChannelPredict, 3, 'y', minsamples=3)
@@ -222,4 +220,7 @@ class ChannelPredictYTests(VelocityPredictTests, unittest.TestCase):
             dict(x=xg.flatten() + dx, y=yg.flatten() + dy, frame=n))
 
 if __name__ == '__main__':
-    unittest.main()
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)
+

--- a/trackpy/tests/test_preprocessing.py
+++ b/trackpy/tests/test_preprocessing.py
@@ -1,8 +1,10 @@
 from __future__ import division
 import nose
 from numpy.testing.utils import assert_allclose
-from trackpy.preprocessing import *
+from trackpy.preprocessing import (bandpass, legacy_bandpass,
+                                   legacy_bandpass_fftw)
 from trackpy.artificial import gen_nonoverlapping_locations, draw_spots
+from trackpy.tests.common import StrictTestCase
 
 
 pos = gen_nonoverlapping_locations((512, 512), 200, 20)

--- a/trackpy/tests/test_static.py
+++ b/trackpy/tests/test_static.py
@@ -244,24 +244,24 @@ class TestArcLenAndArea(StrictTestCase):
             assert_almost_equal(result[1:], result[:-1])
 
     def test_symmetry_circle_corner(self):
-        h0 = np.random.random(self.N)
-        h1 = np.random.random(self.N) * np.sqrt(1-h0**2)
         R = np.random.random(self.N) * 100
+        h0 = np.random.random(self.N) * R
+        h1 = np.random.random(self.N) * np.sqrt(R**2-h0**2)
         assert_almost_equal(circle_corner_arclen(h0, h1, R),
                             circle_corner_arclen(h1, h0, R))
 
     def test_symmetry_sphere_edge(self):
-        h0 = np.random.random(self.N)
-        h1 = np.random.random(self.N) * np.sqrt(1-h0**2)
         R = np.random.random(self.N) * 100
+        h0 = np.random.random(self.N) * R
+        h1 = np.random.random(self.N) * np.sqrt(R**2-h0**2)
         assert_almost_equal(sphere_edge_area(h0, h1, R),
                             sphere_edge_area(h1, h0, R))
 
     def test_symmetry_sphere_corner(self):
-        h0 = np.random.random(self.N)
-        h1 = np.random.random(self.N) * np.sqrt(1-h0**2)
-        h2 = np.random.random(self.N) * np.sqrt(1-h0**2-h1**2)
         R = np.random.random(self.N) * 100
+        h0 = np.random.random(self.N) * R
+        h1 = np.random.random(self.N) * np.sqrt(R**2-h0**2)
+        h2 = np.random.random(self.N) * np.sqrt(R**2-h0**2-h1**2)
         result = np.array([sphere_corner_area(h0, h1, h2, R),
                            sphere_corner_area(h1, h2, h0, R),
                            sphere_corner_area(h2, h0, h1, R),

--- a/trackpy/tests/test_static.py
+++ b/trackpy/tests/test_static.py
@@ -3,11 +3,12 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 from trackpy.static import *
-import unittest
 import pandas
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_less
 from trackpy.static import cluster
+from trackpy.tests.common import StrictTestCase
+
 
 def _points_ring3D(r_edges, dr, n):
     """Returns x, y, z array of points comprising shells extending from r to
@@ -29,7 +30,7 @@ def _points_ring3D(r_edges, dr, n):
     return np.array(refx_all), np.array(refy_all), np.array(refz_all)
 
 
-class TestPairCorrelation(unittest.TestCase):
+class TestPairCorrelation(StrictTestCase):
 
 
     def test_correlation_2d_lattice(self):
@@ -183,7 +184,7 @@ class TestPairCorrelation(unittest.TestCase):
         return df
 
 
-class TestArcLenAndArea(unittest.TestCase):
+class TestArcLenAndArea(StrictTestCase):
     def setUp(self):
         self.N = 10  # some tests scale with N**2!
 
@@ -270,7 +271,7 @@ class TestArcLenAndArea(unittest.TestCase):
         assert_almost_equal(result[1:], result[:-1])
 
 
-class TestNormCircle(unittest.TestCase):
+class TestNormCircle(StrictTestCase):
     def setUp(self):
         self.R = np.random.random() * 100
         self.point = np.repeat([[self.R, self.R]], 4, axis=0)
@@ -314,7 +315,7 @@ class TestNormCircle(unittest.TestCase):
         assert_almost_equal(result, R*np.pi/2)
 
 
-class TestNormSphere(unittest.TestCase):
+class TestNormSphere(StrictTestCase):
     def setUp(self):
         self.R = np.random.random() * 100
         R = self.R
@@ -391,7 +392,7 @@ def pos_to_df(pos):
     return pd.DataFrame(pos_a, columns=pos_columns)
 
 
-class TestFindClusters(unittest.TestCase):
+class TestFindClusters(StrictTestCase):
     def setUp(self):
         self.N = 10
 

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -375,3 +375,13 @@ def catch_keyboard_interrupt(gen, logger=None):
             running = False
         else:
             pass
+
+EXPONENT_EPS_FLOAT64 = np.log(np.finfo(np.float64).eps)
+def safe_exp(arr):
+    # Calculate exponent, dealing with NaN and Underflow warnings
+    result = np.zeros_like(arr)
+    result[np.isnan(arr)] = np.nan  # propagate NaNs
+    with np.errstate(invalid='ignore'):  # ignore comparison with NaN
+        mask = arr > EXPONENT_EPS_FLOAT64
+    result[mask] = np.exp(arr[mask])
+    return result


### PR DESCRIPTION
I cleaned the many warning messages that were triggered during the tests.

Biggest change is that I impelemented `StrictTestCase` that makes pandas and numpy strict, and suppresses trackpy log messages. All tests are rebased on this TestCase (hence the many changed files)

The commit messages are clear, most of it is rather straightforward.