### PR TITLE
Issue 529

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup_parameters = dict(
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
     install_requires = ['numpy>=1.8', 'scipy>=0.12', 'six>=1.8',
-	                'pandas>=0.13', 'pyyaml', 'matplotlib'],
+	                'pandas>=0.13', 'pyyaml', 'matplotlib',
+                        'tables'],
     packages = ['trackpy', 'trackpy.refine', 'trackpy.linking'],
     long_description = descr,
 )

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup_parameters = dict(
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
     install_requires = ['numpy>=1.8', 'scipy>=0.12', 'six>=1.8',
-	                'pandas>=0.13', 'pyyaml', 'matplotlib',
-                        'tables'],
+	                'pandas>=0.13', 'pyyaml', 'matplotlib'],
     packages = ['trackpy', 'trackpy.refine', 'trackpy.linking'],
     long_description = descr,
 )

--- a/trackpy/framewise_data.py
+++ b/trackpy/framewise_data.py
@@ -248,13 +248,13 @@ class PandasHDFStoreSingleNode(FramewiseData):
         self._t_column = t_column
         self.store = pd.HDFStore(self.filename, mode, **kwargs)
 
-        with pd.HDFStore(self.filename) as store:
-            try:
-                store[self.key]
-            except KeyError:
-                pass
-            else:
-                self._validate_node(use_tabular_copy)
+        store = pd.HDFStore(self.filename)
+        try:
+            store[self.key]
+        except KeyError:
+            pass
+        else:
+            self._validate_node(use_tabular_copy)
 
     @property
     def t_column(self):

--- a/trackpy/framewise_data.py
+++ b/trackpy/framewise_data.py
@@ -248,7 +248,7 @@ class PandasHDFStoreSingleNode(FramewiseData):
         self._t_column = t_column
         self.store = pd.HDFStore(self.filename, mode, **kwargs)
 
-        with pd.get_store(self.filename) as store:
+        with pd.HDFStore(self.filename) as store:
             try:
                 store[self.key]
             except KeyError:

--- a/trackpy/framewise_data.py
+++ b/trackpy/framewise_data.py
@@ -255,6 +255,7 @@ class PandasHDFStoreSingleNode(FramewiseData):
             pass
         else:
             self._validate_node(use_tabular_copy)
+        store.close()
 
     @property
     def t_column(self):

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -313,7 +313,17 @@ def _pandas_sort_pre_017(df, by, *args, **kwargs):
     return df.sort(*args, columns=by, **kwargs)
 
 def _pandas_sort_post_017(df, by, *args, **kwargs):
-    """Use sort_values() to sort a DataFrame"""
+    """
+    Use sort_values() to sort a DataFrame
+    This raises a ValueError if the given value is both
+    a column and an index label, i.e.:
+    ValueError: 'frame' is both an index level and a column
+    label, which is ambiguous.
+    Because we usually sort by columns, we can rename
+    the index to supress the ValueError.
+    """
+    if df.index.name is not None and df.index.name in by:
+        df.index.name += '_index'
     return df.sort_values(*args, by=by, **kwargs)
 
 if is_pandas_since_017:


### PR DESCRIPTION
New versions of pandas issue a ValueError when you try to sort on a label that is both a column and an index. Because we mainly sort on columns, I propose to rename the index by appending '_index' in these cases.

While it might be better to address the underlying issue that we probably shouldn't give the index the same name as a column, this will give us a working trackpy for newer pandas versions for now. Additionally, it makes the `pandas_sort` function more robust.