### PR TITLE
Remove dependency of test suite on nose.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,26 @@ matrix:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
+      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 numba=0.13.4 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
+      env: DEPS="numpy=1.8.2 scipy=0.12.0 matplotlib=1.3 pillow=2.1 pandas=0.13.0 scikit-image=0.9 numba=0.13.4 pytables scikit-learn=0.14.1 pyyaml" BUILD_DOCS=false
     # "Typical" environments: versions 2-3 years old
     # Python 2, circa 2016
     - python: "2.7"
-      env: DEPS="numpy=1.10 scipy=0.17 matplotlib=1.5 pillow=3.1 pandas=0.18.1 scikit-image=0.12 pytables numba=0.23.1 scikit-learn=0.17.1 pyyaml" BUILD_DOCS=false SKIP_SLOW=true
+      env: DEPS="numpy=1.10 scipy=0.17 matplotlib=1.5 pillow=3.1 pandas=0.18.1 scikit-image=0.12 pytables numba=0.23.1 scikit-learn=0.17.1 pyyaml" BUILD_DOCS=false
     # Python 3, circa September 2017 (Anaconda 5.0.0)
     - python: "3.5"
-      env: DEPS="numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml" BUILD_DOCS=true SKIP_SLOW=true
+      env: DEPS="numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml" BUILD_DOCS=true
     # Environments with most recent versions, on python 2.7 and python 3.6
     - python: "2.7"
-      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn" BUILD_DOCS=false SKIP_SLOW=true
+      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn" BUILD_DOCS=false
     - python: "3.6"
-      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"  BUILD_DOCS=false SKIP_SLOW=false
+      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"  BUILD_DOCS=false
 
 
 install:
   - conda update --yes conda
-  - conda create -n testenv --yes $DEPS nose python=$TRAVIS_PYTHON_VERSION
+  - conda create -n testenv --yes $DEPS python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
 
   # for debugging...
@@ -40,7 +40,7 @@ before_install:
   - export PATH=/home/travis/mc/bin:$PATH
 
 script:
-  - if [ $SKIP_SLOW == true ]; then nosetests --nologcapture -a '!slow'; else nosetests --nologcapture; fi
+  - python -munittest
   - |
     if [ $BUILD_DOCS == true ]; then
       conda config --append channels conda-forge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
 
   # Install dependencies
   - conda update --yes conda
-  - conda create -n testenv --yes %DEPS% nose python=%PYTHON_VERSION%
+  - conda create -n testenv --yes %DEPS% python=%PYTHON_VERSION%
   - activate testenv
 
   # for debugging...
@@ -31,4 +31,4 @@ install:
 build: false
 
 test_script:
-  - nosetests --nologcapture -A "not slow"
+  - python -munittest

--- a/trackpy/tests/README.rst
+++ b/trackpy/tests/README.rst
@@ -3,4 +3,6 @@ Testing
 
 This suite of tests verifies that everything is working as expected. There are unit tests, checking for sanity. There are systems tests, running multistep calculations to reproduce the result of a control experiment such as the viscosity of water. (So far, that's the only one.)
 
-Tests should be run using [nosetests](https://nose.readthedocs.org/en/latest/).
+Tests should be run using unittest_.
+
+.. _unittest: https://docs.python.org/3/library/unittest.html

--- a/trackpy/tests/locate/test_brightfield_ring.py
+++ b/trackpy/tests/locate/test_brightfield_ring.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import logging
 
-import nose
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -274,6 +273,5 @@ class TestLocateBrightfieldRing(StrictTestCase):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_correlations.py
+++ b/trackpy/tests/test_correlations.py
@@ -32,7 +32,7 @@ class TestCorrelations(StrictTestCase):
         expected = np.zeros_like(actual)
         assert_allclose(actual, expected, atol=1e-3)
 
+
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -3,9 +3,9 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import range
 import os
+import unittest
 import warnings
 
-import nose
 import numpy as np
 from pandas import DataFrame
 from numpy.testing import assert_allclose, assert_array_less
@@ -797,14 +797,13 @@ class TestFeatureIdentificationWithNumba(
 
     def check_skip(self):
         if not NUMBA_AVAILABLE:
-            raise nose.SkipTest("Numba not installed. Skipping.")
+            raise unittest.SkipTest("Numba not installed. Skipping.")
 
     def skip_numba(self):
-        raise nose.SkipTest("This feature is not "
-                            "supported by the numba variant. Skipping.")
+        raise unittest.SkipTest("This feature is not "
+                                "supported by the numba variant. Skipping.")
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -2,9 +2,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import functools
-import nose
-import warnings
 import os
+import unittest
+import warnings
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
@@ -42,7 +42,7 @@ def _skip_if_no_pytables():
     try:
         import tables
     except ImportError:
-        raise nose.SkipTest('pytables not installed. Skipping.')
+        raise unittest.SkipTest('pytables not installed. Skipping.')
 
 
 class FeatureSavingTester(object):
@@ -63,7 +63,7 @@ class FeatureSavingTester(object):
         try:
             s = self.storage_class(STORE_NAME)
         except IOError:
-            nose.SkipTest('Cannot make an HDF5 file. Skipping')
+            unittest.SkipTest('Cannot make an HDF5 file. Skipping')
         else:
             tp.batch(self.v, output=s, engine='python', meta=False,
                      **self.PARAMS)
@@ -108,7 +108,7 @@ class TestPandasHDFStoreBig(FeatureSavingTester, StrictTestCase):
         try:
             s = self.storage_class(STORE_NAME)
         except IOError:
-            nose.SkipTest('Cannot make an HDF5 file. Skipping')
+            unittest.SkipTest('Cannot make an HDF5 file. Skipping')
         else:
             framedata = self.expected[self.expected.frame == 0]
             def putfake(store, i):
@@ -175,6 +175,5 @@ class TestPandasHDFStoreSingleNodeCompressed(FeatureSavingTester,
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_find.py
+++ b/trackpy/tests/test_find.py
@@ -120,6 +120,5 @@ class TestFindGreyDilationLegacy(StrictTestCase):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -2,10 +2,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import itertools
+import unittest
+
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
-import nose
 from numpy.testing import assert_equal
 
 from trackpy.utils import pandas_sort
@@ -24,7 +25,7 @@ class FindLinkTests(SubnetNeededTests):
 
     def link(self, f, search_range, *args, **kwargs):
         if 'pos_columns' in kwargs:
-            raise nose.SkipTest('Skipping find_link tests with custom pos_columns.')
+            raise unittest.SkipTest('Skipping find_link tests with custom pos_columns.')
         # the minimal spacing between features in f is assumed to be 1.
 
         # from scipy.spatial import cKDTree
@@ -94,7 +95,7 @@ class FindLinkOneFailedFindTests(FindLinkTests):
         fail_frame = FAIL_FRAME.get(test_name, 3)
 
         if fail_frame is None:
-            nose.SkipTest()
+            unittest.SkipTest()
 
         def callback(image, coords, **unused_kwargs):
             if image.frame_no == fail_frame:
@@ -126,7 +127,7 @@ class FindLinkManyFailedFindTests(FindLinkTests):
         fail_frame = FAIL_FRAME.get(test_name, 3)
 
         if fail_frame is None:
-            raise nose.SkipTest()
+            raise unittest.SkipTest()
 
         def callback(image, coords, **unused_kwargs):
             if image.frame_no >= fail_frame:

--- a/trackpy/tests/test_leastsq.py
+++ b/trackpy/tests/test_leastsq.py
@@ -1,5 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+
+from unittest import SkipTest
+
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_allclose
@@ -12,8 +15,6 @@ from trackpy.refine.least_squares import (dimer, trimer, tetramer, dimer_global,
                                           FitFunctions, vect_from_params)
 from trackpy.tests.common import assert_coordinates_close, StrictTestCase
 from scipy.optimize.slsqp import approx_jacobian
-from nose import SkipTest
-from nose.plugins.attrib import attr
 
 
 EPSILON = 1E-7
@@ -653,7 +654,6 @@ class RefineTsts(object):
         self.assertLess(devs['parr_mean'], self.accuracy_constrained * max(self.size))
         self.assertLess(devs['perp_rms'], self.precision_perfect)
 
-    @attr('slow')
     def test_trimer_constrained(self):
         hard_radius = 1.
         constraints = trimer(2*np.array(self.size)*hard_radius, self.ndim)
@@ -666,7 +666,6 @@ class RefineTsts(object):
 
         self.assertLess(devs['pos'], self.precision_perfect)
 
-    @attr('slow')
     def test_tetramer_constrained(self):
         if self.ndim != 3:
             raise SkipTest('Tetramers are only tested in 3D')
@@ -696,7 +695,6 @@ class TestFit_gauss2D(RefineTsts, StrictTestCase):
 #      fit_func = 'gauss'
 
 
-@attr('slow')
 class TestFit_gauss3D(RefineTsts, StrictTestCase):
      size = SIZE_3D
      ndim = 3
@@ -704,7 +702,6 @@ class TestFit_gauss3D(RefineTsts, StrictTestCase):
      fit_func = 'gauss'
 
 
-@attr('slow')
 class TestFit_gauss3D_a(RefineTsts, StrictTestCase):
      size = SIZE_3D_ANISOTROPIC
      ndim = 3
@@ -840,7 +837,6 @@ class TestMultiple(StrictTestCase):
         assert_coordinates_close(result[self.im.pos_columns].values,
                                  self.im.coords, 0.1)
 
-    @attr('slow')
     def test_var_global(self):
         self.im.clear()
         self.im.draw_features(100, 15, self.diameter)
@@ -1017,5 +1013,5 @@ class TestFitFunctions(StrictTestCase):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb'], exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_legacy_linking.py
+++ b/trackpy/tests/test_legacy_linking.py
@@ -3,13 +3,13 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 from copy import deepcopy
+import unittest
 import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal
 import pandas as pd
 from pandas import DataFrame
-import nose
 
 from trackpy.try_numba import NUMBA_AVAILABLE
 from trackpy.linking.legacy import (link, link_df, link_df_iter,
@@ -41,7 +41,7 @@ def hash_generator(dims, box_size):
 
 def _skip_if_no_numba():
     if not NUMBA_AVAILABLE:
-        raise nose.SkipTest('numba not installed. Skipping.')
+        raise unittest.SkipTest('numba not installed. Skipping.')
 
 
 def random_walk(N):
@@ -309,14 +309,14 @@ class CommonTrackingTests(object):
         assert_traj_equal(actual_iter, expected)
         assert 'particle' not in f.columns
 
-    @nose.tools.raises(SubnetOversizeException)
     def test_oversize_fail(self):
-        self.link_df(contracting_grid(), 1)
+        with self.assertRaises(SubnetOversizeException):
+            self.link_df(contracting_grid(), 1)
 
-    @nose.tools.raises(SubnetOversizeException)
     def test_adaptive_fail(self):
         """Check recursion limit"""
-        self.link_df(contracting_grid(), 1, adaptive_stop=0.92)
+        with self.assertRaises(SubnetOversizeException):
+            self.link_df(contracting_grid(), 1, adaptive_stop=0.92)
 
     def link(self, *args, **kwargs):
         kwargs.update(self.linker_opts)
@@ -357,11 +357,11 @@ class TestOnce(StrictTestCase):
         f_iter = (frame for fnum, frame in f.groupby('arbitrary name'))
         list(link_df_iter(f_iter, 5, t_column=name, verify_integrity=True))
 
-    @nose.tools.raises(ValueError)
     def test_check_iter(self):
         """Check that link_df_iter() makes a useful error message if we
         try to pass a single DataFrame."""
-        list(link_df_iter(self.features.copy(), 5))
+        with self.assertRaises(ValueError):
+            list(link_df_iter(self.features.copy(), 5))
 
 
 class SubnetNeededTests(CommonTrackingTests):
@@ -770,7 +770,7 @@ class TestBTreeWithNumbaLink(NumbaOnlyTests, StrictTestCase):
         self.linker_opts = dict(link_strategy='numba',
                                 neighbor_strategy='BTree')
 
+
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -3,10 +3,11 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 from copy import copy
+import unittest
+
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
-import nose
 from numpy.testing import assert_equal
 
 from trackpy.try_numba import NUMBA_AVAILABLE
@@ -27,7 +28,7 @@ def random_walk(N):
 
 def _skip_if_no_numba():
     if not NUMBA_AVAILABLE:
-        raise nose.SkipTest('numba not installed. Skipping.')
+        raise unittest.SkipTest('numba not installed. Skipping.')
 
 
 SKLEARN_AVAILABLE = True
@@ -39,7 +40,7 @@ except ImportError:
 
 def _skip_if_no_sklearn():
     if not SKLEARN_AVAILABLE:
-        raise nose.SkipTest('Scikit-learn not installed. Skipping.')
+        raise unittest.SkipTest('Scikit-learn not installed. Skipping.')
 
 def unit_steps():
     return pd.DataFrame(dict(x=np.arange(5), y=5, frame=np.arange(5)))
@@ -303,15 +304,15 @@ class CommonTrackingTests(StrictTestCase):
                            to_eucl=to_eucl)
         assert_traj_equal(actual, expected)
 
-    @nose.tools.raises(SubnetOversizeException)
     def test_oversize_fail(self):
-        df = contracting_grid()
-        self.link(df, search_range=2)
+        with self.assertRaises(SubnetOversizeException):
+            df = contracting_grid()
+            self.link(df, search_range=2)
 
-    @nose.tools.raises(SubnetOversizeException)
     def test_adaptive_fail(self):
         """Check recursion limit"""
-        self.link(contracting_grid(), search_range=2, adaptive_stop=1.84)
+        with self.assertRaises(SubnetOversizeException):
+            self.link(contracting_grid(), search_range=2, adaptive_stop=1.84)
 
     def link(self, f, search_range, *args, **kwargs):
         kwargs = dict(self.linker_opts, **kwargs)

--- a/trackpy/tests/test_mask.py
+++ b/trackpy/tests/test_mask.py
@@ -211,7 +211,6 @@ class TestMasking(StrictTestCase):
         assert_equal(sli.sum(), 13)
 
 
-
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb'], exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_misc.py
+++ b/trackpy/tests/test_misc.py
@@ -1,17 +1,16 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
-import os
 import logging
-import warnings
+import os
 import types
+import unittest
+import warnings
 
 import trackpy
 import trackpy.diag
 from trackpy.tests.common import StrictTestCase
 from trackpy.try_numba import NUMBA_AVAILABLE
-
-import nose
 
 path, _ = os.path.split(os.path.abspath(__file__))
 
@@ -50,7 +49,7 @@ class LoggerTests(StrictTestCase):
 class NumbaTests(StrictTestCase):
     def setUp(self):
         if not NUMBA_AVAILABLE:
-            raise nose.SkipTest("Numba not installed. Skipping.")
+            raise unittest.SkipTest("Numba not installed. Skipping.")
         self.funcs = trackpy.try_numba._registered_functions
 
     def tearDown(self):

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -207,6 +207,5 @@ class TestSpecial(StrictTestCase):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_plot_traj_labeling.py
+++ b/trackpy/tests/test_plot_traj_labeling.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import os
 
-from nose.plugins.attrib import attr
 import pandas as pd
 
 from trackpy import ptraj
@@ -15,14 +14,14 @@ path, _ = os.path.split(os.path.abspath(__file__))
 
 class TestLabeling(StrictTestCase):
     def setUp(self):
-        self.sparse = pd.read_pickle(os.path.join(path, 'data', 
+        self.sparse = pd.read_pickle(os.path.join(path, 'data',
                                            'sparse_trajectories.df'))
 
-    @attr('slow')
     def test_labeling_sparse_trajectories(self):
         suppress_plotting()
         ptraj(self.sparse, label=True) # No errors?
+
+
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -1,6 +1,6 @@
 
-from nose.plugins.attrib import attr
 import os
+import unittest
 
 import numpy as np
 import pandas as pd
@@ -11,7 +11,6 @@ from trackpy import plots
 from trackpy.utils import suppress_plotting, fit_powerlaw
 from trackpy.tests.common import StrictTestCase
 
-import nose
 # Quiet warnings about Axes not being compatible with tight_layout
 import warnings
 warnings.filterwarnings("ignore", message="This figure includes Axes that are not compatible with tight_layout")
@@ -28,17 +27,16 @@ else:
 
 def _skip_if_no_pims():
     if not PIMS_AVAILABLE:
-        raise nose.SkipTest('PIMS not installed. Skipping.')
+        raise unittest.SkipTest('PIMS not installed. Skipping.')
 
 
 class TestPlots(StrictTestCase):
     def setUp(self):
         # older matplotlib may raise an invalid error
         np.seterr(invalid='ignore')
-        self.sparse = pd.read_pickle(os.path.join(path, 'data', 
+        self.sparse = pd.read_pickle(os.path.join(path, 'data',
                                            'sparse_trajectories.df'))
 
-    @attr('slow')
     def test_labeling_sparse_trajectories(self):
         suppress_plotting()
         plots.plot_traj(self.sparse, label=True)
@@ -127,6 +125,5 @@ class TestPlots(StrictTestCase):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -3,8 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import functools
 
-from nose import SkipTest
-import nose.tools
+import unittest
 import numpy as np
 import pandas
 
@@ -97,13 +96,13 @@ class BaselinePredictTests(LinkWithPrediction, StrictTestCase):
                                 self.get_unwrapped_linker(), 45)
         assert not all(ll.values == 2)
 
-    @nose.tools.raises(trackpy.SubnetOversizeException)
     def test_subnet_fail(self):
-        Nside = Nside_oversize
-        ll = get_linked_lengths((mkframe(0, Nside),
-                                 mkframe(25, Nside),
-                                 mkframe(75, Nside)),
-                                self.get_unwrapped_linker(), 100)
+        with self.assertRaises(trackpy.SubnetOversizeException):
+            Nside = Nside_oversize
+            ll = get_linked_lengths((mkframe(0, Nside),
+                                     mkframe(25, Nside),
+                                     mkframe(75, Nside)),
+                                    self.get_unwrapped_linker(), 100)
 
 class VelocityPredictTests(LinkWithPrediction):
     def test_simple_predict(self):
@@ -152,7 +151,7 @@ class VelocityPredictTests(LinkWithPrediction):
 
     def test_predict_diagnostics(self):
         if getattr(self, 'coords_via_images', False):
-            raise SkipTest
+            raise unittest.SkipTest
         """Minimally test predictor instrumentation."""
         pred = self.instrumented_predict_class()
         Nside = Nside_oversize
@@ -402,7 +401,5 @@ class FLChannelPredictYTests(FindLinkPredictTest, ChannelPredictYTests):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
-
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_preprocessing.py
+++ b/trackpy/tests/test_preprocessing.py
@@ -1,5 +1,7 @@
 from __future__ import division
-import nose
+
+import unittest
+
 from numpy.testing.utils import assert_allclose
 from trackpy.preprocessing import (bandpass, legacy_bandpass,
                                    legacy_bandpass_fftw)
@@ -24,12 +26,12 @@ class LegacyPreprocessingTests(StrictTestCase):
         try:
             import pyfftw
         except ImportError:
-            raise nose.SkipTest("pyfftw not installed. Skipping.")
+            raise unittest.SkipTest("pyfftw not installed. Skipping.")
         lbp_fftw = legacy_bandpass_fftw(self.frame, 2, 5)[self.margin:-self.margin,
                                                           self.margin:-self.margin]
         assert_allclose(lbp_fftw, self.bp_scipy, atol=1.1)
 
+
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()

--- a/trackpy/tests/test_static.py
+++ b/trackpy/tests/test_static.py
@@ -6,7 +6,6 @@ from trackpy.static import *
 import pandas as pd
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_less
-from nose.plugins.attrib import attr
 from trackpy.static import cluster
 from trackpy.tests.common import StrictTestCase
 
@@ -99,7 +98,6 @@ class TestPairCorrelation(StrictTestCase):
         r = peaks.max() * 1/x**2
         self.assertTrue( np.allclose(peaks, r, atol=.02) )
 
-    @attr('slow')
     def test_correlation_3d_lattice(self):
         ### Lattice Test 
         # With proper edge handling, g(r) of the particle at the center should 
@@ -488,6 +486,5 @@ class TestFindClusters(StrictTestCase):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    import unittest
+    unittest.main()


### PR DESCRIPTION
Nose is quite unlikely to be installed on a dev's machine these days.

The test suite can fairly easily be converted to plain unittest, except
for the "slow" attrs which would need pytest to be replicated.  I'm not
against making the test suite depend on pytest (which is quite common
nowadays), but I'm not really sure it's worth it either -- the slow
tests don't add *so much* runtime to the test suite either.