### PR TITLE
Fix deprecations in recent Pythons.

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -4,13 +4,16 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from six.moves import zip
 from itertools import tee
-from collections import Iterable
 from functools import wraps
 import warnings
 import logging
 
 import numpy as np
 
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 try:
     from pims import plot_to_frame, plots_to_frame, normalize
 except ImportError:

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -186,7 +186,7 @@ HH:MM:SS, H:MM:SS, MM:SS, and M:SS all OK.
     if not isinstance(partial_timestamp, str):
         # might be NaN or other unprocessable entry
         return partial_timestamp
-    input_format = '\d?\d?:?\d?\d:\d\d'
+    input_format = r'\d?\d?:?\d?\d:\d\d'
     if not re.match(input_format, partial_timestamp):
         raise ValueError("Input string cannot be regularized.")
     partial_digits = list(partial_timestamp)


### PR DESCRIPTION
Iterable will be removed from collections in Py3.9; \d is an invalid
escape.