### PR TITLE
Implement a user-friendly refine function making locate more modular

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -13,7 +13,7 @@ from .preprocessing import (bandpass, convert_to_int, invert_image,
 from .utils import (record_meta, validate_tuple, is_isotropic,
                     default_size_columns)
 from .find import grey_dilation, where_close
-from .refine import refine_com
+from .refine import refine_com_arr
 from .masks import (binary_mask, N_binary_mask, r_squared_mask,
                     x_squared_masks, cosmask, sinmask)
 from .uncertainty import _static_error, measure_noise
@@ -439,10 +439,9 @@ def locate(raw_image, diameter, minmass=None, maxsize=None, separation=None,
         return DataFrame(columns=columns)
 
     # Refine their locations and characterize mass, size, etc.
-    refined_coords = refine_com(raw_image, image, radius, coords,
-                                separation=separation,
-                                max_iterations=max_iterations,
-                                engine=engine, characterize=characterize)
+    refined_coords = refine_com_arr(raw_image, image, radius, coords,
+                                    max_iterations=max_iterations,
+                                    engine=engine, characterize=characterize)
 
     # Flat peaks return multiple nearby maxima. Eliminate duplicates.
     if np.all(np.greater(separation, 0)):

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -191,7 +191,7 @@ def estimate_size(image, radius, coord, estimated_mass):
 
 
 def refine(*args, **kwargs):
-    warnings.warn("trackpy.feature.refine will be deprecated: please use routines in "
+    warnings.warn("trackpy.feature.refine is deprecated: please use routines in "
                   "trackpy.refine", PendingDeprecationWarning)
     return refine_com(*args, **kwargs)
 

--- a/trackpy/find.py
+++ b/trackpy/find.py
@@ -28,8 +28,7 @@ def where_close(pos, separation, intensity=None):
     # Rescale positions, so that pairs are identified below a distance
     # of 1.
     if isinstance(pos, pd.DataFrame):
-        pos_rescaled = pos.values
-        pos_rescaled /= separation
+        pos_rescaled = pos.values / separation
     else:
         pos_rescaled = pos / separation
     duplicates = cKDTree(pos_rescaled, 30).query_pairs(1 - 1e-7)

--- a/trackpy/find.py
+++ b/trackpy/find.py
@@ -5,6 +5,7 @@ import warnings
 import logging
 
 import numpy as np
+import pandas as pd
 from scipy import ndimage
 from scipy.spatial import cKDTree
 
@@ -26,7 +27,11 @@ def where_close(pos, separation, intensity=None):
         return []
     # Rescale positions, so that pairs are identified below a distance
     # of 1.
-    pos_rescaled = pos / separation
+    if isinstance(pos, pd.DataFrame):
+        pos_rescaled = pos.values
+        pos_rescaled /= separation
+    else:
+        pos_rescaled = pos / separation
     duplicates = cKDTree(pos_rescaled, 30).query_pairs(1 - 1e-7)
     if len(duplicates) == 0:
         return []

--- a/trackpy/linking/find_link.py
+++ b/trackpy/linking/find_link.py
@@ -14,7 +14,7 @@ from ..masks import slice_image, mask_image
 from ..find import grey_dilation, drop_close
 from ..utils import default_pos_columns, is_isotropic, validate_tuple
 from ..preprocessing import bandpass
-from ..refine import refine_com
+from ..refine import refine_com_arr
 from ..feature import characterize
 
 from .utils import points_from_arr
@@ -140,8 +140,8 @@ def find_link(reader, search_range, separation, diameter=None, memory=0,
             if len(coords) == 0:
                 return features
             # no separation filtering, because we use precise grey dilation
-            coords = refine_com(image, image_proc, radius, coords, separation=0,
-                                characterize=False)
+            coords = refine_com_arr(image, image_proc, radius, coords, separation=0,
+                                    characterize=False)
             features[refine_columns] = coords
             return features
 

--- a/trackpy/refine/__init__.py
+++ b/trackpy/refine/__init__.py
@@ -1,2 +1,2 @@
-from .center_of_mass import refine_com
+from .center_of_mass import refine_com, refine_com_arr
 from .least_squares import refine_leastsq

--- a/trackpy/refine/center_of_mass.py
+++ b/trackpy/refine/center_of_mass.py
@@ -61,7 +61,10 @@ def refine_com(raw_image, image, radius, coords, max_iterations=10,
     if isinstance(coords, pd.DataFrame):
         if pos_columns is None:
             pos_columns = guess_pos_columns(coords)
+        index = coords.index
         coords = coords[pos_columns].values
+    else:
+        index = None
 
     coord_columns = default_pos_columns(image.ndim)
     columns = coord_columns + ['mass']
@@ -78,7 +81,7 @@ def refine_com(raw_image, image, radius, coords, max_iterations=10,
                              engine=engine, shift_thresh=shift_thresh,
                              characterize=characterize)
 
-    return pd.DataFrame(refined, columns=columns)
+    return pd.DataFrame(refined, columns=columns, index=index)
 
 
 def refine_com_arr(raw_image, image, radius, coords, max_iterations=10,

--- a/trackpy/refine/center_of_mass.py
+++ b/trackpy/refine/center_of_mass.py
@@ -41,7 +41,7 @@ def refine_com(raw_image, image, radius, coords, max_iterations=10,
         used for final characterization
     image : array (any dimension)
         processed image, used for locating center of mass
-    coord : array or DataFrame
+    coords : array or DataFrame
         estimated position
     separation : float or tuple
         Minimum separtion between features.
@@ -103,7 +103,7 @@ def refine_com_arr(raw_image, image, radius, coords, max_iterations=10,
         warnings.warn("max_iterations has to be larger than 0. setting it to 1.")
         max_iterations = 1
     if raw_image.ndim != coords.shape[1]:
-        raise ValueError("The image has a differnt number of dimensions than "
+        raise ValueError("The image has a different number of dimensions than "
                          "the coordinate array.")
 
     # ensure that radius is tuple of integers, for direct calls to refine_com_arr()

--- a/trackpy/refine/center_of_mass.py
+++ b/trackpy/refine/center_of_mass.py
@@ -70,6 +70,9 @@ def refine_com(raw_image, image, radius, coords, max_iterations=10,
         columns += default_size_columns(image.ndim, isotropic) + \
             ['ecc', 'signal', 'raw_mass']
 
+    if len(coords) == 0:
+        return pd.DataFrame(columns=columns)
+
     refined = refine_com_arr(raw_image, image, radius, coords,
                              max_iterations=max_iterations,
                              engine=engine, shift_thresh=shift_thresh,

--- a/trackpy/refine/center_of_mass.py
+++ b/trackpy/refine/center_of_mass.py
@@ -57,6 +57,9 @@ def refine_com(raw_image, image, radius, coords, max_iterations=10,
         remaining iterations.
     characterize : boolean, True by default
         Compute and return mass, size, eccentricity, signal.
+    pos_columns: list of strings, optional
+        Column names that contain the position coordinates.
+        Defaults to ``['y', 'x']`` or ``['z', 'y', 'x']``, if ``'z'`` exists.
     """
     if isinstance(coords, pd.DataFrame):
         if pos_columns is None:
@@ -66,8 +69,11 @@ def refine_com(raw_image, image, radius, coords, max_iterations=10,
     else:
         index = None
 
-    coord_columns = default_pos_columns(image.ndim)
-    columns = coord_columns + ['mass']
+    radius = validate_tuple(radius, image.ndim)
+
+    if pos_columns is None:
+        pos_columns = default_pos_columns(image.ndim)
+    columns = pos_columns + ['mass']
     if characterize:
         isotropic = radius[1:] == radius[:-1]
         columns += default_size_columns(image.ndim, isotropic) + \
@@ -96,6 +102,9 @@ def refine_com_arr(raw_image, image, radius, coords, max_iterations=10,
     if max_iterations <= 0:
         warnings.warn("max_iterations has to be larger than 0. setting it to 1.")
         max_iterations = 1
+    if raw_image.ndim != coords.shape[1]:
+        raise ValueError("The image has a differnt number of dimensions than "
+                         "the coordinate array.")
 
     # ensure that radius is tuple of integers, for direct calls to refine_com_arr()
     radius = validate_tuple(radius, image.ndim)

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -740,22 +740,22 @@ class CommonFeatureIdentificationTests(object):
 
         guess = np.array([[6, 13]])
         actual = refine_com_arr(image, image, 6, guess,characterize=False,
-                                engine=self.engine)[:, :2][:, ::-1]
+                                engine=self.engine)[:, :2]
         assert_allclose(actual, expected, atol=0.1)
 
         guess = np.array([[7, 12]])
         actual = refine_com_arr(image, image, 6, guess, characterize=False,
-                                engine=self.engine)[:, :2][:, ::-1]
+                                engine=self.engine)[:, :2]
         assert_allclose(actual, expected, atol=0.1)
 
         guess = np.array([[7, 14]])
         actual = refine_com_arr(image, image, 6, guess, characterize=False,
-                                engine=self.engine)[:, :2][:, ::-1]
+                                engine=self.engine)[:, :2]
         assert_allclose(actual, expected, atol=0.1)
 
         guess = np.array([[6, 12]])
         actual = refine_com_arr(image, image, 6, guess, characterize=False,
-                                engine=self.engine)[:, :2][:, ::-1]
+                                engine=self.engine)[:, :2]
         assert_allclose(actual, expected, atol=0.1)
 
     def test_uncertainty_failure(self):

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -16,7 +16,7 @@ from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.artificial import (draw_feature, draw_spots, draw_point, draw_array,
                                 gen_nonoverlapping_locations)
 from trackpy.utils import pandas_sort
-from trackpy.refine import refine_com
+from trackpy.refine import refine_com_arr
 from trackpy.tests.common import sort_positions, StrictTestCase
 from trackpy.preprocessing import invert_image
 from trackpy.uncertainty import measure_noise
@@ -739,23 +739,23 @@ class CommonFeatureIdentificationTests(object):
         draw_feature(image, pos, 3.75)
 
         guess = np.array([[6, 13]])
-        actual = refine_com(image, image, 6, guess,characterize=False,
-                            engine=self.engine)[:, :2][:, ::-1]
+        actual = refine_com_arr(image, image, 6, guess,characterize=False,
+                                engine=self.engine)[:, :2][:, ::-1]
         assert_allclose(actual, expected, atol=0.1)
 
         guess = np.array([[7, 12]])
-        actual = refine_com(image, image, 6, guess, characterize=False,
-                            engine=self.engine)[:, :2][:, ::-1]
+        actual = refine_com_arr(image, image, 6, guess, characterize=False,
+                                engine=self.engine)[:, :2][:, ::-1]
         assert_allclose(actual, expected, atol=0.1)
 
         guess = np.array([[7, 14]])
-        actual = refine_com(image, image, 6, guess, characterize=False,
-                            engine=self.engine)[:, :2][:, ::-1]
+        actual = refine_com_arr(image, image, 6, guess, characterize=False,
+                                engine=self.engine)[:, :2][:, ::-1]
         assert_allclose(actual, expected, atol=0.1)
 
         guess = np.array([[6, 12]])
-        actual = refine_com(image, image, 6, guess, characterize=False,
-                            engine=self.engine)[:, :2][:, ::-1]
+        actual = refine_com_arr(image, image, 6, guess, characterize=False,
+                                engine=self.engine)[:, :2][:, ::-1]
         assert_allclose(actual, expected, atol=0.1)
 
     def test_uncertainty_failure(self):

--- a/trackpy/tests/test_leastsq.py
+++ b/trackpy/tests/test_leastsq.py
@@ -206,17 +206,6 @@ class RefineTsts(object):
             size = df[self.size_columns].values
         return pos, signal, size, pos_err
 
-    def from_tp_ndarray(self, ndarray):
-        ndim = self.ndim
-        pos = ndarray[:, ndim-1:None:-1]
-        if self.isotropic:
-            size = ndarray[:, ndim + 1]
-            signal = ndarray[:, ndim + 3]
-        else:
-            size = ndarray[:, 2*ndim:ndim:-1]
-            signal = ndarray[:, 2*ndim + 2]
-        return pos, signal, size, None
-
     def get_deviations(self, actual_pos, expected_pos, cluster_size,
                        expected_center, expected_angle):
         """Obtain deviations in cluster coordinate system"""
@@ -412,7 +401,7 @@ class RefineTsts(object):
 
         actual = refine_com(image, image, self.radius, p0_pos, **kwargs)
 
-        actual = self.from_tp_ndarray(actual)
+        actual = self.from_dataframe(actual)
         return self.compute_deviations(actual, expected)
 
 
@@ -508,7 +497,7 @@ class RefineTsts(object):
 
         actual = refine_com(image, image, self.radius, p0_pos, **kwargs)
 
-        actual = self.from_tp_ndarray(actual)
+        actual = self.from_dataframe(actual)
         actual_pos, actual_signal, actual_size, pos_err = actual
         deviations = self.get_deviations(actual_pos, expected_pos, cluster_size,
                                          expected_center, expected_angle)

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -352,16 +352,18 @@ def guess_pos_columns(f):
 
 def default_pos_columns(ndim):
     """ Sets the default position column names """
-    return ['z', 'y', 'x'][-ndim:]
+    if ndim < 4:
+        return ['z', 'y', 'x'][-ndim:]
+    else:
+        return map(lambda i: 'x' + str(i), range(ndim))
 
 
 def default_size_columns(ndim, isotropic):
     """ Sets the default size column names """
     if isotropic:
-        size_columns = ['size']
+        return ['size']
     else:
-        size_columns = ['size_z', 'size_y', 'size_x'][-ndim:]
-    return size_columns
+        return ['size_' + cc for cc in default_pos_columns(ndim)]
 
 
 def is_isotropic(value):


### PR DESCRIPTION
This continues the work discussed in #257.

`trackpy.refine_com` now returns a `DataFrame` with clearly labeled columns. `locate` is now rebased on this, and as it does not require the to-dataframe conversion any more, this simplifies `locate` a bit. There might be some performance loss in locate, although I expect it is negligible.

For users that want to use only numpy, `trackpy.refine_com_arr` is there, which is basically the old `refine` function.