### PR TITLE
REF: Compute drift

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -7,7 +7,7 @@ from pandas import DataFrame, Series
 
 import warnings
 from warnings import warn
-from .utils import pandas_sort, guess_pos_columns
+from .utils import pandas_sort, pandas_rolling, guess_pos_columns
 
 
 def msd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
@@ -277,7 +277,7 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
     mask = (f_diff['particle'] == 0) & (f_diff['frame_diff'] == 1)
     dx = f_diff.loc[mask, pos_columns + ['frame']].groupby('frame').mean()
     if smoothing > 0:
-        dx = pd.rolling_mean(dx, smoothing, min_periods=0)
+        dx = pandas_rolling(dx, smoothing, min_periods=0)
     return dx.cumsum()
 
 

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -72,11 +72,11 @@ class TestDrift(StrictTestCase):
         # ^ no drift measured for Frame 0
 
         actual = tp.compute_drift(self.dead_still)
-        assert_frame_equal(actual, expected)
+        assert_frame_equal(actual, expected[['y', 'x']])
 
         # Small random drift
         actual = tp.compute_drift(self.many_walks)
-        assert_frame_equal(actual, expected)
+        assert_frame_equal(actual, expected[['y', 'x']])
 
     def test_constant_drift(self):
         N = 10
@@ -86,7 +86,7 @@ class TestDrift(StrictTestCase):
         expected.columns = ['x', 'y']
 
         actual = tp.compute_drift(self.steppers)
-        assert_frame_equal(actual, expected)
+        assert_frame_equal(actual, expected[['y', 'x']])
 
     def test_subtract_zero_drift(self):
         N = 10

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -328,11 +328,11 @@ else:
     pandas_iloc = _pandas_iloc_pre_016
 
 def _pandas_rolling_pre_018(df, window, *args, **kwargs):
-    """Use sort() to sort a DataFrame"""
+    """Use rolling_mean() to compute a rolling average"""
     return df.rolling_mean(window, *args, **kwargs)
 
 def _pandas_rolling_since_018(df, window, *args, **kwargs):
-    """Use sort_values() to sort a DataFrame"""
+    """Use rolling() to compute a rolling average"""
     return df.rolling(window, *args, **kwargs)
 
 if is_pandas_since_018:

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -33,6 +33,12 @@ try:
 except ValueError:  # Probably a development version
     is_pandas_since_017 = True
 
+try:
+    is_pandas_since_018 = (LooseVersion(pd.__version__) >=
+                           LooseVersion('0.18.0'))
+except ValueError:  # Probably a development version
+    is_pandas_since_018 = True
+
 
 # Wrap the scipy cKDTree to work around a bug in scipy 0.18.0
 try:
@@ -306,7 +312,6 @@ if is_pandas_since_017:
 else:
     pandas_sort = _pandas_sort_pre_017
 
-
 def _pandas_iloc_pre_016(df, inds):
     """Workaround for bug, iloc with empty list, in pandas < 0.16"""
     if len(inds) > 0:
@@ -314,15 +319,26 @@ def _pandas_iloc_pre_016(df, inds):
     else:
         return df.iloc[:0]
 
-
 def _pandas_iloc_since_016(df, inds):
     return df.iloc[inds]
-
 
 if is_pandas_since_016:
     pandas_iloc = _pandas_iloc_since_016
 else:
     pandas_iloc = _pandas_iloc_pre_016
+
+def _pandas_rolling_pre_018(df, window, *args, **kwargs):
+    """Use sort() to sort a DataFrame"""
+    return df.rolling_mean(window, *args, **kwargs)
+
+def _pandas_rolling_since_018(df, window, *args, **kwargs):
+    """Use sort_values() to sort a DataFrame"""
+    return df.rolling(window, *args, **kwargs)
+
+if is_pandas_since_018:
+    pandas_rolling = _pandas_rolling_since_018
+else:
+    pandas_rolling = _pandas_rolling_pre_018
 
 
 def guess_pos_columns(f):


### PR DESCRIPTION
This simplifies the `compute_drift` function, enhancing its performance by about a factor 2 and circumventing the bug discussed in #446.