### PR TITLE
Accelerate linking by avoiding DataFrame.groupby.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false
+      env: DEPS="numpy=1.9 scipy=0.14.0 matplotlib=1.4 pillow=2.1 pandas=0.15 scikit-image=0.10 pytables scikit-learn=0.15 pyyaml libgfortran=1" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 numba=0.13.4 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false
+      env: DEPS="numpy=1.9 scipy=0.14.0 matplotlib=1.4 pillow=2.1 pandas=0.15 scikit-image=0.10 numba=0.14 pytables scikit-learn=0.15 pyyaml libgfortran=1" BUILD_DOCS=false
     # "Typical" environments: versions 2-3 years old
     # Python 2, circa 2016
     - python: "2.7"

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup_parameters = dict(
     author = "Trackpy Contributors",
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
-    install_requires = ['numpy>=1.8', 'scipy>=0.12', 'six>=1.8',
-	                'pandas>=0.13', 'pyyaml', 'matplotlib'],
+    install_requires = ['numpy>=1.9', 'scipy>=0.14', 'six>=1.8',
+                        'pandas>=0.15', 'pyyaml', 'matplotlib'],
     packages = ['trackpy', 'trackpy.refine', 'trackpy.linking', 'trackpy.locate_functions'],
     long_description = descr,
 )


### PR DESCRIPTION
On a personal dataset, this patch accelerates trackpy.link_df ~3-fold.
(I haven't managed to run the vbench benchmarks locally -- Py2 environments are too far away for me.)

Edit: This bumps the oldest supported numpy from 1.8.2 (released Aug. 4 2014) to 1.9.0 (released Sept. 7 2014, added return_counts), and thus also matplotlib from 1.3 to 1.4, numba from 0.13 to 0.14, scikit-image from 0.9 to 0.10, scikit-learn from 0.14 to 0.15, scipy from 0.12 to 0.14, and pandas from 0.13 to 0.15 (all because of availability of conda packages, except pandas 0.15 for some obscure compat with pytables problem?).  Hopefully that's fine with the devs; I can do without but the code would be a tiny bit more complicated.