### PR TITLE
Solve numpy deprecation warnings

### DIFF
--- a/trackpy/artificial.py
+++ b/trackpy/artificial.py
@@ -108,7 +108,7 @@ def draw_feature(image, position, size, max_value=None, feat_func='gauss',
     coords = np.meshgrid(*vectors, indexing='ij', sparse=True)
     r = np.sqrt(np.sum(np.array(coords)**2, axis=0))
     spot = max_value * feat_func(r, ndim=image.ndim, **kwargs)
-    image[rect] += spot.astype(image.dtype)
+    image[tuple(rect)] += spot.astype(image.dtype)
 
 
 def gen_random_locations(shape, count, margin=0):

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -621,7 +621,7 @@ def characterize(coords, image, radius, scale_factor=1.):
                    for c, r, sh in zip(coord, radius, shape)]):
             continue
         rect = [slice(c - r, c + r + 1) for c, r in zip(coord, radius)]
-        neighborhood = mask * image[rect]
+        neighborhood = mask * image[tuple(rect)]
         mass[feat] = neighborhood.sum() / scale_factor
         signal[feat] = neighborhood.max() / scale_factor
         if isotropic:

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -121,7 +121,7 @@ def get_slice(coords, shape, radius):
         slices[i] = slice(int(round(lower_bound_trunc)),
                           int(round(upper_bound_trunc)))
         origin[i] = lower_bound_trunc
-    return slices, origin
+    return tuple(slices), origin
 
 
 def slice_image(pos, image, radius):

--- a/trackpy/refine/center_of_mass.py
+++ b/trackpy/refine/center_of_mass.py
@@ -229,8 +229,9 @@ def _refine(raw_image, image, radius, coords, max_iterations,
     for feat, coord in enumerate(coords):
         for iteration in range(max_iterations):
             # Define the circular neighborhood of (x, y).
-            rect = [slice(c - r, c + r + 1) for c, r in zip(coord, radius)]
-            neighborhood = mask*image[rect]
+            rect = tuple([slice(c - r, c + r + 1)
+                          for c, r in zip(coord, radius)])
+            neighborhood = mask * image[rect]
             cm_n = _safe_center_of_mass(neighborhood, radius, ogrid)
             cm_i = cm_n - radius + coord  # image coords
 
@@ -272,7 +273,7 @@ def _refine(raw_image, image, radius, coords, max_iterations,
         else:
             ecc[feat] = np.nan
         signal[feat] = neighborhood.max()  # based on bandpassed image
-        raw_neighborhood = mask*raw_image[rect]
+        raw_neighborhood = mask * raw_image[rect]
         raw_mass[feat] = raw_neighborhood.sum()  # based on raw image
 
     if not characterize:

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -553,7 +553,7 @@ class CommonFeatureIdentificationTests(object):
         rect = [slice(c - radius, c + radius + 1) for c in center]
         mask = tp.masks.binary_mask(radius, 2)
         Npx = mask.sum()
-        EXPECTED_MASS = (spot[rect] * mask).sum()
+        EXPECTED_MASS = (spot[tuple(rect)] * mask).sum()
 
         # Generate feature locations and make the image
         expected = gen_nonoverlapping_locations(shape, N, diameter, diameter)


### PR DESCRIPTION
Solves warnings like:
```
    FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  return image[slices], origin
```