### PR TITLE
Make docs buildable with recent numpydocs

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -28,9 +28,9 @@ def msd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
     -------
     DataFrame([<x>, <y>, <x^2>, <y^2>, msd], index=t)
 
-    If detail is True, the DataFrame also contains a column N,
-    the estimated number of statistically independent measurements
-    that comprise the result at each lagtime.
+        If detail is True, the DataFrame also contains a column N,
+        the estimated number of statistically independent measurements
+        that comprise the result at each lagtime.
 
     Notes
     -----
@@ -38,7 +38,8 @@ def msd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
 
     See also
     --------
-    imsd() and emsd()
+    imsd
+    emsd
     """
     if traj['frame'].max() - traj['frame'].min() + 1 == len(traj):
         # no gaps: use fourier-transform algorithm

--- a/trackpy/predict.py
+++ b/trackpy/predict.py
@@ -337,8 +337,8 @@ def instrumented(limit=None):
 
     limit : maximum number of recent frames to retain. If None, keep all.
 
-    Example
-    -------
+    Examples
+    --------
 
     >>> pred = instrumented()(ChannelPredict)(50, flow_axis='y')
     >>> pred.link_df_iter(...)


### PR DESCRIPTION
... which have become stricter validation-wise.

Note that while old numpydocs did not error on the "imsd() and emsd()"
"See Also" section, they only linked to imsd() and silently dropped
emsd().  (A recent numpydoc just errors on it.)