### PR TITLE
Fix linking duplicate bug

### DIFF
--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -55,6 +55,7 @@ def link_iter(coords_iter, search_range, **kwargs):
 
     for t, coords in coords_iter:
         linker.next_level(coords, t)
+        logger.info("Frame {0}: {1} trajectories present.".format(t, len(linker.particle_ids)))
         yield t, linker.particle_ids
 
 

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -243,15 +243,15 @@ def assign_subnet(source, dest, subnets):
         raise ValueError("No subnet for added destination particle")
     if i1 == i2:  # if a and b are already in the same subnet, do nothing
         return
-    if i1 is None:  # source did not belong to a subset before
+    if i1 is None:  # source did not belong to a subnet before
         # just add it
         subnets[i2][0].add(source)
         source.subnet = i2
-    elif i2 is None:  # dest did not belong to a subset before
+    elif i2 is None:  # dest did not belong to a subnet before
         # just add it
         subnets[i1][1].add(dest)
         dest.subnet = i1
-    else:  # source belongs to subset i1 before
+    else:  # source belongs to subnet i1 before
         # merge the subnets
         subnets[i2][0].update(subnets[i1][0])
         subnets[i2][1].update(subnets[i1][1])


### PR DESCRIPTION
This addresses #472. The problem was in the `split_subnet()` function that is called when oversize subnets are broken into smaller daughter subnets, as part of the adaptive search feature. In addition to creating smaller sets of source and destination particles, each source particle's `forward_cands` list must also be pruned to remove candidates that are beyond the new `search_range`. This is because `forward_cands` is used by the subnet linker. If `forward_cands` is not pruned, then effectively speaking, the same destination particle may appear in multiple daughter subnets, and so it may be added to multiple tracks.

I was unable to formulate a simple test for this problem, but I did add a comment at the relevant portion of the code, so that hopefully we will be sure to account for this detail in any future implementation 🙂.

This also restores status messages to the "traditional" linking functions (e.g. `link_df_iter`).

Some additional notes about the hunt for this bug:
1. I first encountered this bug when using prediction on a real data set. Unfortunately, in general prediction depends on all preceding frames, making it hard to reproduce the bug quickly. I used prediction diagnostics to obtain the predicted coordinates that actually triggered the bug. I then saved the predicted coordinates at *t*, and the observed coordinates at *t*+1, to a file so that I could reproduce the bug in seconds instead of hours.
2. The code uses `set` in many places so that the particles' `uuid`s and the subnet IDs are not deterministic. I used a recipe for an `OrderedSet` to fix this so that I could reliably identify particles.
3. I used the debugger built into PyCharm. A lot.