### PR TITLE
FIX Do not calculate noise with insufficient pixels

### DIFF
--- a/doc/releases/v0.4.txt
+++ b/doc/releases/v0.4.txt
@@ -4,8 +4,8 @@ Development version
 API Changes
 ~~~~~~~~~~~
 
-- "trackpy.locate" and associated functions now report "signal" (and noise) to be
-  NaN when there is only one usable background pixel to sample. (:issue:`519`)
+- "trackpy.locate" and associated functions now report "ep" to be NaN when
+  there is only one usable background pixel to sample. (:issue:`519`)
 
 
 v0.4.2

--- a/doc/releases/v0.4.txt
+++ b/doc/releases/v0.4.txt
@@ -1,3 +1,13 @@
+Development version
+-------------------
+
+API Changes
+~~~~~~~~~~~
+
+- "trackpy.locate" and associated functions now report "signal" (and noise) to be
+  NaN when there is only one usable background pixel to sample. (:issue:`519`)
+
+
 v0.4.2
 ------
 

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -30,9 +30,10 @@ def measure_noise(image_bp, image_raw, radius):
     """
     structure = binary_mask(radius, image_bp.ndim)
     background = ~morphology.binary_dilation(image_bp, structure=structure)
-    if background.sum() == 0:  # edge case of no background identified
+    n_background = background.sum()
+    if n_background == 0:  # edge case of no background identified
         return np.nan, np.nan
-    elif background.sum() == 1:  # edge case of not enough background identified
+    elif n_background == 1:  # edge case of not enough background identified
         return image_raw[background].mean(), np.nan
     else:
         return image_raw[background].mean(), image_raw[background].std()

--- a/trackpy/uncertainty.py
+++ b/trackpy/uncertainty.py
@@ -32,6 +32,8 @@ def measure_noise(image_bp, image_raw, radius):
     background = ~morphology.binary_dilation(image_bp, structure=structure)
     if background.sum() == 0:  # edge case of no background identified
         return np.nan, np.nan
+    elif background.sum() == 1:  # edge case of not enough background identified
+        return image_raw[background].mean(), np.nan
     else:
         return image_raw[background].mean(), image_raw[background].std()
 


### PR DESCRIPTION
`uncertainty.measure_noise` returns 0 for noise if there is only one pixel in the background region. This leads to 0 for `ep` which I think is rather strange and unexpected. My change would instead make the result `NaN` which I think is more understandable to the end user.