### PR TITLE
PERF/WIP: Parallel subnet solving

### DIFF
--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -238,7 +238,7 @@ def numba_link(s_sn, dest_size, search_range, max_size=30, diag=False):
     dest_results = [dcands[i] if i >= 0 else None for i in best_assignments]
     return source_results, dest_results
 
-@try_numba_jit(nopython=True)
+@try_numba_jit(nopython=True, nogil=True)
 def _numba_subnet_norecur(ncands, candsarray, dists2array, cur_assignments,
                           cur_sums, tmp_assignments, best_assignments):
     """Find the optimal track assignments for a subnetwork, without recursion.


### PR DESCRIPTION
Inspired by #499 , this uses the `nogil` option for numba so that the subnet solver can be multithreaded. Threading lets us avoid worrying very much about shared mutable state in the linker, and also has lower overhead. The current implementation uses the `concurrent.futures` module so it is not compatible with older Python versions, and that's why some of the tests fail.

I have confirmed that this lets linking use multiple CPUs. However I have not confirmed that this is a significant speedup for common workloads. So I invite interested users to try it out!! At some point I will try this out on my own data, which has lots of subnets.

Obviously this is also missing tests, and an API to control the new feature. Right now multithreading is always enabled.