### PR TITLE
Tutorial update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ matrix:
       env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
     - python: "2.7"
       env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 numba=0.13.4 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
-    # "Typical" environments: package versions from 2016
+    # "Typical" environments: versions 2-3 years old
+    # Python 2, circa 2016
     - python: "2.7"
       env: DEPS="numpy=1.10 scipy=0.17 matplotlib=1.5 pillow=3.1 pandas=0.18.1 scikit-image=0.12 pytables numba=0.23.1 scikit-learn=0.17.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
+    # Python 3, circa September 2017 (Anaconda 5.0.0)
     - python: "3.5"
-      env: DEPS="numpy=1.10 scipy=0.17 matplotlib=1.5 pillow=3.1 pandas=0.18.1 scikit-image=0.12 pytables numba=0.23.1 scikit-learn=0.17.1 pyyaml" BUILD_DOCS=true SKIP_SLOW=true
+      env: DEPS="numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml" BUILD_DOCS=true SKIP_SLOW=true
     # Environments with most recent versions, on python 2.7 and python 3.6
     - python: "2.7"
       env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn" BUILD_DOCS=false SKIP_SLOW=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
     - PYTHON: "C:\\Miniconda"
       PYTHON_VERSION: "2.7"
-      DEPS: "numpy=1.8.2 scipy=0.14.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 numba=0.13.4 pytables scikit-learn=0.14.1 pyyaml"
+      DEPS: "numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml"
 
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,8 +101,8 @@ release or the `developer <https://http://soft-matter.github.io/trackpy/dev/>`_ 
    Streaming <tutorial/on-disk>
    Performance <tutorial/performance>
    Parallelized Feature Finding <tutorial/parallel-locate>
+   Tracking Large Features Such As Bubbles <tutorial/custom-feature-detection>
    Tracking Particles' Rings in Bright-Field Microscopy <tutorial/brightfield>
-   Tracking Large Features Such as Bubbles, and Visualizing a Velocity Field <tutorial/custom-feature-detection>
 
 .. raw:: html
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,7 +101,8 @@ release or the `developer <https://http://soft-matter.github.io/trackpy/dev/>`_ 
    Streaming <tutorial/on-disk>
    Performance <tutorial/performance>
    Parallelized Feature Finding <tutorial/parallel-locate>
-   Tracking Large Features Such As Bubbles <tutorial/custom-feature-detection>
+   Tracking Particles' Rings in Bright-Field Microscopy <tutorial/brightfield>
+   Tracking Large Features Such as Bubbles, and Visualizing a Velocity Field <tutorial/custom-feature-detection>
 
 .. raw:: html
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -31,4 +31,5 @@ Extending & Customizing Trackpy
 .. toctree::
    :maxdepth: 2
 
+   Tracking Particles' Rings in Bright-Field Microscopy <tutorial/brightfield>
    Tracking Large Features Such as Bubbles, and Visualizing a Velocity Field <tutorial/custom-feature-detection>

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -31,4 +31,4 @@ Extending & Customizing Trackpy
 .. toctree::
    :maxdepth: 2
 
-   Tracking Large Features Such As Bubbles <tutorial/custom-feature-detection>
+   Tracking Large Features Such as Bubbles, and Visualizing a Velocity Field <tutorial/custom-feature-detection>

--- a/doc/tutorial/Makefile
+++ b/doc/tutorial/Makefile
@@ -7,6 +7,6 @@ notebooks:
 	# the first line is a title, which is necessary for it to be included in the Sphinx toctree
 	@- $(foreach FILE, $(FILES), \
 	    jupyter nbconvert --to html $(NOTEBOOK_DIR)/$(FILE) --output $(CURDIR)/$(FILE:.ipynb=.html); \
-	    echo -e '$(FILE:.ipynb=)\n------------------------------------------------\n.. raw:: html\n    :file: '$(FILE:.ipynb=.html) > $(FILE:.ipynb=.rst); \
+	    bash -c 'echo -e "$(FILE:.ipynb=)\n------------------------------------------------\n.. raw:: html\n    :file: "$(FILE:.ipynb=.html)' > $(FILE:.ipynb=.rst); \
 	)
 

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -108,7 +108,7 @@ def get_slice(coords, shape, radius):
     coords = coords[np.all(in_bounds, axis=0)]
     # return if no coordinates are left
     if len(coords) == 0:
-        return [slice(None, 0)] * ndim, None
+        return tuple([slice(None, 0)] * ndim), None
     # calculate the box
     lower = coords.min(axis=0) - radius
     upper = coords.max(axis=0) + radius + 1

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -514,10 +514,10 @@ def velocity_corr(t, frame1, frame2):
     DataFrame, indexed by particle, including dx, dy, and direction
     """
     j = relate_frames(t, frame1, frame2)
-    cosine = np.cos(np.subtract.outer(j.direction, j.direction))
-    r = np.sqrt(np.subtract.outer(j.x, j.x)**2 +
-                np.subtract.outer(j.y, j.y)**2)
-    dot_product = cosine*np.abs(np.multiply.outer(j.dr, j.dr))
+    cosine = np.cos(np.subtract.outer(j.direction.values, j.direction.values))
+    r = np.sqrt(np.subtract.outer(j.x.values, j.x.values)**2 +
+                np.subtract.outer(j.y.values, j.y.values)**2)
+    dot_product = cosine*np.abs(np.multiply.outer(j.dr.values, j.dr.values))
     upper_triangle = np.triu_indices_from(r, 1)
     result = DataFrame({'r': r[upper_triangle],
                         'dot_product': dot_product[upper_triangle]})


### PR DESCRIPTION
This makes a few small improvements:

* Tutorial page titles should no longer begin with "-e"
* Advertises bubble-tracking tutorial better, since it is a start-to-finish example like the walkthrough.
* Adds links to the brightfield feature tutorial in https://github.com/soft-matter/trackpy-examples/pull/50