### PR TITLE
Link custom metric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ matrix:
     - python: "2.7"
       env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow==2.1 pandas=0.13.0 scikit-image=0.9 pyyaml pytables" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pillow==2.5.1 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables" BUILD_DOCS=false
+      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pillow==2.5.1 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables scikit-learn" BUILD_DOCS=false
     # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
-      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==2.9 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw" BUILD_DOCS=false
+      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==2.9 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw scikit-learn" BUILD_DOCS=false
     - python: "3.4"
-      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==3.0 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw" BUILD_DOCS=true
+      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==3.0 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw scikit-learn" BUILD_DOCS=true
     - python: "3.5"
-      env: DEPS="numpy scipy matplotlib pillow pandas!=0.18.0 scikit-image pyyaml pytables numba"  BUILD_DOCS=false
+      env: DEPS="numpy scipy matplotlib pillow pandas!=0.18.0 scikit-image pyyaml pytables numba scikit-learn"  BUILD_DOCS=false
     - python: "3.6"
-      env: DEPS="numpy scipy matplotlib pillow pandas!=0.18.0 scikit-image pyyaml pytables numba"  BUILD_DOCS=false
+      env: DEPS="numpy scipy matplotlib pillow pandas!=0.18.0 scikit-image pyyaml pytables numba scikit-learn"  BUILD_DOCS=false
 
 
 install:

--- a/trackpy/linking/__init__.py
+++ b/trackpy/linking/__init__.py
@@ -1,4 +1,4 @@
-from .linking import (TreeFinder, link, link_df, link_iter, link_df_iter,
+from .linking import (link, link_df, link_iter, link_df_iter,
                       logger, Linker, adaptive_link_wrap)
 from .find_link import find_link, find_link_iter
 from .utils import verify_integrity, SubnetOversizeException, TrackUnstored, \

--- a/trackpy/linking/find_link.py
+++ b/trackpy/linking/find_link.py
@@ -298,6 +298,9 @@ class FindLinker(Linker):
     """
     def __init__(self, search_range, separation, diameter=None,
                  minmass=0, percentile=64, **kwargs):
+        if 'dist_func' in kwargs:
+            warnings.warn("Custom distance functions are untested using "
+                          "the FindLinker and likely will cause issues!")
         super(FindLinker, self).__init__(search_range, **kwargs)
         if diameter is None:
             diameter = separation

--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -8,13 +8,13 @@ import itertools, functools
 
 import numpy as np
 
-from ..utils import (default_pos_columns, guess_pos_columns,
-                     validate_tuple, pandas_sort)
+from ..utils import (guess_pos_columns,
+                     validate_tuple, is_isotropic, pandas_sort)
 from ..try_numba import NUMBA_AVAILABLE
 from .utils import (Point, TrackUnstored, points_from_arr,
                     coords_from_df, coords_from_df_iter,
                     SubnetOversizeException)
-from .subnet import TreeFinder, Subnets, split_subnet
+from .subnet import HashBTree, HashKDTree, Subnets, split_subnet
 from .subnetlinker import (subnet_linker_recursive, subnet_linker_drop,
                            subnet_linker_numba, subnet_linker_nonrecursive)
 
@@ -47,10 +47,6 @@ def link_iter(coords_iter, search_range, **kwargs):
         t, coords = 0, val
     else:
         t, coords = val
-
-    #  obtain dimensionality
-    ndim = coords.shape[1]
-    search_range = validate_tuple(search_range, ndim)
 
     # initialize the linker and yield the particle ids of the first frame
     linker = Linker(search_range, **kwargs)
@@ -96,6 +92,16 @@ def link(f, search_range, pos_columns=None, t_column='frame', **kwargs):
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses numba if available
         'drop' causes particles in subnetworks to go unlinked
+    neighbor_strategy : {'KDTree', 'BTree'}
+        algorithm used to identify nearby features. Default 'KDTree'.
+    to_eucl : function, optional
+        function that transforms a N x ndim array of positions into coordinates
+        in Euclidean space. Useful for instance to link by Euclidean distance
+        starting from radial coordinates. If search_range is anisotropic, this
+        parameter cannot be used.
+    dist_func : function, optional
+        a custom distance function that takes two 1D arrays of coordinates and
+        returns a float. Must be used with the 'BTree' neighbor_strategy.
 
     Returns
     -------
@@ -103,8 +109,6 @@ def link(f, search_range, pos_columns=None, t_column='frame', **kwargs):
     The t_column (by default: 'frame') will be coerced to integer."""
     if pos_columns is None:
         pos_columns = guess_pos_columns(f)
-    ndim = len(pos_columns)
-    search_range = validate_tuple(search_range, ndim)
 
     # copy the dataframe
     f = f.copy()
@@ -132,6 +136,10 @@ def link_df_iter(f_iter, search_range, pos_columns=None,
     Parameters
     ----------
     f_iter : iterable of DataFrames with feature positions, frame indices
+    pos_columns : list of str, optional
+        Default is ['y', 'x'], or ['z', 'y', 'x'] when 'z' is present in f.
+        If this is not supplied, f_iter will be investigated, which might cost
+        performance. For optimal performance, always supply this parameter.
 
     Yields
     ------
@@ -147,8 +155,6 @@ def link_df_iter(f_iter, search_range, pos_columns=None,
         f0 = next(f_iter_dummy)
         pos_columns = guess_pos_columns(f0)
         del f_iter_dummy, f0
-    ndim = len(pos_columns)
-    search_range = validate_tuple(search_range, ndim)
 
     f_iter, f_coords_iter = itertools.tee(f_iter)
     coords_iter = coords_from_df_iter(f_coords_iter, pos_columns, t_column)
@@ -203,7 +209,7 @@ class Linker(object):
 
     Attributes
     ----------
-    hash : TreeFinder
+    hash : Hash object
         The hash containing the points of the current level
     mem_set : set of points
     mem_history : list of sets of points
@@ -248,15 +254,29 @@ class Linker(object):
     # Maximum number of candidates per particle
     MAX_NEIGHBORS = 10
 
-    def __init__(self, search_range, memory=0, link_strategy=None,
-                 predictor=None, adaptive_stop=None, adaptive_step=0.95,
-                 dist_func=None):
+    def __init__(self, search_range, memory=0, predictor=None,
+                 adaptive_stop=None, adaptive_step=0.95,
+                 neighbor_strategy=None, link_strategy=None,
+                 dist_func=None, to_eucl=None):
         self.memory = memory
         self.predictor = predictor
         self.track_cls = TrackUnstored
-        self.adaptive_stop = adaptive_stop
-        self.adaptive_step = adaptive_step
-        self.dist_func = dist_func
+
+        if neighbor_strategy is None:
+            if dist_func is None:
+                neighbor_strategy = 'KDTree'
+            else:
+                neighbor_strategy = 'BTree'
+        elif neighbor_strategy not in ['KDTree', 'BTree']:
+            raise ValueError("neighbor_strategy must be 'KDTree' or 'BTree'")
+        elif neighbor_strategy != 'BTree' and dist_func is not None:
+            raise ValueError("For custom distance functions please use "
+                             "the 'BTree' neighbor_strategy.")
+
+        self.hash_cls = dict(KDTree=HashKDTree,
+                             BTree=HashBTree)[neighbor_strategy]
+        self.dist_func = dist_func  # a custom distance function
+        self.to_eucl = to_eucl      # to euclidean coordinates
 
         if link_strategy is None or link_strategy == 'auto':
             if NUMBA_AVAILABLE:
@@ -277,15 +297,29 @@ class Linker(object):
         else:
             raise ValueError("Unknown linking strategy '{}'".format(link_strategy))
 
-        self.ndim = len(search_range)
-        self.search_range = np.array(search_range)
+        # if search_range is anisotropic, transform coordinates to a rescaled
+        # space with search_range == 1.
+        if is_isotropic(search_range):
+            if hasattr(search_range, '__iter__'):
+                self.search_range = search_range[0]
+            else:
+                self.search_range = search_range
+        elif self.to_eucl is not None:
+            raise ValueError('Cannot use anisotropic search ranges in '
+                             'combination with a coordinate transformation.')
+        else:
+            search_range = np.atleast_2d(search_range)
+            self.to_eucl = lambda x: x / search_range
+            self.search_range = 1.
+            # also rescale adaptive_stop
+            if adaptive_stop is not None:
+                adaptive_stop = np.max(adaptive_stop / search_range)
+
         self.hash = None
         self.mem_set = set()
 
-        if self.adaptive_stop is not None:
-            # internal adaptive_stop is a fraction of search range
-            adaptive_stop = np.max(adaptive_stop / self.search_range)
-            if 1 * self.adaptive_stop <= 0:
+        if adaptive_stop is not None:
+            if 1 * adaptive_stop <= 0:
                 raise ValueError("adaptive_stop must be positive.")
             self.subnet_linker = functools.partial(adaptive_link_wrap,
                                                    subnet_linker=subnet_linker,
@@ -316,8 +350,9 @@ class Linker(object):
         if prev_hash is not None and self.predictor is not None:
             prev_hash.set_predictor(self.predictor, t)  # Rewrite positions
 
-        self.hash = TreeFinder(points_from_arr(coords, t, extra_data),
-                               self.search_range, dist_func=self.dist_func)
+        self.hash = self.hash_cls(points_from_arr(coords, t, extra_data),
+                                  ndim=coords.shape[1], to_eucl=self.to_eucl,
+                                  dist_func=self.dist_func)
         return prev_hash
 
     def init_level(self, coords, t, extra_data=None):
@@ -353,23 +388,20 @@ class Linker(object):
     @property
     def coords_df(self):
         return self.hash.coords_df
-    @coords_df.setter
-    def coords_df(self, value):
-        if len(value) != len(self.hash.points):
-            raise ValueError("Number of features has changed")
-        self.coords = value[default_pos_columns(self.ndim)].values
 
     def next_level(self, coords, t, extra_data=None):
         prev_hash = self.update_hash(coords, t, extra_data)
 
-        self.subnets = Subnets(prev_hash, self.hash, self.MAX_NEIGHBORS)
+        self.subnets = Subnets(prev_hash, self.hash, self.search_range,
+                               self.MAX_NEIGHBORS)
         spl, dpl = self.assign_links()
         self.apply_links(spl, dpl)
 
     def assign_links(self):
         spl, dpl = [], []
         for source_set, dest_set in self.subnets:
-            sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set, 1.)
+            sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set,
+                                                self.search_range)
             spl.extend(sn_spl)
             dpl.extend(sn_dpl)
 

--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -249,12 +249,14 @@ class Linker(object):
     MAX_NEIGHBORS = 10
 
     def __init__(self, search_range, memory=0, link_strategy=None,
-                 predictor=None, adaptive_stop=None, adaptive_step=0.95):
+                 predictor=None, adaptive_stop=None, adaptive_step=0.95,
+                 dist_func=None):
         self.memory = memory
         self.predictor = predictor
         self.track_cls = TrackUnstored
         self.adaptive_stop = adaptive_stop
         self.adaptive_step = adaptive_step
+        self.dist_func = dist_func
 
         if link_strategy is None or link_strategy == 'auto':
             if NUMBA_AVAILABLE:
@@ -315,7 +317,7 @@ class Linker(object):
             prev_hash.set_predictor(self.predictor, t)  # Rewrite positions
 
         self.hash = TreeFinder(points_from_arr(coords, t, extra_data),
-                               self.search_range)
+                               self.search_range, dist_func=self.dist_func)
         return prev_hash
 
     def init_level(self, coords, t, extra_data=None):

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -11,10 +11,18 @@ import pandas as pd
 from .utils import points_to_arr
 from ..utils import default_pos_columns, cKDTree
 
+try:
+    from sklearn.neighbors import BallTree
+except ImportError:
+    BallTree = None
+
 
 class TreeFinder(object):
     def __init__(self, points, search_range, dist_func=None):
         """Takes a list of particles."""
+        if dist_func is not None and BallTree is None:
+            raise ImportError("Scikit-learn (sklearn) is required "
+                              "for custom distance functions.")
         self.ndim = len(search_range)
         self.search_range = np.atleast_2d(search_range)
         if not isinstance(points, list):
@@ -76,11 +84,6 @@ class TreeFinder(object):
             if self.dist_func is None:
                 self._kdtree = cKDTree(coords_mapped, 15)
             else:
-                try:
-                    from sklearn.neighbors import BallTree
-                except ImportError:
-                    raise ImportError("Scikit-learn (sklearn) is required "
-                                      "for custom distance functions.")
                 self._kdtree = BallTree(coords_mapped,
                                         metric='pyfunc', func=self.dist_func)
         # This could be tuned

--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -12,7 +12,7 @@ from trackpy.utils import pandas_sort
 from trackpy.artificial import CoordinateReader
 from trackpy.linking import find_link
 from trackpy.tests.common import assert_traj_equal, StrictTestCase
-from trackpy.tests.test_linking import SubnetNeededTests
+from trackpy.tests.test_linking import SubnetNeededTests, _skip_if_no_sklearn
 
 
 class FindLinkTests(SubnetNeededTests):
@@ -68,6 +68,7 @@ class FindLinkTests(SubnetNeededTests):
 
 class FindLinkTestsBTree(FindLinkTests):
     def setUp(self):
+        _skip_if_no_sklearn()
         super(FindLinkTestsBTree, self).setUp()
         self.linker_opts['neighbor_strategy'] = 'BTree'
 

--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -22,6 +22,8 @@ class FindLinkTests(SubnetNeededTests):
         self.linker_opts['diameter'] = 15
 
     def link(self, f, search_range, *args, **kwargs):
+        if 'pos_columns' in kwargs:
+            raise nose.SkipTest('Skipping find_link tests with custom pos_columns.')
         # the minimal spacing between features in f is assumed to be 1.
 
         # from scipy.spatial import cKDTree
@@ -62,6 +64,12 @@ class FindLinkTests(SubnetNeededTests):
         # Should not raise
         actual = self.link(f, 5.2, separation=9.5, diameter=15.2)
         assert_traj_equal(actual, expected)
+
+
+class FindLinkTestsBTree(FindLinkTests):
+    def setUp(self):
+        super(FindLinkTestsBTree, self).setUp()
+        self.linker_opts['neighbor_strategy'] = 'BTree'
 
 
 class FindLinkOneFailedFindTests(FindLinkTests):
@@ -176,7 +184,7 @@ class FindLinkSpecialCases(StrictTestCase):
     def test_two_isolated(self):
         shape = (32, 32)
         expected = DataFrame({'x': [8, 16, 24, 16], 'y': [8, 8, 24, 24],
-                                 'frame': [0, 1, 0, 1], 'particle': [0, 0, 1, 1]})
+                              'frame': [0, 1, 0, 1], 'particle': [0, 0, 1, 1]})
         for remove in [[], [0], [1], [0, 1]]:
             actual = self.link(expected, shape=shape, remove=remove)
             assert_traj_equal(actual, expected)


### PR DESCRIPTION
This reimplements the kwarg `neighbor_strategy`, but the BTree is now based on the BallTree from scikit-learn, allowing for custom metrics.

To define a custom metric, you can:
 - pass a function as `to_eucl` that converts an `(N, ndim)` array of coordinates to an `(N, ndim2)` array of Euclidean coordinates (fast)
 - pass a function as `dist_func` that takes two `(ndim,)` arrays of positions and returns a distance (`float`). See [here](http://scikit-learn.org/stable/modules/generated/sklearn.neighbors.DistanceMetric.html)

I had to change the default rescaling of coordinates with `search_range`, that is why this PR is rather extensive. We have some (maybe negligible) performance increase for isotropic search ranges, because coordinates are not rescaled.