### PR TITLE
Added ability to use custom DistanceMetric

### DIFF
--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -53,9 +53,11 @@ def link_iter(coords_iter, search_range, **kwargs):
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses hybrid (numba+recursive) if available
         'drop' causes particles in subnetworks to go unlinked
-    dist_func : function, optional
-        a custom distance function that takes two 1D arrays of coordinates and
-        returns a float. Must be used with the 'BTree' neighbor_strategy.
+    dist_func : function or ```sklearn.metrics.DistanceMetric``` class, optional
+        A custom python distance function or Scikit Learn DistanceMetric class. 
+        If a python distance function is passed, it must take two 1D arrays of 
+        coordinates and return a float. Must be used with the 'BTree' 
+        neighbor_strategy.
     to_eucl : function, optional
         function that transforms a N x ndim array of positions into coordinates
         in Euclidean space. Useful for instance to link by Euclidean distance
@@ -144,9 +146,11 @@ def link(f, search_range, pos_columns=None, t_column='frame', **kwargs):
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses hybrid (numba+recursive) if available
         'drop' causes particles in subnetworks to go unlinked
-    dist_func : function, optional
-        a custom distance function that takes two 1D arrays of coordinates and
-        returns a float. Must be used with the 'BTree' neighbor_strategy.
+    dist_func : function or ```sklearn.metrics.DistanceMetric``` class, optional
+        A custom python distance function or Scikit Learn DistanceMetric class. 
+        If a python distance function is passed, it must take two 1D arrays of 
+        coordinates and return a float. Must be used with the 'BTree' 
+        neighbor_strategy.
     to_eucl : function, optional
         function that transforms a N x ndim array of positions into coordinates
         in Euclidean space. Useful for instance to link by Euclidean distance
@@ -240,9 +244,11 @@ def link_df_iter(f_iter, search_range, pos_columns=None,
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses hybrid (numba+recursive) if available
         'drop' causes particles in subnetworks to go unlinked
-    dist_func : function, optional
-        a custom distance function that takes two 1D arrays of coordinates and
-        returns a float. Must be used with the 'BTree' neighbor_strategy.
+    dist_func : function or ```sklearn.metrics.DistanceMetric``` class, optional
+        A custom python distance function or Scikit Learn DistanceMetric class. 
+        If a python distance function is passed, it must take two 1D arrays of 
+        coordinates and return a float. Must be used with the 'BTree' 
+        neighbor_strategy.
     to_eucl : function, optional
         function that transforms a N x ndim array of positions into coordinates
         in Euclidean space. Useful for instance to link by Euclidean distance

--- a/trackpy/linking/linking.py
+++ b/trackpy/linking/linking.py
@@ -53,11 +53,11 @@ def link_iter(coords_iter, search_range, **kwargs):
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses hybrid (numba+recursive) if available
         'drop' causes particles in subnetworks to go unlinked
-    dist_func : function or ```sklearn.metrics.DistanceMetric``` class, optional
-        A custom python distance function or Scikit Learn DistanceMetric class. 
-        If a python distance function is passed, it must take two 1D arrays of 
-        coordinates and return a float. Must be used with the 'BTree' 
-        neighbor_strategy.
+    dist_func : function or ```sklearn.metrics.DistanceMetric``` instance, optional
+        A custom python distance function or instance of the 
+        Scikit Learn DistanceMetric class. If a python distance function is 
+        passed, it must take two 1D arrays of coordinates and return a float. 
+        Must be used with the 'BTree' neighbor_strategy.
     to_eucl : function, optional
         function that transforms a N x ndim array of positions into coordinates
         in Euclidean space. Useful for instance to link by Euclidean distance
@@ -146,11 +146,11 @@ def link(f, search_range, pos_columns=None, t_column='frame', **kwargs):
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses hybrid (numba+recursive) if available
         'drop' causes particles in subnetworks to go unlinked
-    dist_func : function or ```sklearn.metrics.DistanceMetric``` class, optional
-        A custom python distance function or Scikit Learn DistanceMetric class. 
-        If a python distance function is passed, it must take two 1D arrays of 
-        coordinates and return a float. Must be used with the 'BTree' 
-        neighbor_strategy.
+    dist_func : function or ```sklearn.metrics.DistanceMetric``` instance, optional
+        A custom python distance function or instance of the 
+        Scikit Learn DistanceMetric class. If a python distance function is 
+        passed, it must take two 1D arrays of coordinates and return a float. 
+        Must be used with the 'BTree' neighbor_strategy.
     to_eucl : function, optional
         function that transforms a N x ndim array of positions into coordinates
         in Euclidean space. Useful for instance to link by Euclidean distance
@@ -244,11 +244,11 @@ def link_df_iter(f_iter, search_range, pos_columns=None,
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses hybrid (numba+recursive) if available
         'drop' causes particles in subnetworks to go unlinked
-    dist_func : function or ```sklearn.metrics.DistanceMetric``` class, optional
-        A custom python distance function or Scikit Learn DistanceMetric class. 
-        If a python distance function is passed, it must take two 1D arrays of 
-        coordinates and return a float. Must be used with the 'BTree' 
-        neighbor_strategy.
+    dist_func : function or ```sklearn.metrics.DistanceMetric``` instance, optional
+        A custom python distance function or instance of the 
+        Scikit Learn DistanceMetric class. If a python distance function is 
+        passed, it must take two 1D arrays of coordinates and return a float. 
+        Must be used with the 'BTree' neighbor_strategy.
     to_eucl : function, optional
         function that transforms a N x ndim array of positions into coordinates
         in Euclidean space. Useful for instance to link by Euclidean distance

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -10,7 +10,10 @@ from ..utils import default_pos_columns
 
 try:
     from sklearn.neighbors import BallTree
-    from sklearn.metrics import DistanceMetric
+    try:
+        from sklearn.metrics import DistanceMetric
+    except ImportError:
+        from sklearn.neighbors import DistanceMetric
 except ImportError:
     BallTree = None
 

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -10,6 +10,7 @@ from ..utils import default_pos_columns
 
 try:
     from sklearn.neighbors import BallTree
+    from sklearn.metrics import DistanceMetric
 except ImportError:
     BallTree = None
 
@@ -195,8 +196,12 @@ class HashBTree(HashBase):
             if self.dist_func is None:
                 self._btree = BallTree(coords_mapped)
             else:
-                self._btree = BallTree(coords_mapped,
-                                       metric='pyfunc', func=self.dist_func)
+                if isinstance(self.dist_func, DistanceMetric):
+                    self._btree = BallTree(coords_mapped,
+                                           metric=self.dist_func)
+                else:
+                    self._btree = BallTree(coords_mapped,
+                                           metric='pyfunc', func=self.dist_func)
         # This could be tuned
         self._clean = True
 

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -717,7 +717,7 @@ class TestBTreeLink(SubnetNeededTests):
         _skip_if_no_sklearn()
         self.linker_opts = dict(neighbor_strategy='BTree')
 
-    def test_custom_dist_func(self):
+    def test_custom_dist_pyfunc(self):
         # Several 2D random walkers
         N = 5
         length = 5
@@ -749,6 +749,32 @@ class TestBTreeLink(SubnetNeededTests):
         # link using a custom distance function
         actual = self.link(f_radial, search_range, pos_columns=['r', 'angle'],
                            dist_func=dist_func)
+        assert_traj_equal(actual, expected)
+
+
+    def test_custom_dist_metric(self):
+        import sklearn.neighbors
+
+        # Several 2D random walkers
+        N = 5
+        length = 5
+        step_size = 2
+        search_range = 3
+
+        steps = (np.random.random((2, length, N)) - 0.5) * step_size
+        x, y = np.cumsum(steps, axis=2)
+        f = DataFrame(dict(x=x.ravel(), y=y.ravel(),
+                           frame=np.repeat(np.arange(length), N)))
+
+        # link in normal (2D Euclidean) coordinates
+        expected = self.link(f, search_range)
+
+        # leave x, y for the comparison at the end
+
+        dist_func = sklearn.neighbors.DistanceMetric.get_metric("euclidean")
+        
+        # link using a custom distance function
+        actual = self.link(f, search_range, dist_func=dist_func)
         assert_traj_equal(actual, expected)
 
 


### PR DESCRIPTION
Per #691, I added the ability to use a custom scikit-learn `DistanceMetric` function as a `dist_func` parameter in `trackpy.link`. I also added a new test for this method. I *think* that this would allow users to extend the `DistanceMetric` class, too, with compiled distance functions (and therefore faster than passing in a python function). 