### PR TITLE
Add zenodo metadata file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,7 +14,7 @@
         }, 
         {
             "orcid": "0000-0003-0746-0547", 
-            "affiliation": "California Polytechnic State University", 
+            "affiliation": "Pennsylvania State University", 
             "name": "Keim, Nathan C."
         }, 
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,32 @@
+{
+    "license": "BSD-3-Clause", 
+    "upload_type": "software", 
+    "creators": [
+        {
+            "orcid": "0000-0002-5947-6017", 
+            "affiliation": "Brookhaven National Lab", 
+            "name": "Allan, Daniel B."
+        }, 
+        {
+            "orcid": "0000-0003-4692-608X", 
+            "affiliation": "Brookhaven National Lab", 
+            "name": "Caswell, Thomas"
+        }, 
+        {
+            "orcid": "0000-0003-0746-0547", 
+            "affiliation": "California Polytechnic State University", 
+            "name": "Keim, Nathan C."
+        }, 
+        {
+            "orcid": "0000-0002-0488-2237", 
+            "affiliation": "Leiden University", 
+            "name": "van der Wel, Casper M."
+        },
+        {
+            "orcid": "0000-0003-3925-5732",
+            "affliation": "Leiden University",
+            "name": "Verweij, Ruben W."
+        }
+    ], 
+    "access_right": "open"
+}


### PR DESCRIPTION
This file should be picked up by Zenodo to automatically set the metadata of the publication. I had to manually set them for the last release (and v0.4.2 as well). I think it is justified to add @rbnvrw to the list of authors as he did a major contribution in #527.

Other changes to the metadata can be done easily, please let me know if you think there is anyone else that should be in the authors list, or other metadata fields that should be updated.
