### PR TITLE
Fixing rolling sum calculations to use Pandas API correctly.

### DIFF
--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -74,6 +74,9 @@ class TestDrift(StrictTestCase):
         actual = tp.compute_drift(self.dead_still)
         assert_frame_equal(actual, expected[['y', 'x']])
 
+        actual_rolling = tp.compute_drift(self.dead_still, smoothing=2)
+        assert_frame_equal(actual_rolling, expected[['y', 'x']])
+
         # Small random drift
         actual = tp.compute_drift(self.many_walks)
         assert_frame_equal(actual, expected[['y', 'x']])

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -329,11 +329,11 @@ else:
 
 def _pandas_rolling_pre_018(df, window, *args, **kwargs):
     """Use rolling_mean() to compute a rolling average"""
-    return df.rolling_mean(window, *args, **kwargs)
+    return pd.rolling_mean(df, window, *args, **kwargs)
 
 def _pandas_rolling_since_018(df, window, *args, **kwargs):
     """Use rolling() to compute a rolling average"""
-    return df.rolling(window, *args, **kwargs)
+    return df.rolling(window, *args, **kwargs).mean()
 
 if is_pandas_since_018:
     pandas_rolling = _pandas_rolling_since_018


### PR DESCRIPTION
This fixes an issue with how the rolling sum calculations were implemented.

The pre-0.18 pandas rolling sum calculation called the Pandas API
incorrectly:
* Version 0.13.0 implements the [`rolling_mean()`](http://pandas.pydata.org/pandas-docs/version/0.13/generated/pandas.rolling_mean.html?highlight=rolling#pandas.rolling_mean)
        function from the module level, as in, `pd.rolling_mean(my_df)`, while the `_pandas_rolling_pre_018()`
        method in utils implements it as `df.rolling_mean()`. This
        commit fixes that incorrect API implementation.

The post-0.18 pandas rolling sum calculation did not use the Pandas API
correctly:
* Version 0.18.1, released in May 2016, did away with `pd.rolling_mean(df)`
        and updated it with `df.rolling().mean()`. See the [Version 0.18.1 What's New page](http://pandas.pydata.org/pandas-docs/version/0.18/whatsnew.html?highlight=rolling_mean)
        for the update. This was implemented incorrectly because trackpy
        only called `df.rolling()`, which returns a Rolling object. The
        Rolling object does not have a cumulative sum `cumsum()`
        function, which caused an exception to be thrown from the
        `compute_drift()` function when `cumsum()` was called on the
        Rolling object.

To do:
* We still need to add a test for the `compute_drift()` function that
        uses a rolling sum parameter. However, there are additional
        issues with the Travis tests that will require a separate pull request 
        to address.

This pull request will **not** implement a test of the `compute_drift()`
function. Rather, updates to tests will be implemented as a separate PR.