### PR TITLE
FIX: Adaptive search bug that could trigger "Too many forward candidates"

### DIFF
--- a/trackpy/linking/find_link.py
+++ b/trackpy/linking/find_link.py
@@ -475,6 +475,9 @@ class FindLinker(Linker):
             else:
                 new_cands = set()
 
+            for sp in source_set:
+                sp.forward_cands.sort(key=lambda x: x[1])
+
             # link
             sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set,
                                                 self.search_range)

--- a/trackpy/linking/find_link.py
+++ b/trackpy/linking/find_link.py
@@ -475,10 +475,8 @@ class FindLinker(Linker):
             else:
                 new_cands = set()
 
-            # sort candidates and add in penalty for not linking
-            for _s in source_set:
-                _s.forward_cands.sort(key=lambda x: x[1])
-                _s.forward_cands.append((None, self.search_range))
+            for sp in source_set:
+                sp.forward_cands.sort(key=lambda x: x[1])
 
             # link
             sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set,

--- a/trackpy/linking/find_link.py
+++ b/trackpy/linking/find_link.py
@@ -475,8 +475,10 @@ class FindLinker(Linker):
             else:
                 new_cands = set()
 
-            for sp in source_set:
-                sp.forward_cands.sort(key=lambda x: x[1])
+            # sort candidates and add in penalty for not linking
+            for _s in source_set:
+                _s.forward_cands.sort(key=lambda x: x[1])
+                _s.forward_cands.append((None, self.search_range))
 
             # link
             sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set,

--- a/trackpy/linking/legacy.py
+++ b/trackpy/linking/legacy.py
@@ -1148,11 +1148,12 @@ class Linker(object):
                         dest_set.discard(c_dp[0])
                 done_flg = (len(d_sn) == d_sn_sz) and (len(s_sn) == s_sn_sz)
 
-            # add in penalty for not linking
+            # sort and add in penalty for not linking
             for _s in s_sn:
                 # If we end up having to recurse for adaptive search, this final
                 # element will be dropped and re-added, because search_range is
                 # decreasing.
+                _s.forward_cands.sort(key=lambda x: x[1])
                 _s.forward_cands.append((None, search_range))
 
             try:

--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -503,6 +503,9 @@ class Linker(object):
     def assign_links(self):
         spl, dpl = [], []
         for source_set, dest_set in self.subnets:
+            for sp in source_set:
+                sp.forward_cands.sort(key=lambda x: x[1])
+
             sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set,
                                                 self.search_range)
             spl.extend(sn_spl)

--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -500,8 +500,11 @@ class Linker(object):
     def assign_links(self):
         spl, dpl = [], []
         for source_set, dest_set in self.subnets:
-            for sp in source_set:
-                sp.forward_cands.sort(key=lambda x: x[1])
+            # sort candidates and add in penalty for not linking before the
+            # subnetlinker, preventing repeats occuring during adaptive linking
+            for _s in source_set:
+                _s.forward_cands.sort(key=lambda x: x[1])
+                _s.forward_cands.append((None, self.search_range))
 
             sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set,
                                                 self.search_range)

--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -500,11 +500,8 @@ class Linker(object):
     def assign_links(self):
         spl, dpl = [], []
         for source_set, dest_set in self.subnets:
-            # sort candidates and add in penalty for not linking before the
-            # subnetlinker, preventing repeats occuring during adaptive linking
-            for _s in source_set:
-                _s.forward_cands.sort(key=lambda x: x[1])
-                _s.forward_cands.append((None, self.search_range))
+            for sp in source_set:
+                sp.forward_cands.sort(key=lambda x: x[1])
 
             sn_spl, sn_dpl = self.subnet_linker(source_set, dest_set,
                                                 self.search_range)

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -280,6 +280,8 @@ def split_subnet(source, dest, new_range):
         sp.subnet = None
         new_fcs = []
         for dp, dist in sp.forward_cands:
+            # Remove particles that are outside new_range
+            # (including, presumably, the null candidate)
             if dist <= new_range:
                 new_fcs.append((dp, dist))
             else:

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -294,6 +294,9 @@ def split_subnet(source, dest, new_range):
             # if dp is None:
             #     continue
             assign_subnet(sp, dp, subnets=subnets)
+
+        # the null particle was removed: re-add it here
+        sp.forward_cands.append((None, new_range))
     return (subnets[key] for key in subnets)
 
 

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -274,9 +274,10 @@ def split_subnet(source, dest, new_range):
         sp.subnet = None
         new_fcs = []
         for dp, dist in sp.forward_cands:
-            if dist <= new_range or dp is None:
+            if dist <= new_range:
                 new_fcs.append((dp, dist))
-            sp.forward_cands = new_fcs
+        new_fcs.append((None, new_range))
+        sp.forward_cands = new_fcs
     # Each destination particle gets its own fresh subnet.
     # These are numbered differently from the "global" dictionary
     # of subnets maintained by the instance of the Subnet class.

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -296,9 +296,6 @@ def split_subnet(source, dest, new_range):
             # if dp is None:
             #     continue
             assign_subnet(sp, dp, subnets=subnets)
-
-        # the null particle was removed: re-add it here
-        sp.forward_cands.append((None, new_range))
     return (subnets[key] for key in subnets)
 
 

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -265,6 +265,12 @@ def assign_subnet(source, dest, subnets):
 def split_subnet(source, dest, new_range):
     """Break apart a subnet by using a reduced search_range."""
     subnets = dict()
+    # Each destination particle gets its own fresh subnet.
+    # These are numbered differently from the "global" dictionary
+    # of subnets maintained by the instance of the Subnet class.
+    for i, dp in enumerate(dest):
+        dp.subnet = i
+        subnets[i] = set(), {dp}
     # Clear source particles' subnets, and prune their forward candidates
     # according to new_range.
     # The pruning step is crucial because some subnet linkers ignore
@@ -276,19 +282,17 @@ def split_subnet(source, dest, new_range):
         for dp, dist in sp.forward_cands:
             if dist <= new_range:
                 new_fcs.append((dp, dist))
-        new_fcs.append((None, new_range))
+            else:
+                break  # List was sorted by distance
+        # There's no need to re-add the null candidate here; that will be done by the
+        # subnet linker if needed
+        # new_fcs.append((None, new_range))
         sp.forward_cands = new_fcs
-    # Each destination particle gets its own fresh subnet.
-    # These are numbered differently from the "global" dictionary
-    # of subnets maintained by the instance of the Subnet class.
-    for i, dp in enumerate(dest):
-        dp.subnet = i
-        subnets[i] = set(), {dp}
 
-    for sp in source:
-        for dp, dist in sp.forward_cands:
-            if dp is None:
-                continue
+        for dp, dist in new_fcs:
+            # Null candidates were removed
+            # if dp is None:
+            #     continue
             assign_subnet(sp, dp, subnets=subnets)
     return (subnets[key] for key in subnets)
 

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -429,6 +429,18 @@ def subnet_linker_nonrecursive(source_set, dest_set, search_range, **kwargs):
 
 
 def subnet_linker_numba(source_set, dest_set, search_range, **kwargs):
+    """Link a subnet using a numba-accelerated algorithm.
+
+    Since this is meant to be the highest-performance option, it
+    has some special behaviors:
+
+    - Each source particle's forward_cands must be sorted by distance.
+    - Subnets with only 1 source or destination particle, or with at
+      most 4 source particles and 4 destination particles, are
+      solved using the recursive pure-Python algorithm, which has
+      much less overhead since it does not convert to a numpy
+      representation.
+    """
     lss = len(source_set)
     lds = len(dest_set)
     if lss == 0 and lds == 1:

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -386,9 +386,9 @@ def subnet_linker_recursive(source_set, dest_set, search_range, **kwargs):
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
 
-    # sort candidates and add in penalty for not linking
+    # Add the null candidate that is required by the subnet linker.
+    # Forward candidates were already sorted by Linker.assign_links()
     for _s in source_set:
-        _s.forward_cands.sort(key=lambda x: x[1])
         _s.forward_cands.append((None, search_range))
 
     snl = SubnetLinker(source_set, len(dest_set), search_range, **kwargs)
@@ -413,9 +413,9 @@ def subnet_linker_nonrecursive(source_set, dest_set, search_range, **kwargs):
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
 
-    # sort candidates and add in penalty for not linking
+    # Add the null candidate that is required by the subnet linker.
+    # Forward candidates were already sorted by Linker.assign_links()
     for _s in source_set:
-        _s.forward_cands.sort(key=lambda x: x[1])
         _s.forward_cands.append((None, search_range))
 
     sn_spl, sn_dpl = nonrecursive_link(source_set, len(dest_set), search_range, **kwargs)
@@ -453,6 +453,7 @@ def subnet_linker_numba(source_set, dest_set, search_range,
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
 
+    # Add the null candidate that is required by the subnet linker.
     # Forward candidates were already sorted by Linker.assign_links()
     for _s in source_set:
         _s.forward_cands.append((None, search_range))

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -386,11 +386,6 @@ def subnet_linker_recursive(source_set, dest_set, search_range, **kwargs):
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
 
-    # sort candidates and add in penalty for not linking
-    for _s in source_set:
-        _s.forward_cands.sort(key=lambda x: x[1])
-        _s.forward_cands.append((None, search_range))
-
     snl = SubnetLinker(source_set, len(dest_set), search_range, **kwargs)
     sn_spl, sn_dpl = [list(particles) for particles in zip(*snl.best_pairs)]
 
@@ -412,11 +407,6 @@ def subnet_linker_nonrecursive(source_set, dest_set, search_range, **kwargs):
     elif len(source_set) == 1 and len(dest_set) == 0:
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
-
-    # sort candidates and add in penalty for not linking
-    for _s in source_set:
-        _s.forward_cands.sort(key=lambda x: x[1])
-        _s.forward_cands.append((None, search_range))
 
     sn_spl, sn_dpl = nonrecursive_link(source_set, len(dest_set), search_range, **kwargs)
 
@@ -452,10 +442,6 @@ def subnet_linker_numba(source_set, dest_set, search_range,
     elif lss == 1 and lds == 0:
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
-
-    # Forward candidates were already sorted by Linker.assign_links()
-    for _s in source_set:
-        _s.forward_cands.append((None, search_range))
 
     # Shortcut for small subnets, because the numba linker has significant overhead
     if (lds == 1 or lss == 1 or (lds <= 3 and lss <= 3)) and hybrid:

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -386,6 +386,11 @@ def subnet_linker_recursive(source_set, dest_set, search_range, **kwargs):
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
 
+    # sort candidates and add in penalty for not linking
+    for _s in source_set:
+        _s.forward_cands.sort(key=lambda x: x[1])
+        _s.forward_cands.append((None, search_range))
+
     snl = SubnetLinker(source_set, len(dest_set), search_range, **kwargs)
     sn_spl, sn_dpl = [list(particles) for particles in zip(*snl.best_pairs)]
 
@@ -407,6 +412,11 @@ def subnet_linker_nonrecursive(source_set, dest_set, search_range, **kwargs):
     elif len(source_set) == 1 and len(dest_set) == 0:
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
+
+    # sort candidates and add in penalty for not linking
+    for _s in source_set:
+        _s.forward_cands.sort(key=lambda x: x[1])
+        _s.forward_cands.append((None, search_range))
 
     sn_spl, sn_dpl = nonrecursive_link(source_set, len(dest_set), search_range, **kwargs)
 
@@ -442,6 +452,10 @@ def subnet_linker_numba(source_set, dest_set, search_range,
     elif lss == 1 and lds == 0:
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
+
+    # Forward candidates were already sorted by Linker.assign_links()
+    for _s in source_set:
+        _s.forward_cands.append((None, search_range))
 
     # Shortcut for small subnets, because the numba linker has significant overhead
     if (lds == 1 or lss == 1 or (lds <= 3 and lss <= 3)) and hybrid:

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -458,7 +458,7 @@ def subnet_linker_numba(source_set, dest_set, search_range,
         _s.forward_cands.append((None, search_range))
 
     # Shortcut for small subnets, because the numba linker has significant overhead
-    if (lds == 1 or lss == 1 or (lds <= 4 and lss <= 4)) and hybrid:
+    if (lds == 1 or lss == 1 or (lds <= 3 and lss <= 3)) and hybrid:
         sn_spl, sn_dpl = recursive_linker_obj(source_set, lds, search_range, **kwargs)
     else:
         sn_spl, sn_dpl = numba_link(source_set, lds, search_range, **kwargs)

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -427,19 +427,19 @@ def subnet_linker_nonrecursive(source_set, dest_set, search_range, **kwargs):
 
     return sn_spl, sn_dpl
 
-
-def subnet_linker_numba(source_set, dest_set, search_range, **kwargs):
+def subnet_linker_numba(source_set, dest_set, search_range,
+                        hybrid=True, **kwargs):
     """Link a subnet using a numba-accelerated algorithm.
 
     Since this is meant to be the highest-performance option, it
     has some special behaviors:
 
     - Each source particle's forward_cands must be sorted by distance.
-    - Subnets with only 1 source or destination particle, or with at
-      most 4 source particles and 4 destination particles, are
-      solved using the recursive pure-Python algorithm, which has
-      much less overhead since it does not convert to a numpy
-      representation.
+    - If the 'hybrid' option is true, subnets with only 1 source or
+      destination particle, or with at most 4 source particles and
+      4 destination particles, are solved using the recursive
+      pure-Python algorithm, which has much less overhead since
+      it does not convert to a numpy representation.
     """
     lss = len(source_set)
     lds = len(dest_set)
@@ -458,7 +458,7 @@ def subnet_linker_numba(source_set, dest_set, search_range, **kwargs):
         _s.forward_cands.append((None, search_range))
 
     # Shortcut for small subnets, because the numba linker has significant overhead
-    if lds == 1 or lss == 1 or (lds <= 4 and lss <= 4):
+    if (lds == 1 or lss == 1 or (lds <= 4 and lss <= 4)) and hybrid:
         sn_spl, sn_dpl = recursive_linker_obj(source_set, lds, search_range, **kwargs)
     else:
         sn_spl, sn_dpl = numba_link(source_set, lds, search_range, **kwargs)

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -441,17 +441,13 @@ def subnet_linker_numba(source_set, dest_set, search_range, **kwargs):
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
 
-    # Sort candidates and add in penalty for not linking.
-    # During adaptive search, sorting only needs to happen on the first
-    # iteration. There's an opportunity for a ~1% speedup by moving
-    # sorting to Linker.assign_links()
+    # Forward candidates were already sorted by Linker.assign_links()
     for _s in source_set:
-        _s.forward_cands.sort(key=lambda x: x[1])
         _s.forward_cands.append((None, search_range))
 
-    # Further shortcuts to avoid running the numba linker, which has significant overhead
-    if lds == 1 or lss == 1 or (lds <= 3 and lss <= 3):
-        sn_spl, sn_dpl = nonrecursive_link(source_set, lds, search_range, **kwargs)
+    # Shortcut for small subnets, because the numba linker has significant overhead
+    if lds == 1 or lss == 1 or (lds <= 4 and lss <= 4):
+        sn_spl, sn_dpl = recursive_linker_obj(source_set, lds, search_range, **kwargs)
     else:
         sn_spl, sn_dpl = numba_link(source_set, lds, search_range, **kwargs)
 

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -439,7 +439,10 @@ def subnet_linker_numba(source_set, dest_set, search_range, **kwargs):
         # particle is lost. Not possible with default Linker implementation.
         return [source_set.pop()], [None]
 
-    # sort candidates and add in penalty for not linking
+    # Sort candidates and add in penalty for not linking.
+    # During adaptive search, sorting only needs to happen on the first
+    # iteration. There's an opportunity for a ~1% speedup by moving
+    # sorting to Linker.assign_links()
     for _s in source_set:
         _s.forward_cands.sort(key=lambda x: x[1])
         _s.forward_cands.append((None, search_range))

--- a/trackpy/linking/utils.py
+++ b/trackpy/linking/utils.py
@@ -100,6 +100,8 @@ class Point(object):
     :py:meth:`Point.__init__`.  (See :py:class:`~trackpy.linking.PointND` for
     example. )
     '''
+    __slots__ = ['_track', 'uuid', 't', 'pos', 'id', 'extra_data', 
+                 'forward_cands', 'subnet', 'relocate_neighbors', '__dict__']
     @classmethod
     def reset_counter(cls, c=0):
         cls.counter = itertools.count(c)
@@ -178,6 +180,7 @@ class TrackUnstored(object):
         The first feature in the track
 
     """
+    __slots__ = ['id', 'indx', '__dict__']
     @classmethod
     def reset_counter(cls, c=0):
         cls.counter = itertools.count(c)

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -701,6 +701,12 @@ class TestNumbaLink(SubnetNeededTests):
         self.linker_opts = dict(link_strategy='numba')
 
 
+class TestHybridLink(SubnetNeededTests):
+    def setUp(self):
+        _skip_if_no_numba()
+        self.linker_opts = dict(link_strategy='hybrid')
+
+
 class TestNonrecursiveLink(SubnetNeededTests):
     def setUp(self):
         self.linker_opts = dict(link_strategy='nonrecursive')

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -808,14 +808,6 @@ class TestMockSubnetlinker(StrictTestCase):
         for i in range(len(fwd_cds) - 1):
             self.assertLess(fwd_cds[i][1], fwd_cds[i + 1][1])
 
-        # there's exactly one null candidate, at the end
-        for i in range(len(fwd_cds) - 1):
-            self.assertIsNot(fwd_cds[i][0], None)
-        self.assertIs(fwd_cds[-1][0], None)
-
-        # the null candidate's dist equals the search_range
-        self.assertEquals(fwd_cds[-1][1], search_range)
-
     def test_adaptive_subnet(self):
         Linker.MAX_SUB_NET_SIZE_ADAPTIVE = 1
 
@@ -830,23 +822,19 @@ class TestMockSubnetlinker(StrictTestCase):
         self.assertEquals(len(self.source[0]), 2)
         self.assertEquals(len(self.dest[0]), 2)
         for p in self.source[0]:
-            self.assertEquals(len(p['forward_cands']), 3)
-            for cand, dist in p['forward_cands'][:-1]:
+            self.assertEquals(len(p['forward_cands']), 2)
+            for cand, dist in p['forward_cands']:
                 self.assertIsNot(cand, None)
                 self.assertLess(dist, self.sr[0])
-            self.assertIs(p['forward_cands'][-1][0], None)
-            self.assertAlmostEqual(p['forward_cands'][-1][1], self.sr[0])
 
         # round 1: search range 2; same
         self.assertEquals(self.sr[1], 2.)
         self.assertEquals(len(self.source[1]), 2)
         self.assertEquals(len(self.dest[1]), 2)
         for p in self.source[1]:
-            for cand, dist in p['forward_cands'][:-1]:
+            for cand, dist in p['forward_cands']:
                 self.assertIsNot(cand, None)
                 self.assertLess(dist, self.sr[1])
-            self.assertIs(p['forward_cands'][-1][0], None)
-            self.assertAlmostEqual(p['forward_cands'][-1][1], self.sr[1])
 
         # round 2, both calls: search range 0.5, subnets separate
         for i in (2, 3):
@@ -854,7 +842,5 @@ class TestMockSubnetlinker(StrictTestCase):
             self.assertEquals(len(self.source[i]), 1)
             self.assertEquals(len(self.dest[i]), 1)
             for p in self.source[i]:
-                self.assertEquals(len(p['forward_cands']), 2)
+                self.assertEquals(len(p['forward_cands']), 1)
                 self.assertAlmostEqual(p['forward_cands'][0][1], 0.1)
-                self.assertIs(p['forward_cands'][1][0], None)
-                self.assertAlmostEqual(p['forward_cands'][1][1], self.sr[i])

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -2,6 +2,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import os
+from copy import copy
+import functools
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
@@ -11,7 +13,8 @@ from numpy.testing import assert_equal
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.utils import pandas_sort
 from trackpy.linking import (link, link_iter, link_df_iter, verify_integrity,
-                             SubnetOversizeException)
+                             SubnetOversizeException, Linker)
+from trackpy.linking.subnetlinker import subnet_linker_recursive
 from trackpy.tests.common import assert_traj_equal, StrictTestCase
 
 path, _ = os.path.split(os.path.abspath(__file__))
@@ -750,3 +753,100 @@ class TestBTreeLink(SubnetNeededTests):
         actual = self.link(f_radial, search_range, pos_columns=['r', 'angle'],
                            dist_func=dist_func)
         assert_traj_equal(actual, expected)
+
+
+class TestMockSubnetlinker(StrictTestCase):
+    def setUp(self):
+        self.dest = []
+        self.source = []
+        self.sr = []
+
+        def copy_point(point):
+            return dict(id=point.id, pos=point.pos, t=point.t,
+                        forward_cands=copy(point.forward_cands))
+
+        def mock_subnetlinker(source_set, dest_set, search_range, **kwargs):
+            self.source.append([copy_point(p) for p in source_set])
+            self.dest.append([copy_point(p) for p in dest_set])
+            self.sr.append(search_range)
+
+            return subnet_linker_recursive(source_set, dest_set, search_range,
+                                           **kwargs)
+
+        self.linker_opts = dict(link_strategy=mock_subnetlinker)
+        self.default_max_size = Linker.MAX_SUB_NET_SIZE_ADAPTIVE
+
+    def tearDown(self):
+        Linker.MAX_SUB_NET_SIZE_ADAPTIVE = self.default_max_size
+
+    def link(self, *args, **kwargs):
+        kwargs.update(self.linker_opts)
+        return link(*args, **kwargs)
+
+    def test_single_subnet(self):
+        f = DataFrame({'x': [0, 1, 2, 3, 4],
+                       'frame': [0, 1, 1, 1, 1]})
+        search_range = 10.
+
+        self.link(f, search_range=search_range, pos_columns=['x'])
+
+        source = self.source[0]
+        dest = self.dest[0]
+        sr = self.sr[0]
+
+        self.assertEquals(sr, search_range)
+        self.assertEquals(len(source), 1)
+        self.assertEquals(len(dest), 4)
+
+        fwd_cds = source[0]['forward_cands']
+
+        # the forward candidate distances are sorted in ascending order
+        for i in range(len(fwd_cds) - 1):
+            self.assertLess(fwd_cds[i][1], fwd_cds[i + 1][1])
+
+        # the last one is None and its dist equals the search_range
+        self.assertIs(fwd_cds[-1][0], None)
+        self.assertEquals(fwd_cds[-1][1], search_range)
+
+    def test_adaptive_subnet(self):
+        Linker.MAX_SUB_NET_SIZE_ADAPTIVE = 1
+
+        f = DataFrame({'x': [0.0, 1.0, 0.1, 1.1],
+                       'frame': [0, 0, 1, 1]})
+        search_range = 8
+        self.link(f, search_range=search_range, pos_columns=['x'],
+                  adaptive_step=0.25, adaptive_stop=0.25)
+
+        # round 0: search range 8, one call to subnetlinker
+        self.assertEquals(self.sr[0], 8.)
+        self.assertEquals(len(self.source[0]), 2)
+        self.assertEquals(len(self.dest[0]), 2)
+        for p in self.source[0]:
+            self.assertEquals(len(p['forward_cands']), 3)
+            for cand, dist in p['forward_cands'][:-1]:
+                self.assertIsNot(cand, None)
+                self.assertLess(dist, self.sr[0])
+            self.assertIs(p['forward_cands'][-1][0], None)
+            self.assertAlmostEqual(p['forward_cands'][-1][1], self.sr[0])
+
+        # round 1: search range 2; same
+        self.assertEquals(self.sr[1], 2.)
+        self.assertEquals(len(self.source[1]), 2)
+        self.assertEquals(len(self.dest[1]), 2)
+        for p in self.source[1]:
+            for cand, dist in p['forward_cands'][:-1]:
+                self.assertIsNot(cand, None)
+                self.assertLess(dist, self.sr[1])
+            self.assertIs(p['forward_cands'][-1][0], None)
+            self.assertAlmostEqual(p['forward_cands'][-1][1], self.sr[1])
+
+        # round 2, both calls: search range 0.5, subnets separate
+        for i in (2, 3):
+            self.assertEquals(self.sr[i], 0.5)
+            self.assertEquals(len(self.source[i]), 1)
+            self.assertEquals(len(self.dest[i]), 1)
+            for p in self.source[i]:
+                self.assertEquals(len(p['forward_cands']), 2)
+                self.assertAlmostEqual(p['forward_cands'][0][1], 0.1)
+                self.assertIs(p['forward_cands'][1][0], None)
+                self.assertAlmostEqual(p['forward_cands'][1][1], self.sr[i])

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -800,12 +800,20 @@ class TestMockSubnetlinker(StrictTestCase):
 
         fwd_cds = source[0]['forward_cands']
 
+        # there are no forward candidates inside search_range
+        for p, dist in fwd_cds:
+            self.assertLessEqual(dist, search_range)
+
         # the forward candidate distances are sorted in ascending order
         for i in range(len(fwd_cds) - 1):
             self.assertLess(fwd_cds[i][1], fwd_cds[i + 1][1])
 
-        # the last one is None and its dist equals the search_range
+        # there's exactly one null candidate, at the end
+        for i in range(len(fwd_cds) - 1):
+            self.assertIsNot(fwd_cds[i][0], None)
         self.assertIs(fwd_cds[-1][0], None)
+
+        # the null candidate's dist equals the search_range
         self.assertEquals(fwd_cds[-1][1], search_range)
 
     def test_adaptive_subnet(self):


### PR DESCRIPTION
This partially addresses #487. When many iterations of adaptive search are required to reduce a subnet to solvable size, there is a "leak" that adds superfluous null particles to the list of forward candidates. This PR fixes that bug, but performance in this case is still much worse than the adaptive search implementation in v0.3.