### PR TITLE
API: Improve dependencies report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ matrix:
       env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
     - python: "2.7"
       env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 numba=0.13.4 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
-    # "Typical" environments: package versions from 2016
+    # "Typical" environments: versions 2-3 years old
+    # Python 2, circa 2016
     - python: "2.7"
       env: DEPS="numpy=1.10 scipy=0.17 matplotlib=1.5 pillow=3.1 pandas=0.18.1 scikit-image=0.12 pytables numba=0.23.1 scikit-learn=0.17.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
+    # Python 3, circa September 2017 (Anaconda 5.0.0)
     - python: "3.5"
-      env: DEPS="numpy=1.10 scipy=0.17 matplotlib=1.5 pillow=3.1 pandas=0.18.1 scikit-image=0.12 pytables numba=0.23.1 scikit-learn=0.17.1 pyyaml" BUILD_DOCS=true SKIP_SLOW=true
+      env: DEPS="numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml" BUILD_DOCS=true SKIP_SLOW=true
     # Environments with most recent versions, on python 2.7 and python 3.6
     - python: "2.7"
       env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn" BUILD_DOCS=false SKIP_SLOW=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
     - PYTHON: "C:\\Miniconda"
       PYTHON_VERSION: "2.7"
-      DEPS: "numpy=1.8.2 scipy=0.14.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 numba=0.13.4 pytables scikit-learn=0.14.1 pyyaml"
+      DEPS: "numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml"
 
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"

--- a/doc/releases/v0.4.txt
+++ b/doc/releases/v0.4.txt
@@ -32,12 +32,13 @@ Enhancements
 
 - Added "trackpy.linking.link_partial" (:issue:`445`)
 
-
 Bug fixes
 ~~~~~~~~~
 
 - Removed warnings in case Pandas 0.23 is used (:issue:`503`)
 
+- "trackpy.diag.dependencies" now gives information about a more complete set
+  of packages.
 
 v0.4.1
 ------

--- a/trackpy/diag.py
+++ b/trackpy/diag.py
@@ -31,7 +31,7 @@ def dependencies():
         optional dependency is not installed, None
     """
     packages = ['six', 'numpy', 'scipy', 'matplotlib', 'pandas',
-                'skimage', 'pyyaml', 'tables', 'numba', 'pyfftw']
+                'skimage', 'sklearn', 'pyyaml', 'tables', 'numba', 'pyfftw']
     result = OrderedDict()
 
     # trackpy itself comes first

--- a/trackpy/diag.py
+++ b/trackpy/diag.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 
 from . import try_numba
 from . import preprocessing
+from . import __version__
 
 
 def performance_report():
@@ -30,8 +31,12 @@ def dependencies():
         optional dependency is not installed, None
     """
     packages = ['six', 'numpy', 'scipy', 'matplotlib', 'pandas',
-                'scikit-image', 'pyyaml', 'pytables', 'numba', 'pyfftw']
+                'skimage', 'pyyaml', 'tables', 'numba', 'pyfftw']
     result = OrderedDict()
+
+    # trackpy itself comes first
+    result['trackpy'] = __version__
+
     for package_name in packages:
         try:
             package = importlib.import_module(package_name)
@@ -43,9 +48,11 @@ def dependencies():
             except AttributeError:
                 version = package.version  # pyfftw does not have __version__
             result[package_name] = version
+
     # Build Python version string
     version_info = sys.version_info
     version_string = '.'.join(map(str, [version_info[0], version_info[1],
                                   version_info[2]]))
     result['python'] = version_string
+
     return result

--- a/trackpy/diag.py
+++ b/trackpy/diag.py
@@ -31,7 +31,7 @@ def dependencies():
         optional dependency is not installed, None
     """
     packages = ['six', 'numpy', 'scipy', 'matplotlib', 'pandas',
-                'skimage', 'sklearn', 'pyyaml', 'tables', 'numba', 'pyfftw']
+                'skimage', 'sklearn', 'pyyaml', 'tables', 'numba', 'pims']
     result = OrderedDict()
 
     # trackpy itself comes first
@@ -43,11 +43,7 @@ def dependencies():
         except ImportError:
             result[package_name] = None
         else:
-            try:
-                version = package.__version__
-            except AttributeError:
-                version = package.version  # pyfftw does not have __version__
-            result[package_name] = version
+            result[package_name] = package.__version__
 
     # Build Python version string
     version_info = sys.version_info

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -108,7 +108,7 @@ def get_slice(coords, shape, radius):
     coords = coords[np.all(in_bounds, axis=0)]
     # return if no coordinates are left
     if len(coords) == 0:
-        return [slice(None, 0)] * ndim, None
+        return tuple([slice(None, 0)] * ndim), None
     # calculate the box
     lower = coords.min(axis=0) - radius
     upper = coords.max(axis=0) + radius + 1

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -514,10 +514,10 @@ def velocity_corr(t, frame1, frame2):
     DataFrame, indexed by particle, including dx, dy, and direction
     """
     j = relate_frames(t, frame1, frame2)
-    cosine = np.cos(np.subtract.outer(j.direction, j.direction))
-    r = np.sqrt(np.subtract.outer(j.x, j.x)**2 +
-                np.subtract.outer(j.y, j.y)**2)
-    dot_product = cosine*np.abs(np.multiply.outer(j.dr, j.dr))
+    cosine = np.cos(np.subtract.outer(j.direction.values, j.direction.values))
+    r = np.sqrt(np.subtract.outer(j.x.values, j.x.values)**2 +
+                np.subtract.outer(j.y.values, j.y.values)**2)
+    dot_product = cosine*np.abs(np.multiply.outer(j.dr.values, j.dr.values))
     upper_triangle = np.triu_indices_from(r, 1)
     result = DataFrame({'r': r[upper_triangle],
                         'dot_product': dot_product[upper_triangle]})


### PR DESCRIPTION
This corrects some of the package names in `diag.dependencies()` and adds trackpy as a "dependency" to aid in diagnostics. It also puts `dependencies()` into the root namespace, so it will eventually be easier to ask people to run it.

This was originally part of #566 but I'm making it a separate PR.