### PR TITLE
Include trackpy.predict in API

### DIFF
--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -24,6 +24,7 @@ from .framewise_data import FramewiseData, PandasHDFStore, PandasHDFStoreBig, \
            PandasHDFStoreSingleNode
 from .find_link import link_simple, link_simple_iter, find_link, find_link_iter
 from .refine import refine_com, refine_leastsq
+from . import predict
 from . import utils
 from . import artificial
 from .utils import handle_logging, ignore_logging, quiet

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -230,8 +230,7 @@ def make_pandas_strict():
 
     Does nothing for Pandas versions before 0.13.0.
     """
-    major, minor, micro = pd.__version__.split('.')
-    if major == '0' and int(minor) >= 13:
+    if LooseVersion(pd.__version__) >= LooseVersion('0.13.0'):
         pd.set_option('mode.chained_assignment', 'raise')
 
 


### PR DESCRIPTION
Previously users had to `import trackpy.predict` to use e.g. `trackpy.predict.DriftPredict`. Now they can skip that step.

This is an omission I have meant to correct for a long time!