### PR TITLE
_msd_gaps: check for multiple trajectories per particle when reindexing

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -89,9 +89,17 @@ def _msd_gaps(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
     result_columns = ['<{}>'.format(p) for p in pos_columns] + \
                      ['<{}^2>'.format(p) for p in pos_columns]
 
-    # Reindex with consecutive frames, placing NaNs in the gaps.
-    pos = traj.set_index('frame')[pos_columns] * mpp
-    pos = pos.reindex(np.arange(pos.index[0], 1 + pos.index[-1]))
+    # The following fails if > 1 record per particle (cannot reindex):
+    try:
+        # Reindex with consecutive frames, placing NaNs in the gaps.
+        pos = traj.set_index('frame')[pos_columns] * mpp
+        pos = pos.reindex(np.arange(pos.index[0], 1 + pos.index[-1]))
+    except ValueError:
+        # reindex failed due to duplicate index values
+        raise Exception("Cannot use msd_gaps, more than one trajectory " \
+                + "per particle found.")
+
+
 
     max_lagtime = min(max_lagtime, len(pos) - 1)  # checking to be safe
 

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -95,9 +95,12 @@ def _msd_gaps(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
         pos = traj.set_index('frame')[pos_columns] * mpp
         pos = pos.reindex(np.arange(pos.index[0], 1 + pos.index[-1]))
     except ValueError:
-        # reindex failed due to duplicate index values
-        raise Exception("Cannot use msd_gaps, more than one trajectory " \
-                + "per particle found.")
+        if traj['frame'].nunique()!=len(traj['frame']):
+            # Reindex failed due to duplicate index values
+            raise Exception("Cannot use msd_gaps, more than one trajectory "
+                            "per particle found.")
+        else:
+            raise
 
 
 


### PR DESCRIPTION
Addresses #463.

Script to reproduce (adjust path_to_trackpy), taken mostly from `test_reproducibility.py` and walkthrough notebook:

```
import os.path
import trackpy as tp
import pims
from trackpy.preprocessing import invert_image
from trackpy.motion import _msd_gaps

path_to_trackpy = '/path/to/trackpy'

path, _ = os.path.split(os.path.abspath(__file__))

video = pims.ImageSequence(os.path.join(path_to_trackpy, 'tests', 'video', 'image_sequence'))
f = tp.batch(invert_image(video), diameter=9, minmass=240)
t = tp.link_df(f, 15, memory=3)
d = tp.compute_drift(t)
t_stationary = tp.subtract_drift(t,d)

MPP = 10
FPS = 10

print(_msd_gaps(t_stationary, MPP, FPS))
```
