### PR TITLE
DOC: Update Keim funding info

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -134,9 +134,10 @@ the University of Chicago, Chicago IL.  This work was supported in
 part by NSF Grant DMR-1105145 and NSF-MRSEC DMR-0820054.  Tom can be
 reached at tcaswell@gmail.com.
 
-This package was developed in part by Nathan C. Keim, as part of his postdoctoral
-research in Paulo Arratia's group at the University of Pennsylvania,
-Philadelphia. This work was supported by NSF-MRSEC DMR-1120901.
+This package was developed in part by Nathan C. Keim at Cal Poly,
+San Luis Obispo, California and supported by NSF Grant DMR-1708870.
+Portions were also developed at the University of Pennsylvania,
+Philadelphia, supported by NSF-MRSEC DMR-1120901.
 
 This package was developed in part by Casper van der Wel, as part of his
 PhD thesis work in Daniela Kraft’s group at the Huygens-Kamerlingh-Onnes laboratory,

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -125,19 +125,19 @@ Support
 
 This package was developed in part by Daniel Allan, as part of his
 PhD thesis work on microrheology in Robert L. Leheny's group at Johns Hopkins
-University in Baltimore, MD. The work was supported by the National Science Foundation
+University in Baltimore, MD, USA. The work was supported by the National Science Foundation
 under grant number CBET-1033985.  Dan can be reached at dallan@pha.jhu.edu.
 
 This package was developed in part by Thomas A Caswell as part of his
 PhD thesis work in Sidney R Nagel's and Margaret L Gardel's groups at
-the University of Chicago, Chicago IL.  This work was supported in
+the University of Chicago, Chicago IL, USA.  This work was supported in
 part by NSF Grant DMR-1105145 and NSF-MRSEC DMR-0820054.  Tom can be
 reached at tcaswell@gmail.com.
 
 This package was developed in part by Nathan C. Keim at Cal Poly,
-San Luis Obispo, California and supported by NSF Grant DMR-1708870.
+San Luis Obispo, California, USA and supported by NSF Grant DMR-1708870.
 Portions were also developed at the University of Pennsylvania,
-Philadelphia, supported by NSF-MRSEC DMR-1120901.
+Philadelphia, USA, supported by NSF-MRSEC DMR-1120901.
 
 This package was developed in part by Casper van der Wel, as part of his
 PhD thesis work in Daniela Kraft’s group at the Huygens-Kamerlingh-Onnes laboratory,


### PR DESCRIPTION
This just updates the "Support" section of the intro page to acknowledge current funding for my trackpy work. Also, to reduce the US-centeredness, all affiliations now specify the country.

Because I am closing out a reporting period, It would be great to merge this week if possible.