### PR TITLE
PERF: Don't sort links before applying them.

### DIFF
--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -307,13 +307,6 @@ def adaptive_link_wrap(source_set, dest_set, search_range, subnet_linker,
     return sn_spl, sn_dpl
 
 
-def _sort_key_spl_dpl(x):
-    if x[0] is not None:
-        return list(x[0].pos)
-    else:
-        return list(x[1].pos)
-
-
 class Linker(object):
     """Linker class that sequentially links ndarrays of coordinates together.
 
@@ -536,7 +529,7 @@ class Linker(object):
 
     def apply_links(self, spl, dpl):
         new_mem_set = set()
-        for sp, dp in sorted(zip(spl, dpl), key=_sort_key_spl_dpl):
+        for sp, dp in zip(spl, dpl):
             # Do linking
             if sp is not None and dp is not None:
                 sp.track.add_point(dp)


### PR DESCRIPTION
This should not have any effects on the linking(?) given that the
sorting is by x/y coordinate, which is basically arbitrary.

This speeds up the simple example below by ~15%
```python
import time
import numpy as np
from pandas import DataFrame
import trackpy as tp; tp.ignore_logging()

n_particles = 50
n_frames = 10000
frame_size = 200
starting = np.random.random((n_particles, 2)) * frame_size
dxys = np.random.standard_normal((n_frames, n_particles, 2))
xys = starting + np.cumsum(dxys, axis=0)
frames = []
xs = []
ys = []
for f in range(n_frames):
    for p in range(n_particles):
        if np.random.random() < 0.5:  # Kill half of the localizations.
            continue
        frames.append(f)
        xs.append(xys[f, p, 0])
        ys.append(xys[f, p, 1])
df = DataFrame({"frame": frames, "x": xs, "y": ys})

__start = time.perf_counter()
tp.link_df(df, 3, memory=10)
print("elapsed", time.perf_counter() - __start)
```

On personal datasets the speedup goes up to 2x(!).

This PR goes on top of #596.