### PR TITLE
BLD: Add locate_functions to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup_parameters = dict(
     url = "https://github.com/soft-matter/trackpy",
     install_requires = ['numpy>=1.8', 'scipy>=0.12', 'six>=1.8',
 	                'pandas>=0.13', 'pyyaml', 'matplotlib'],
-    packages = ['trackpy', 'trackpy.refine', 'trackpy.linking'],
+    packages = ['trackpy', 'trackpy.refine', 'trackpy.linking', 'trackpy.locate_functions'],
     long_description = descr,
 )
 


### PR DESCRIPTION
#527 reorganized the locate code and created the `locate_functions` subdirectory. This makes sure it is included in the source distributions made by e.g. `python setup.py sdist`.

This will fix an issue with `v0.4.2rc1`; I will then try out `v0.4.2rc2`.