### PR TITLE
DOC: add full API reference using Sphinx recursive option

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,7 +1,5 @@
 .. _api_ref:
 
-.. currentmodule:: trackpy
-
 API reference
 =============
 The core functionality of trackpy is grouped into three separate steps:
@@ -15,9 +13,9 @@ Convenience functions for feature finding, refinement, and linking are readily a
 .. autosummary::
     :toctree: generated/
 
-    locate
-    batch
-    link
+    trackpy.locate
+    trackpy.batch
+    trackpy.link
 
 For more control on your tracking "pipeline", the following core functions are provided:
 
@@ -27,8 +25,8 @@ Feature finding
 .. autosummary::
     :toctree: generated/
 
-    grey_dilation
-    find_link
+    trackpy.grey_dilation
+    trackpy.find_link
 
 
 Coordinate refinement
@@ -36,18 +34,18 @@ Coordinate refinement
 .. autosummary::
     :toctree: generated/
 
-    refine_com
-    refine_leastsq
+    trackpy.refine_com
+    trackpy.refine_leastsq
 
 Linking
 -------
 .. autosummary::
     :toctree: generated/
 
-    link
-    link_iter
-    link_df_iter
-    link_partial
+    trackpy.link
+    trackpy.link_iter
+    trackpy.link_df_iter
+    trackpy.link_partial
 
 
 :func:`~trackpy.linking.link` and :func:`~trackpy.linking.link_df_iter` run
@@ -69,10 +67,10 @@ Static Analysis
 .. autosummary::
     :toctree: generated/
 
-    static.proximity
-    static.pair_correlation_2d
-    static.pair_correlation_3d
-    static.cluster
+    trackpy.static.proximity
+    trackpy.static.pair_correlation_2d
+    trackpy.static.pair_correlation_3d
+    trackpy.static.cluster
 
 Motion Analysis
 ---------------
@@ -80,21 +78,21 @@ Motion Analysis
 .. autosummary::
     :toctree: generated/
 
-    motion.msd
-    motion.imsd
-    motion.emsd
-    motion.compute_drift
-    motion.subtract_drift
-    motion.vanhove
-    motion.relate_frames
-    motion.velocity_corr
-    motion.direction_corr
-    motion.is_typical
-    motion.diagonal_size
-    motion.theta_entropy
-    motion.min_rolling_theta_entropy
-    filtering.filter_stubs
-    filtering.filter_clusters
+    trackpy.motion.msd
+    trackpy.motion.imsd
+    trackpy.motion.emsd
+    trackpy.motion.compute_drift
+    trackpy.motion.subtract_drift
+    trackpy.motion.vanhove
+    trackpy.motion.relate_frames
+    trackpy.motion.velocity_corr
+    trackpy.motion.direction_corr
+    trackpy.motion.is_typical
+    trackpy.motion.diagonal_size
+    trackpy.motion.theta_entropy
+    trackpy.motion.min_rolling_theta_entropy
+    trackpy.filtering.filter_stubs
+    trackpy.filtering.filter_clusters
 
 Prediction Framework
 --------------------
@@ -104,12 +102,12 @@ Trackpy extends the Crocker--Grier algoritm using a prediction framework, descri
 .. autosummary::
    :toctree: generated/
 
-   predict.NullPredict     
-   predict.ChannelPredict
-   predict.DriftPredict
-   predict.NearestVelocityPredict
-   predict.predictor
-   predict.instrumented
+   trackpy.predict.NullPredict     
+   trackpy.predict.ChannelPredict
+   trackpy.predict.DriftPredict
+   trackpy.predict.NearestVelocityPredict
+   trackpy.predict.predictor
+   trackpy.predict.instrumented
 
 Plotting Tools
 --------------
@@ -119,23 +117,23 @@ Trackpy includes functions for plotting the data in ways that are commonly usefu
 .. autosummary::
     :toctree: generated/
 
-    annotate
-    scatter
-    plot_traj
-    annotate3d
-    scatter3d
-    plot_traj3d
-    plot_displacements
-    subpx_bias
-    plot_density_profile
+    trackpy.annotate
+    trackpy.scatter
+    trackpy.plot_traj
+    trackpy.annotate3d
+    trackpy.scatter3d
+    trackpy.plot_traj3d
+    trackpy.plot_displacements
+    trackpy.subpx_bias
+    trackpy.plot_density_profile
 
 These two are almost too simple to justify their existence -- just a convenient shorthand for a common plotting task.
 
 .. autosummary::
     :toctree: generated/
 
-    mass_ecc
-    mass_size
+    trackpy.mass_ecc
+    trackpy.mass_size
 
 Image Conversion
 ----------------
@@ -149,12 +147,12 @@ to executre these steps manually, you can.
 .. autosummary::
     :toctree: generated/
 
-    find.percentile_threshold
-    preprocessing.bandpass
-    preprocessing.lowpass
-    preprocessing.scale_to_gamut
-    preprocessing.invert_image
-    preprocessing.convert_to_int
+    trackpy.find.percentile_threshold
+    trackpy.preprocessing.bandpass
+    trackpy.preprocessing.lowpass
+    trackpy.preprocessing.scale_to_gamut
+    trackpy.preprocessing.invert_image
+    trackpy.preprocessing.convert_to_int
 
 Framewise Data Storage & Retrieval Interface
 --------------------------------------------
@@ -170,10 +168,10 @@ optimizations. :class:`~trackpy.framewise_data.PandasHDFStoreBig` is a good gene
 .. autosummary::
     :toctree: generated/
 
-    PandasHDFStore
-    PandasHDFStoreBig
-    PandasHDFStoreSingleNode
-    FramewiseData
+    trackpy.PandasHDFStore
+    trackpy.PandasHDFStoreBig
+    trackpy.PandasHDFStoreSingleNode
+    trackpy.FramewiseData
 
 That last class cannot be used directly; it is meant to be subclassed
 to support other formats. See *Writing Your Own Interface* in the streaming tutorial for
@@ -194,9 +192,9 @@ configuring the logger however you like.
 .. autosummary::
     :toctree: generated/
 
-    quiet
-    handle_logging
-    ignore_logging
+    trackpy.quiet
+    trackpy.handle_logging
+    trackpy.ignore_logging
 
 Utility functions
 -----------------
@@ -204,9 +202,9 @@ Utility functions
 .. autosummary::
     :toctree: generated/
 
-    minmass_v03_change
-    minmass_v04_change
-    utils.fit_powerlaw
+    trackpy.minmass_v03_change
+    trackpy.minmass_v04_change
+    trackpy.utils.fit_powerlaw
 
 Diagnostic functions
 --------------------
@@ -214,8 +212,8 @@ Diagnostic functions
 .. autosummary::
    :toctree: generated/
 
-   diag.performance_report
-   diag.dependencies
+   trackpy.diag.performance_report
+   trackpy.diag.dependencies
 
 Low-Level API (Advanced)
 ------------------------
@@ -228,8 +226,8 @@ Trackpy implements the most intensive (read: slowest) parts of the core feature-
 .. autosummary::
    :toctree: generated/
 
-   enable_numba
-   disable_numba
+   trackpy.enable_numba
+   trackpy.disable_numba
 
 
 Low-Level Linking API
@@ -240,21 +238,15 @@ All of the linking functions in trackpy provide the same level of control over t
 .. autosummary::
     :toctree: generated/
 
-    link_iter
-    link
+    trackpy.link_iter
+    trackpy.link
 
 And the following classes can be subclassed to implement a customized linking procedure.
 
 .. autosummary::
     :toctree: generated/
 
-    Point
-    PointND
-    Track
-    TrackUnstored 
-    HashTable
-    SubnetOversizeException
-
+    trackpy.SubnetOversizeException
 
 Masks
 ^^^^^
@@ -264,13 +256,24 @@ These functions may also be useful for rolling your own algorithms:
 .. autosummary::
     :toctree: generated/
 
-    masks.binary_mask
-    masks.r_squared_mask
-    masks.x_squared_masks
-    masks.cosmask
-    masks.sinmask
-    masks.theta_mask
-    masks.gaussian_kernel
-    masks.mask_image
-    masks.slice_image
+    trackpy.masks.binary_mask
+    trackpy.masks.r_squared_mask
+    trackpy.masks.x_squared_masks
+    trackpy.masks.cosmask
+    trackpy.masks.sinmask
+    trackpy.masks.theta_mask
+    trackpy.masks.gaussian_kernel
+    trackpy.masks.mask_image
+    trackpy.masks.slice_image
+
+Full API reference
+------------------
+
+A full overview of all modules and functions can be found below:
+
+.. autosummary::
+    :toctree: generated/
+    :recursive:
+
+    trackpy
 


### PR DESCRIPTION
I was trying to build the docs locally and found that we do not have an overview of the full trackpy API.
This adds a toctree at the bottom of the API page where you can click through all files / modules and functions.
I think it is a useful addition because also the less often used functions are browse-able through the docs in this way.