### PR TITLE
FIX Number of measurements in emsd

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -229,6 +229,8 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
     # Here, rebuild it from the frame index.
     if not detail:
         return results.set_index('lagt')['msd']
+    # correctly compute the effective number of independent measurements
+    results['N'] = msds['N'].sum(level=1)
     return results
 
 


### PR DESCRIPTION
Emsd with `detail=True` returns a column `'N'` which comprises the number of independent measurements. When averaging over the individual particle MSDs, this number was also averaged, while it should actually be summed.