### PR TITLE
Update pandas.testing imports

### DIFF
--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -9,7 +9,11 @@ import warnings
 import numpy as np
 from pandas import DataFrame
 from numpy.testing import assert_allclose, assert_array_less
-from pandas.testing import assert_produces_warning
+
+try:
+    from pandas._testing import assert_produces_warning
+except ImportError:
+    from pandas.utils.testing import assert_produces_warning
 
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 from pandas import DataFrame
 from numpy.testing import assert_allclose, assert_array_less
-from pandas.util.testing import assert_produces_warning
+from pandas.testing import assert_produces_warning
 
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE
@@ -44,7 +44,7 @@ def compare(shape, count, radius, noise_level, **kwargs):
 class OldMinmass(StrictTestCase):
     def check_skip(self):
         pass
-    
+
     def setUp(self):
         self.shape = (128, 128)
         self.pos = gen_nonoverlapping_locations(self.shape, 10, separation=20,
@@ -59,7 +59,7 @@ class OldMinmass(StrictTestCase):
         minmass_v04 = tp.minmass_v04_change(im, minmass_v03,
                                             diameter=self.tp_diameter)
         return minmass_v04
-    
+
     def test_oldmass_8bit(self):
         old_minmass = 11000
         im = draw_spots(self.shape, self.pos, self.size, bitdepth=8,
@@ -96,7 +96,7 @@ class OldMinmass(StrictTestCase):
         new_minmass = self.minmass_v02_to_v04(im, old_minmass)
         f = tp.locate(im, self.tp_diameter, minmass=new_minmass)
         assert len(f) == self.N
-        
+
     def test_oldmass_invert(self):
         old_minmass = 2800000
         im = draw_spots(self.shape, self.pos, self.size, bitdepth=12,
@@ -620,7 +620,7 @@ class CommonFeatureIdentificationTests(object):
         # ~0.02 precision, as long as the mask is large enough to cover
         # the whole object.
         self.check_skip()
-        L = 501 
+        L = 501
         dims = (L + 2, L)  # avoid square images in tests
         pos = [50, 55]
         cols = ['y', 'x']
@@ -739,7 +739,7 @@ class CommonFeatureIdentificationTests(object):
         draw_feature(image, pos, 3.75)
 
         guess = np.array([[6, 13]])
-        actual = refine_com_arr(image, image, 6, guess,characterize=False,
+        actual = refine_com_arr(image, image, 6, guess, characterize=False,
                                 engine=self.engine)[:, :2]
         assert_allclose(actual, expected, atol=0.1)
 

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_allclose, assert_array_less
 try:
     from pandas._testing import assert_produces_warning
 except ImportError:
-    from pandas.utils.testing import assert_produces_warning
+    from pandas.util.testing import assert_produces_warning
 
 import trackpy as tp
 from trackpy.try_numba import NUMBA_AVAILABLE

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -10,10 +10,10 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 import pandas
 
-try:
-    from pandas.testing import (assert_series_equal, assert_frame_equal)
-except ImportError:
-    from pandas.utils.testing import (assert_series_equal, assert_frame_equal)
+from pandas.testing import (
+    assert_series_equal,
+    assert_frame_equal,
+)
 
 import trackpy as tp
 from trackpy.tests.common import StrictTestCase

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 import pandas
-from pandas.util.testing import (assert_series_equal, assert_frame_equal)
+from pandas.testing import (assert_series_equal, assert_frame_equal)
 
 import trackpy as tp
 from trackpy.tests.common import StrictTestCase

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -9,7 +9,11 @@ import warnings
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 import pandas
-from pandas.testing import (assert_series_equal, assert_frame_equal)
+
+try:
+    from pandas.testing import (assert_series_equal, assert_frame_equal)
+except ImportError:
+    from pandas.utils.testing import (assert_series_equal, assert_frame_equal)
 
 import trackpy as tp
 from trackpy.tests.common import StrictTestCase

--- a/trackpy/tests/test_find.py
+++ b/trackpy/tests/test_find.py
@@ -7,7 +7,11 @@ import trackpy as tp
 from trackpy.artificial import draw_feature
 from trackpy.tests.common import assert_coordinates_close, StrictTestCase
 from trackpy.find import grey_dilation, grey_dilation_legacy
-from pandas.testing import assert_produces_warning
+
+try:
+    from pandas._testing import assert_produces_warning
+except ImportError:
+    from pandas.utils.testing import assert_produces_warning
 
 
 class TestFindGreyDilation(StrictTestCase):

--- a/trackpy/tests/test_find.py
+++ b/trackpy/tests/test_find.py
@@ -7,7 +7,7 @@ import trackpy as tp
 from trackpy.artificial import draw_feature
 from trackpy.tests.common import assert_coordinates_close, StrictTestCase
 from trackpy.find import grey_dilation, grey_dilation_legacy
-from pandas.util.testing import assert_produces_warning
+from pandas.testing import assert_produces_warning
 
 
 class TestFindGreyDilation(StrictTestCase):

--- a/trackpy/tests/test_find.py
+++ b/trackpy/tests/test_find.py
@@ -11,7 +11,7 @@ from trackpy.find import grey_dilation, grey_dilation_legacy
 try:
     from pandas._testing import assert_produces_warning
 except ImportError:
-    from pandas.utils.testing import assert_produces_warning
+    from pandas.util.testing import assert_produces_warning
 
 
 class TestFindGreyDilation(StrictTestCase):

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -5,16 +5,10 @@ import six
 import numpy as np
 from pandas import DataFrame, Series
 
-try:
-    from pandas.testing import (
-        assert_series_equal,
-        assert_frame_equal,
-    )
-except ImportError:
-    from pandas.utils.testing import (
-        assert_series_equal,
-        assert_frame_equal,
-    )
+from pandas.testing import (
+    assert_series_equal,
+    assert_frame_equal,
+)
 
 from numpy.testing import assert_almost_equal
 

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -4,15 +4,24 @@ import six
 
 import numpy as np
 from pandas import DataFrame, Series
-from pandas.testing import (
-    assert_series_equal,
-    assert_frame_equal,
-    assert_almost_equal,
-)
+
+try:
+    from pandas.testing import (
+        assert_series_equal,
+        assert_frame_equal,
+    )
+except ImportError:
+    from pandas.utils.testing import (
+        assert_series_equal,
+        assert_frame_equal,
+    )
+
+from numpy.testing import assert_almost_equal
 
 import trackpy as tp
 from trackpy.utils import pandas_sort, pandas_concat
 from trackpy.tests.common import StrictTestCase
+
 
 def random_walk(N):
     return np.cumsum(np.random.randn(N))

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -4,8 +4,11 @@ import six
 
 import numpy as np
 from pandas import DataFrame, Series
-from pandas.util.testing import (assert_series_equal, assert_frame_equal,
-                                 assert_almost_equal)
+from pandas.testing import (
+    assert_series_equal,
+    assert_frame_equal,
+    assert_almost_equal,
+)
 
 import trackpy as tp
 from trackpy.utils import pandas_sort, pandas_concat


### PR DESCRIPTION
Fixes https://github.com/soft-matter/trackpy/issues/631

Changed imports ``pandas.util.testing`` into ``pandas.testing``, since starting from pandas 0.20.1, ``pandas.util.testing`` is deprecated.