### PR TITLE
DOC: Update docstrings for API functions with kwargs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,6 +48,7 @@ extlinks = {'issue': ('https://github.com/soft-matter/trackpy/issues/%s',
 # Generate the API documentation when building
 autosummary_generate = True
 numpydoc_show_class_members = False
+autodoc_docstring_signature = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/releases/v0.4.0.txt
+++ b/doc/releases/v0.4.0.txt
@@ -1,0 +1,36 @@
+
+v0.4.0
+------
+
+API Changes
+~~~~~~~~~~~
+
+- Refactor of locate to make it more modular. Some API breakages. (:issue:`400`, :issue:`406`)
+
+- Refactor of the linking code giving linking a better API (:issue:`416`)
+
+- Adjust default value of smoothing_size (:issue:`465`)
+
+
+Enhancements
+~~~~~~~~~~~~
+
+- Improved performance of feature finding (:issue:`361`)
+
+- Improved performance of linking (:issue:`400`, :issue:`406`)
+
+- New refinement method using least squares optimization (:issue:`407`)
+
+- New linker that combines gray dilation with linking (FindLinker) (:issue:`407`, :issue:`410`, :issue:`411`, :issue:`416`, :issue:`428`)
+
+- Linking in non-Euclidean coordinate systems and curved metrics (:issue:`448`)
+
+
+Bug fixes
+~~~~~~~~~
+
+- Fix compute drift if dataframes are not sorted (:issue:`409`)
+
+- Fix double counting of non-linking penalty in non-numba linkers (:issue:`430`)
+
+- Fix the N column for emsd (:issue:`434`)

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -191,6 +191,13 @@ def estimate_size(image, radius, coord, estimated_mass):
 
 
 def refine(*args, **kwargs):
+    """
+    Deprecated.
+
+    See also
+    --------
+    trackpy.refine.refine_com
+    """
     warnings.warn("trackpy.feature.refine is deprecated: please use routines in "
                   "trackpy.refine", PendingDeprecationWarning)
     return refine_com(*args, **kwargs)

--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -22,11 +22,49 @@ logger = logging.getLogger(__name__)
 
 
 def link_iter(coords_iter, search_range, **kwargs):
-    """Link an iterable of per-frame coordinates into trajectories.
+    """
+    link_iter(coords_iter, search_range, memory=0, predictor=None,
+        adaptive_stop=None, adaptive_step=0.95, neighbor_strategy=None,
+        link_strategy=None, dist_func=None, to_eucl=None)
+
+    Link an iterable of per-frame coordinates into trajectories.
 
     Parameters
     ----------
-    coords_iter : iterable or enumerated iterable of 2d numpy arrays
+    coords_iter : iterable
+        the iterable produces 2d numpy arrays of coordinates (shape: N, ndim).
+        to tell link_iter what frame number each array is, the iterable may
+        be enumerated so that it produces (number, 2d array) tuples
+    search_range : float or tuple
+        the maximum distance features can move between frames,
+        optionally per dimension
+    memory : integer, optional
+        the maximum number of frames during which a feature can vanish,
+        then reappear nearby, and be considered the same particle. Default: 0
+    predictor : function, optional
+        Improve performance by guessing where a particle will be in
+        the next frame.
+        For examples of how this works, see the "predict" module.
+    adaptive_stop : float, optional
+        If not None, when encountering an oversize subnet, retry by progressively
+        reducing search_range until the subnet is solvable. If search_range
+        becomes <= adaptive_stop, give up and raise a SubnetOversizeException.
+    adaptive_step : float, optional
+        Reduce search_range by multiplying it by this factor.
+    neighbor_strategy : {'KDTree', 'BTree'}
+        algorithm used to identify nearby features. Default 'KDTree'.
+    link_strategy : {'recursive', 'nonrecursive', 'numba', 'drop', 'auto'}
+        algorithm used to resolve subnetworks of nearby particles
+        'auto' uses numba if available
+        'drop' causes particles in subnetworks to go unlinked
+    dist_func : function, optional
+        a custom distance function that takes two 1D arrays of coordinates and
+        returns a float. Must be used with the 'BTree' neighbor_strategy.
+    to_eucl : function, optional
+        function that transforms a N x ndim array of positions into coordinates
+        in Euclidean space. Useful for instance to link by Euclidean distance
+        starting from radial coordinates. If search_range is anisotropic, this
+        parameter cannot be used.
 
     Yields
     ------
@@ -60,7 +98,13 @@ def link_iter(coords_iter, search_range, **kwargs):
 
 
 def link(f, search_range, pos_columns=None, t_column='frame', **kwargs):
-    """Link a DataFrame of coordinates into trajectories.
+    """
+    link(f, search_range, pos_columns=None, t_column='frame', memory=0,
+        predictor=None, adaptive_stop=None, adaptive_step=0.95,
+        neighbor_strategy=None, link_strategy=None, dist_func=None,
+        to_eucl=None)
+
+    Link a DataFrame of coordinates into trajectories.
 
     Parameters
     ----------
@@ -72,13 +116,13 @@ def link(f, search_range, pos_columns=None, t_column='frame', **kwargs):
     search_range : float or tuple
         the maximum distance features can move between frames,
         optionally per dimension
-    memory : integer, optional
-        the maximum number of frames during which a feature can vanish,
-        then reappear nearby, and be considered the same particle. 0 by default.
     pos_columns : list of str, optional
         Default is ['y', 'x'], or ['z', 'y', 'x'] when 'z' is present in f
     t_column : str, optional
         Default is 'frame'
+    memory : integer, optional
+        the maximum number of frames during which a feature can vanish,
+        then reappear nearby, and be considered the same particle. 0 by default.
     predictor : function, optional
         Improve performance by guessing where a particle will be in
         the next frame.
@@ -89,25 +133,30 @@ def link(f, search_range, pos_columns=None, t_column='frame', **kwargs):
         becomes <= adaptive_stop, give up and raise a SubnetOversizeException.
     adaptive_step : float, optional
         Reduce search_range by multiplying it by this factor.
+    neighbor_strategy : {'KDTree', 'BTree'}
+        algorithm used to identify nearby features. Default 'KDTree'.
     link_strategy : {'recursive', 'nonrecursive', 'numba', 'drop', 'auto'}
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses numba if available
         'drop' causes particles in subnetworks to go unlinked
-    neighbor_strategy : {'KDTree', 'BTree'}
-        algorithm used to identify nearby features. Default 'KDTree'.
+    dist_func : function, optional
+        a custom distance function that takes two 1D arrays of coordinates and
+        returns a float. Must be used with the 'BTree' neighbor_strategy.
     to_eucl : function, optional
         function that transforms a N x ndim array of positions into coordinates
         in Euclidean space. Useful for instance to link by Euclidean distance
         starting from radial coordinates. If search_range is anisotropic, this
         parameter cannot be used.
-    dist_func : function, optional
-        a custom distance function that takes two 1D arrays of coordinates and
-        returns a float. Must be used with the 'BTree' neighbor_strategy.
 
     Returns
     -------
     DataFrame with added column 'particle' containing trajectory labels.
-    The t_column (by default: 'frame') will be coerced to integer."""
+    The t_column (by default: 'frame') will be coerced to integer.
+
+    See also
+    --------
+    link_iter
+    """
     if pos_columns is None:
         pos_columns = guess_pos_columns(f)
 
@@ -132,15 +181,58 @@ link_df = link
 
 def link_df_iter(f_iter, search_range, pos_columns=None,
                  t_column='frame', **kwargs):
-    """Link an iterable of DataFrames into trajectories.
+    """
+    link_df_iter(f_iter, search_range, pos_columns=None, t_column='frame',
+        memory=0, predictor=None, adaptive_stop=None, adaptive_step=0.95,
+        neighbor_strategy=None, link_strategy=None, dist_func=None,
+        to_eucl=None)
+
+    Link an iterable of DataFrames into trajectories.
 
     Parameters
     ----------
-    f_iter : iterable of DataFrames with feature positions, frame indices
+    f_iter : iterable of DataFrames
+        Each DataFrame must include any number of column(s) for position and a
+        column of frame numbers. By default, 'x' and 'y' are expected for
+        position, and 'frame' is expected for frame number. For optimal
+        performance, explicitly specify the column names using `pos_columns`
+        and `t_column` kwargs.
+    search_range : float or tuple
+        the maximum distance features can move between frames,
+        optionally per dimension
     pos_columns : list of str, optional
-        Default is ['y', 'x'], or ['z', 'y', 'x'] when 'z' is present in f.
+        Default is ['y', 'x'], or ['z', 'y', 'x'] when 'z' is present in f
         If this is not supplied, f_iter will be investigated, which might cost
         performance. For optimal performance, always supply this parameter.
+    t_column : str, optional
+        Default is 'frame'
+    memory : integer, optional
+        the maximum number of frames during which a feature can vanish,
+        then reappear nearby, and be considered the same particle. 0 by default.
+    predictor : function, optional
+        Improve performance by guessing where a particle will be in
+        the next frame.
+        For examples of how this works, see the "predict" module.
+    adaptive_stop : float, optional
+        If not None, when encountering an oversize subnet, retry by progressively
+        reducing search_range until the subnet is solvable. If search_range
+        becomes <= adaptive_stop, give up and raise a SubnetOversizeException.
+    adaptive_step : float, optional
+        Reduce search_range by multiplying it by this factor.
+    neighbor_strategy : {'KDTree', 'BTree'}
+        algorithm used to identify nearby features. Default 'KDTree'.
+    link_strategy : {'recursive', 'nonrecursive', 'numba', 'drop', 'auto'}
+        algorithm used to resolve subnetworks of nearby particles
+        'auto' uses numba if available
+        'drop' causes particles in subnetworks to go unlinked
+    dist_func : function, optional
+        a custom distance function that takes two 1D arrays of coordinates and
+        returns a float. Must be used with the 'BTree' neighbor_strategy.
+    to_eucl : function, optional
+        function that transforms a N x ndim array of positions into coordinates
+        in Euclidean space. Useful for instance to link by Euclidean distance
+        starting from radial coordinates. If search_range is anisotropic, this
+        parameter cannot be used.
 
     Yields
     ------

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -589,6 +589,13 @@ def min_rolling_theta_entropy(pos, window=24, bins=24):
 
 
 def proximity(*args, **kwargs):
+    """
+    Deprecated
+
+    See also
+    --------
+    trackpy.static.proximity
+    """
     warn('This function has been moved to `trackpy.static', DeprecationWarning)
     from trackpy.static import proximity
     return proximity(*args, **kwargs)


### PR DESCRIPTION
This tackles #452 

I used an idea from https://matplotlib.org/devel/MEP/MEP10.html and set `autodoc_docstring_signature = True` in Sphinx so that the first line of the docstring might override the call signature. This saves us the error-prone hardcoding of kwargs and default values, while keeping the docstrings nicely informative.