### PR TITLE
find_link was not properly doing the com refinement when refine=True

### DIFF
--- a/trackpy/find_link.py
+++ b/trackpy/find_link.py
@@ -207,12 +207,12 @@ def find_link(reader, search_range, separation, diameter=None, memory=0,
         pos_columns = default_pos_columns(ndim)
         refine_columns = pos_columns[::-1] + ['mass']
         radius = tuple([d // 2 for d in diameter])
-        def after_link(image, features, **kwargs):
+        def after_link(image, features, image_proc, **kwargs):
             coords = features[pos_columns].values
             if len(coords) == 0:
                 return features
             # no separation filtering, because we use precise grey dilation
-            coords = refine_com(image, image, radius, coords, separation=0,
+            coords = refine_com(image, image_proc, radius, coords, separation=0,
                                 characterize=False)
             features[refine_columns] = coords
             return features


### PR DESCRIPTION
Even after the PR from #416 the refinement was not done properly and after checking with tp.subpx_bias() the particle positions were confined to integer values in x and y. Now, the refinement is actually done and produces reasonable locations confirmed by tp.subpx_bias()