### PR TITLE
Remove numba on/off toggle

### DIFF
--- a/trackpy/api.py
+++ b/trackpy/api.py
@@ -26,7 +26,7 @@ from . import predict
 from . import utils
 from . import artificial
 from .utils import handle_logging, ignore_logging, quiet
-from .try_numba import try_numba_autojit, enable_numba, disable_numba
+from .try_numba import try_numba_jit, enable_numba, disable_numba
 
 
 # pims import is deprecated. We include it here for backwards

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -13,7 +13,7 @@ from collections import deque
 import numpy as np
 
 from .utils import SubnetOversizeException
-from ..try_numba import try_numba_autojit
+from ..try_numba import try_numba_jit
 
 
 def recursive_linker_obj(s_sn, dest_size, search_range, max_size=30, diag=False):
@@ -238,7 +238,7 @@ def numba_link(s_sn, dest_size, search_range, max_size=30, diag=False):
     dest_results = [dcands[i] if i >= 0 else None for i in best_assignments]
     return source_results, dest_results
 
-@try_numba_autojit(nopython=True)
+@try_numba_jit(nopython=True)
 def _numba_subnet_norecur(ncands, candsarray, dists2array, cur_assignments,
                           cur_sums, tmp_assignments, best_assignments):
     """Find the optimal track assignments for a subnetwork, without recursion.

--- a/trackpy/refine/center_of_mass.py
+++ b/trackpy/refine/center_of_mass.py
@@ -5,7 +5,7 @@ import six
 
 import numpy as np
 import pandas as pd
-from ..try_numba import try_numba_autojit
+from ..try_numba import try_numba_jit
 
 import warnings
 import logging
@@ -281,7 +281,7 @@ def _refine(raw_image, image, radius, coords, max_iterations,
         return np.column_stack([final_coords, mass, Rg, ecc, signal, raw_mass])
 
 
-@try_numba_autojit(nopython=True)
+@try_numba_jit(nopython=True)
 def _numba_refine_2D(image, radiusY, radiusX, coords, N, max_iterations,
                      shift_thresh, shapeY, shapeX, maskY, maskX, N_mask,
                      results):
@@ -350,7 +350,7 @@ def _numba_refine_2D(image, radiusY, radiusX, coords, N, max_iterations,
 
     return 0  # Unused
 
-@try_numba_autojit(nopython=True)
+@try_numba_jit(nopython=True)
 def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
                        max_iterations, shift_thresh, shapeY, shapeX, maskY,
                        maskX, N_mask, r2_mask, cmask, smask, results):
@@ -445,7 +445,7 @@ def _numba_refine_2D_c(raw_image, image, radiusY, radiusX, coords, N,
     return 0  # Unused
 
 
-@try_numba_autojit(nopython=True)
+@try_numba_jit(nopython=True)
 def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
                          max_iterations, shift_thresh, shapeY, shapeX, maskY,
                          maskX, N_mask, y2_mask, x2_mask, cmask, smask,
@@ -550,7 +550,7 @@ def _numba_refine_2D_c_a(raw_image, image, radiusY, radiusX, coords, N,
     return 0  # Unused
 
 
-@try_numba_autojit(nopython=True)
+@try_numba_jit(nopython=True)
 def _numba_refine_3D(raw_image, image, radiusZ, radiusY, radiusX, coords, N,
                      max_iterations, shift_thresh, characterize, shapeZ, shapeY,
                      shapeX, maskZ, maskY, maskX, N_mask, r2_mask, z2_mask,

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -60,3 +60,9 @@ class LoggerTests(StrictTestCase):
         self.assertEqual(len(trackpy.logger.handlers), 1)
         self.assertEqual(trackpy.logger.level, logging.INFO)
         self.assertEqual(trackpy.logger.propagate, 1)
+
+
+class NumbaTests(StrictTestCase):
+    def test_enable(self):
+        trackpy.enable_numba()
+        trackpy.disable_numba()

--- a/trackpy/try_numba.py
+++ b/trackpy/try_numba.py
@@ -62,9 +62,15 @@ class RegisteredFunction(object):
             self.func_name = func.__name__
         except AttributeError:
             self.func_name = func.func_name
-        module_name = inspect.getmodulename(
-            six.get_function_globals(func)['__file__'])
-        module_name = '.'.join(['trackpy', module_name])
+        module_name = inspect.getmoduleinfo(
+            six.get_function_globals(func)['__file__']).name
+        if module_name == 'subnetlinker':
+            module_parent = 'trackpy.linking'
+        elif module_name == 'center_of_mass':
+            module_parent = 'trackpy.refine'
+        else:
+            module_parent = 'trackpy'
+        module_name = '.'.join([module_parent, module_name])
         self.module_name = module_name
         self.autojit_kw = autojit_kw
         if fallback is not None:


### PR DESCRIPTION
This attempts a quickfix for #487 by removing most of our custom numba-wrapping code.

I am not sure why we still have the `enable_numba` and `disable_numba`, because the user can choose between python and numba linkers / feature finding engines anyway.

Another thing: numba.autojit is not necessary from version 0.12, as we do not support this version anyway, I adapted it to numba.jit.