### PR TITLE
Remove linking diagnostics docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -100,7 +100,6 @@ release or the `developer <https://http://soft-matter.github.io/trackpy/dev/>`_ 
    Adaptive Linking <tutorial/adaptive-search>
    Streaming <tutorial/on-disk>
    Performance <tutorial/performance>
-   Linking Diagnostics <tutorial/linking-diagnostics>
    Parallelized Feature Finding <tutorial/parallel-locate>
    Bubble Tracking in Foams <tutorial/custom-feature-detection>
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,7 +101,7 @@ release or the `developer <https://http://soft-matter.github.io/trackpy/dev/>`_ 
    Streaming <tutorial/on-disk>
    Performance <tutorial/performance>
    Parallelized Feature Finding <tutorial/parallel-locate>
-   Bubble Tracking in Foams <tutorial/custom-feature-detection>
+   Tracking Large Features Such As Bubbles <tutorial/custom-feature-detection>
 
 .. raw:: html
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -15,7 +15,6 @@ Basic Usage
    Uncertainty Estimation <tutorial/uncertainty>
    Advanced Linking <tutorial/subnets>
    Adaptive Linking <tutorial/adaptive-search>
-   Linking Diagnostics <tutorial/linking-diagnostics>
 
 Processing Large Data Sets
 --------------------------

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -31,4 +31,4 @@ Extending & Customizing Trackpy
 .. toctree::
    :maxdepth: 2
 
-   Bubble Tracking in Foams <tutorial/custom-feature-detection>
+   Tracking Large Features Such As Bubbles <tutorial/custom-feature-detection>


### PR DESCRIPTION
This removes references to a feature that was introduced in trackpy v0.4. 

It also renames the "bubble tracking in foams" tutorial to be easier to find. A couple different users have asked about large-feature tracking, and there are surely others who are wondering how to do it.