### PR TITLE
Drop Python 2 tests; fix failing "latest" environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
-sudo: false
 
-matrix:
+jobs:
   include:
     # "Legacy" environments: oldest supported versions, without and with numba
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     # Environments with most recent versions, on python 2.7 and python 3.6
     - python: "2.7"
       env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn" BUILD_DOCS=false
-    - python: "3.6"
+    - python: "3.7"
       env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"  BUILD_DOCS=false
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - export PATH=/home/travis/mc/bin:$PATH
 
 script:
-  - python -munittest
+  - python -munittest discover
   - |
     if [ $BUILD_DOCS == true ]; then
       conda config --append channels conda-forge

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,16 @@ language: python
 
 jobs:
   include:
-    # "Legacy" environments: oldest supported versions, without and with numba
-    - python: "2.7"
-      env: DEPS="numpy=1.9 scipy=0.14.0 matplotlib=1.4 pillow=2.1 pandas=0.15 scikit-image=0.10 pytables scikit-learn=0.15 pyyaml libgfortran=1" BUILD_DOCS=false
-    - python: "2.7"
-      env: DEPS="numpy=1.9 scipy=0.14.0 matplotlib=1.4 pillow=2.1 pandas=0.15 scikit-image=0.10 numba=0.14 pytables scikit-learn=0.15 pyyaml libgfortran=1" BUILD_DOCS=false
+    # "Legacy" environments: oldest supported versions, without and with optional dependencies
+    - python: "3.5"
+      env: DEPS="numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pandas=0.20.3 pyyaml" BUILD_DOCS=true
+    - python: "3.5"
+      env: DEPS="numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables scikit-learn=0.19.0 pyyaml" BUILD_DOCS=true
     # "Typical" environments: versions 2-3 years old
-    # Python 2, circa 2016
-    - python: "2.7"
-      env: DEPS="numpy=1.10 scipy=0.17 matplotlib=1.5 pillow=3.1 pandas=0.18.1 scikit-image=0.12 pytables numba=0.23.1 scikit-learn=0.17.1 pyyaml" BUILD_DOCS=false
     # Python 3, circa September 2017 (Anaconda 5.0.0)
     - python: "3.5"
       env: DEPS="numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml" BUILD_DOCS=true
-    # Environments with most recent versions, on python 2.7 and python 3.6
-    - python: "2.7"
-      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn" BUILD_DOCS=false
+    # Environments with most recent versions
     - python: "3.7"
       env: DEPS="numpy scipy!=1.5.0 matplotlib pillow pandas scikit-image pytables numba scikit-learn pyyaml pytables"  BUILD_DOCS=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     - python: "2.7"
       env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn" BUILD_DOCS=false
     - python: "3.7"
-      env: DEPS="numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"  BUILD_DOCS=false
+      env: DEPS="numpy scipy!=1.5.0 matplotlib pillow pandas scikit-image pytables numba scikit-learn pyyaml pytables"  BUILD_DOCS=false
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,6 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Miniconda"
-      PYTHON_VERSION: "2.7"
-      DEPS: "numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml"
-
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7"
       DEPS: "numpy scipy!=1.5.0 matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
       PYTHON_VERSION: "2.7"
       DEPS: "numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 pillow=4.2.1 pandas=0.20.3 scikit-image=0.13.0 pytables numba=0.35.0 scikit-learn=0.19.0 pyyaml"
 
-    - PYTHON: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.6"
+    - PYTHON: "C:\\Miniconda37-x64"
+      PYTHON_VERSION: "3.7"
       DEPS: "numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7"
-      DEPS: "numpy scipy matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"
+      DEPS: "numpy scipy!=1.5.0 matplotlib pillow pandas scikit-image pyyaml pytables numba scikit-learn"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION%"

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -90,7 +90,7 @@ environment with the name softmatter as follows:
 
 .. code-block:: bash
 
-    conda create --name softmatter python=3.6 trackpy nb_conda
+    conda create --name softmatter python=3.7 trackpy nb_conda
 
 The `nb_conda` is optional, but we added it to ensure that Jupyter sees this
 environment as well. You can switch to the environment from within Jupyter in
@@ -111,10 +111,7 @@ More Information for Experienced Python Users
 Archlinux
 """""""""
 
-Package for python 2 and python 3 are available for Archlinux on AUR:
-
-* `Python 2 <https://aur.archlinux.org/packages/python2-trackpy/>`__
-* `Python 3 <https://aur.archlinux.org/packages/python-trackpy/>`__
+Package is available for Archlinux on AUR: `Python 3 <https://aur.archlinux.org/packages/python-trackpy/>`__
 
 pip
 """
@@ -124,13 +121,13 @@ but pip is also supported.
 
 Essential Dependencies:
 
-* Python 2.7, 3.3, or newer
+* Python 3.5 or newer. (trackpy on Python 2.7 is no longer officially supported, though it is still likely to run.)
 * `setuptools <http://pythonhosted.org/setuptools/>`__
-* `six <http://pythonhosted.org/six/>`__ >=1.8
-* `numpy <http://www.scipy.org/>`__ >=1.7
-* `scipy <http://www.scipy.org/>`__ >=0.12
+* `six <http://pythonhosted.org/six/>`__
+* `numpy <http://www.scipy.org/>`__
+* `scipy <http://www.scipy.org/>`__
 * `matplotlib <http://matplotlib.org/>`__
-* `pandas <http://pandas.pydata.org/pandas-docs/stable/overview.html>`__ >=0.13
+* `pandas <http://pandas.pydata.org/pandas-docs/stable/overview.html>`__
 * `pyyaml <http://pyyaml.org/>`__
 
 You will also want to install the `pims <http://soft-matter.github.io/pims/>`_
@@ -192,8 +189,7 @@ These are strongly recommended to make using trackpy more convenient and faster:
       This is included with Anaconda.
 * `numba <http://numba.pydata.org/>`__ for accelerated feature-finding and linking. 
       This is included with Anaconda and Canopy. Installing it any other way is
-      difficult; we recommend sticking with one of these. We support numba versions
-      >=0.13.4 (though 0.13.3 appears to work).
+      difficult; we recommend sticking with one of these.
 * `Pillow <https://pillow.readthedocs.org/>`__ or `PIL <http://www.pythonware.com/products/pil/>`__ for some display routines.
       This is included with Anaconda.
 

--- a/doc/releases/v0.5.txt
+++ b/doc/releases/v0.5.txt
@@ -8,6 +8,8 @@ for many users. Another minor speedup changes the way in which particle numbers
 are generated, which may cause issues with reproducibility in some existing
 workflows (see "API Changes" below).
 
+Note that Python 2 reached end-of-life in 2020, and it is no longer officially
+supported by trackpy.
 
 Enhancements
 ~~~~~~~~~~~~


### PR DESCRIPTION
This PR
- Avoids SciPy 1.5.0; `conda` could not ensure a compatible Numpy version.
- Gets `unittest` to run on Python 2.7. Closes #614 
- Removes some deprecated config keywords that were causing warnings in Travis.

For Python 3.6 or 3.7, scipy 1.5.0 would cause the warning

```
/home/travis/mc/envs/testenv/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
```

and many subsequent errors. This avoids the offending package version.