### PR TITLE
Fix `direction_corr()` for Pandas 1.0

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -490,9 +490,9 @@ def direction_corr(t, frame1, frame2):
     DataFrame, indexed by particle, including dx, dy, and direction
     """
     j = relate_frames(t, frame1, frame2)
-    cosine = np.cos(np.subtract.outer(j.direction, j.direction))
-    r = np.sqrt(np.subtract.outer(j.x, j.x)**2 +
-                np.subtract.outer(j.y, j.y)**2)
+    cosine = np.cos(np.subtract.outer(j.direction.values, j.direction.values))
+    r = np.sqrt(np.subtract.outer(j.x.values, j.x.values)**2 +
+                np.subtract.outer(j.y.values, j.y.values)**2)
     upper_triangle = np.triu_indices_from(r, 1)
     result = DataFrame({'r': r[upper_triangle],
                         'cos': cosine[upper_triangle]})

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -487,7 +487,7 @@ def direction_corr(t, frame1, frame2):
 
     Returns
     -------
-    DataFrame, indexed by particle, including dx, dy, and direction
+    DataFrame for all particle pairs, including dx, dy, and direction
     """
     j = relate_frames(t, frame1, frame2)
     cosine = np.cos(np.subtract.outer(j.direction.values, j.direction.values))

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -189,6 +189,13 @@ class TestMSD(StrictTestCase):
         actual.index = expected.index
         assert_series_equal(np.round(actual), expected)
 
+    def test_direction_corr(self):
+        # just a smoke test
+        f1, f2 = 2, 6
+        df = tp.motion.direction_corr(self.many_walks, f1, f2)
+        P = len(self.many_walks.particle.unique())
+        assert len(df) == (P * (P - 1)) / 2
+
 
 class TestSpecial(StrictTestCase):
     def setUp(self):
@@ -216,13 +223,6 @@ class TestSpecial(StrictTestCase):
             assert 'd' + c in df
         assert 'dr' in df
         assert 'direction' in df
-
-    def test_direction_corr(self):
-        # just a smoke test
-        f1, f2 = 2, 6
-        df = tp.motion.direction_corr(self.steppers, f1, f2)
-        # Only 2 particles, so only 1 correlation
-        assert len(df) == 1
 
 
 if __name__ == '__main__':

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -205,6 +205,25 @@ class TestSpecial(StrictTestCase):
         theta_entropy = lambda x: tp.motion.theta_entropy(x, plot=False)
         self.steppers.groupby('particle').apply(theta_entropy)
 
+    def test_relate_frames(self):
+        # Check completeness of output
+        pos_columns = ['x', 'y']
+        f1, f2 = 2, 6
+        df = tp.motion.relate_frames(self.steppers, f1, f2, pos_columns=pos_columns)
+        for c in pos_columns:
+            assert c in df
+            assert c + '_b' in df
+            assert 'd' + c in df
+        assert 'dr' in df
+        assert 'direction' in df
+
+    def test_direction_corr(self):
+        # just a smoke test
+        f1, f2 = 2, 6
+        df = tp.motion.direction_corr(self.steppers, f1, f2)
+        # Only 2 particles, so only 1 correlation
+        assert len(df) == 1
+
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
Closes #608 . Also adds simple tests for `direction_corr()` and `relate_frames()`.

I also made a best effort to clarify the docstring for `motion.direction_corr()`. (I'm really not familiar with that function.) The index of the returned DataFrame does not refer to particle IDs.