### PR TITLE
TST/DOC: Add a test for vanhove and fix the documented example.

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -381,7 +381,7 @@ def vanhove(pos, lagtime, mpp=1, ensemble=False, bins=24):
     Examples
     --------
     >>> pos = traj.set_index(['frame', 'particle'])['x'].unstack() # particles as columns
-    >>> vh = vanhove(pos)
+    >>> vh = vanhove(pos, lagtime=2)
     """
     # Reindex with consecutive frames, placing NaNs in the gaps.
     pos = pos.reindex(np.arange(pos.index[0], 1 + pos.index[-1]))

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -206,6 +206,24 @@ class TestSpecial(StrictTestCase):
         self.steppers.groupby('particle').apply(theta_entropy)
 
 
+class TestVanHove(StrictTestCase):
+    def setUp(self):
+        N = 10
+        P = 50 # particles
+        A = 1 # step amplitude
+        np.random.seed(0)
+        particles = [DataFrame({'x': A*random_walk(N), 'y': A*random_walk(N),
+                                'frame': np.arange(N), 'particle': i})
+                     for i in range(P)]
+        self.many_walks = conformity(pandas_concat(particles))
+
+    def test_vanhove(self):
+        # a simple "smoke test" to ensure no exceptions are raised
+        traj = self.many_walks
+        pos = traj.set_index(['frame', 'particle'])['x'].unstack() # particles as columns
+        vh = tp.vanhove(pos, lagtime=2)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
The problem reported in #394 is still a mystery to me, but it did highlight
that the ``vanhove`` function has no test coverage. Here is a simple smoke
test.  It passes for me locally, in a fresh environment with the latest version
of all the required dependencies (obtained via pip):

```
$ pip list
cycler (0.10.0)
kiwisolver (1.0.1)
matplotlib (2.2.3)
nose (1.3.7)
numpy (1.15.0)
pandas (0.23.4)
pip (9.0.1)
pkg-resources (0.0.0)
pyparsing (2.2.0)
python-dateutil (2.7.3)
pytz (2018.5)
PyYAML (3.13)
scipy (1.1.0)
setuptools (39.0.1)
six (1.11.0)
trackpy (0.4.1+26.g964a3ae.dirty, /home/dallan/Repos/bnl/trackpy)
wheel (0.31.1)
```

The documented example was missing a required argument (``lagtime``). I fixed
that.