### PR TITLE
Fix rolling sum parameter in compute_drift.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.1 pandas=0.16 scikit-image=0.9 pyyaml pytables" BUILD_DOCS=false
+      env: DEPS="numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.1 pandas=0.16 scikit-image=0.10 pyyaml pytables" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.5 pandas=0.16.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables scikit-learn" BUILD_DOCS=false
+      env: DEPS="numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.5 pandas=0.16.0 scikit-image=0.10 pyyaml numba=0.13.4 pytables scikit-learn" BUILD_DOCS=false
     # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
       env: DEPS="libgfortran=1.0 numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.9 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw scikit-learn" BUILD_DOCS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow==2.1 pandas=0.13.0 scikit-image=0.9 pyyaml pytables" BUILD_DOCS=false
+      env: DEPS="numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.1 pandas=0.16 scikit-image=0.9 pyyaml pytables" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.13.3 matplotlib=1.3 pillow==2.5.1 pandas=0.13.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables scikit-learn" BUILD_DOCS=false
+      env: DEPS="numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.5 pandas=0.16.0 scikit-image=0.9 pyyaml numba=0.13.4 pytables scikit-learn" BUILD_DOCS=false
     # "Recommended" environments: More recent versions, for Py2 and Py3.
     - python: "2.7"
-      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==2.9 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw scikit-learn" BUILD_DOCS=false
+      env: DEPS="libgfortran=1.0 numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==2.9 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw scikit-learn" BUILD_DOCS=false
     - python: "3.4"
-      env: DEPS="libgfortran=1.0 numpy=1.9 scipy=0.16 matplotlib=1.4 pillow==3.0 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw scikit-learn" BUILD_DOCS=true
+      env: DEPS="libgfortran=1.0 numpy=1.12 scipy=0.18 matplotlib=1.5 pillow==3.0 pandas=0.16 scikit-image=0.11 pyyaml numba=0.20 pytables pyfftw scikit-learn" BUILD_DOCS=true
     - python: "3.5"
       env: DEPS="numpy scipy matplotlib pillow pandas!=0.18.0 scikit-image pyyaml pytables numba scikit-learn"  BUILD_DOCS=false
     - python: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,9 @@ setup_parameters = dict(
     author = "Trackpy Contributors",
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
-    install_requires = ['numpy>=1.7', 'scipy>=0.12', 'six>=1.8',
-	                    'pandas>=0.13', 'pims>=0.3.3',
-                        'pyyaml', 'matplotlib'],
+    install_requires = ['numpy>=1.12', 'scipy>=0.18', 'six>=1.8',
+	                    'pandas>=0.16', 'pims>=0.3.3',
+                        'pyyaml', 'matplotlib>=1.5'],
     packages = ['trackpy', 'trackpy.refine', 'trackpy.linking'],
     long_description = descr,
 )

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -277,7 +277,7 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
     mask = (f_diff['particle'] == 0) & (f_diff['frame_diff'] == 1)
     dx = f_diff.loc[mask, pos_columns + ['frame']].groupby('frame').mean()
     if smoothing > 0:
-        dx = pandas_rolling(dx, smoothing, min_periods=0).mean()
+        dx = pandas_rolling(dx, smoothing, min_periods=0)
     return dx.cumsum()
 
 

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -277,7 +277,7 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
     mask = (f_diff['particle'] == 0) & (f_diff['frame_diff'] == 1)
     dx = f_diff.loc[mask, pos_columns + ['frame']].groupby('frame').mean()
     if smoothing > 0:
-        dx = pandas_rolling(dx, smoothing, min_periods=0)
+        dx = pandas_rolling(dx, smoothing, min_periods=0).sum()
     return dx.cumsum()
 
 

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -277,7 +277,7 @@ def compute_drift(traj, smoothing=0, pos_columns=None):
     mask = (f_diff['particle'] == 0) & (f_diff['frame_diff'] == 1)
     dx = f_diff.loc[mask, pos_columns + ['frame']].groupby('frame').mean()
     if smoothing > 0:
-        dx = pandas_rolling(dx, smoothing, min_periods=0).sum()
+        dx = pandas_rolling(dx, smoothing, min_periods=0).mean()
     return dx.cumsum()
 
 

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -74,6 +74,9 @@ class TestDrift(StrictTestCase):
         actual = tp.compute_drift(self.dead_still)
         assert_frame_equal(actual, expected[['y', 'x']])
 
+        actual_rolling = tp.compute_drift(self.dead_still,3)
+        assert_frame_equal(actual_rolling, expected[['y', 'x']])
+
         # Small random drift
         actual = tp.compute_drift(self.many_walks)
         assert_frame_equal(actual, expected[['y', 'x']])

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -333,7 +333,7 @@ def _pandas_rolling_pre_018(df, window, *args, **kwargs):
 
 def _pandas_rolling_since_018(df, window, *args, **kwargs):
     """Use rolling() to compute a rolling average"""
-    return df.rolling(window, *args, **kwargs)
+    return df.rolling(window, *args, **kwargs).mean()
 
 if is_pandas_since_018:
     pandas_rolling = _pandas_rolling_since_018

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -329,7 +329,7 @@ else:
 
 def _pandas_rolling_pre_018(df, window, *args, **kwargs):
     """Use rolling_mean() to compute a rolling average"""
-    return df.rolling_mean(window, *args, **kwargs)
+    return pd.rolling_mean(window, *args, **kwargs)
 
 def _pandas_rolling_since_018(df, window, *args, **kwargs):
     """Use rolling() to compute a rolling average"""


### PR DESCRIPTION
This fixes an issue with how the rolling sum parameter was being used.

The issue:
The pandas rolling() function returns a Rolling object, which does not
have a cumulative sum function cumsum(). The cumsum() function is called
on the trajectory dataframe, which works fine if no rolling sum
parameter is passed, but if there is a rolling sum parameter passed,
the cumsum() function is being called on a Rolling object, which is
undefined, causing compute_drift() to crash with an exception
(Rolling object does not have a cumsum() function).

The fix:
This fixes the problem by calling sum() on the Rolling object,
which returns a dataframe. The cumsum() function can now be called
on the function.

To do:
Add a test for compute_drift() function that uses a rolling sum parameter.
This problem would have been caught with more comprehensive test
coverage of compute_drift().