### PR TITLE
Specify mathjax library url on documentation site

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,6 +45,8 @@ extensions = ['sphinx.ext.autodoc',
 extlinks = {'issue': ('https://github.com/soft-matter/trackpy/issues/%s',
                       'GH')}
 
+mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js'
+
 # Generate the API documentation when building
 autosummary_generate = True
 numpydoc_show_class_members = False


### PR DESCRIPTION
In Chrome, the equations written in MathJax format are not rendered since the default sphinx-mathjax plugin fetches it from non-https url. Setting this variable ensures an https library is loaded.

![snip 2018-03-25 at 00 44 49](https://user-images.githubusercontent.com/5663391/37870118-d00d2b40-2fc5-11e8-82be-5c6699644c17.jpg)
