### PR TITLE
Fix scipy and distutils deprecation warnings

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Environment
         shell: bash
         run: |
-          conda create --name test python=${{ matrix.python }} pytest numpy scipy matplotlib pandas pytables numba scikit-learn pyyaml
+          conda create --name test python=${{ matrix.python }} pytest numpy scipy matplotlib pandas pytables numba scikit-learn pyyaml looseversion
           source activate test
           python -V
           conda info

--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -14,27 +14,27 @@ jobs:
           - python: 3.6
             display_name: "2017"
             numpy: "numpy==1.14.*"  # pre-install numpy due to issue in numba 0.32 wheel building
-            deps: "scipy==1.1.* matplotlib==2.1.* pillow==4.3.* pandas==0.22.* tables==3.4.* scikit-learn==0.19.* pyyaml numba==0.32.* llvmlite==0.17.*"
+            deps: "scipy==1.1.* matplotlib==2.1.* pillow==4.3.* pandas==0.22.* tables==3.4.* scikit-learn==0.19.* pyyaml numba==0.32.* llvmlite==0.17.* looseversion>=1.0.1"
           # 2018
           - python: 3.7
             display_name: "2018"
-            deps: "numpy==1.16.* scipy==1.3.* matplotlib==2.2.* pandas==0.23.* tables==3.5.* scikit-learn==0.20.* pyyaml numba==0.45.* llvmlite==0.29.*"
+            deps: "numpy==1.16.* scipy==1.3.* matplotlib==2.2.* pandas==0.23.* tables==3.5.* scikit-learn==0.20.* pyyaml numba==0.45.* llvmlite==0.29.* looseversion>=1.0.1"
           # 2019
           - python: 3.8
             display_name: "2019"
-            deps: "numpy==1.18.* scipy==1.4.* matplotlib==3.1.* pandas==0.25.* tables==3.6.* scikit-learn==0.22.* pyyaml numba==0.47.* llvmlite==0.31.*"
+            deps: "numpy==1.18.* scipy==1.4.* matplotlib==3.1.* pandas==0.25.* tables==3.6.* scikit-learn==0.22.* pyyaml numba==0.47.* llvmlite==0.31.* looseversion>=1.0.1"
           # 2020
           - python: 3.9
             display_name: "2020"
-            deps: "numpy==1.19.* scipy==1.5.* matplotlib==3.3.* pandas==1.1.* tables==3.6.* scikit-learn==0.24.* pyyaml numba==0.53.* llvmlite==0.36.*"
+            deps: "numpy==1.19.* scipy==1.5.* matplotlib==3.3.* pandas==1.1.* tables==3.6.* scikit-learn==0.24.* pyyaml numba==0.53.* llvmlite==0.36.* looseversion>=1.0.1"
           # 2021 (use Py3.9 & numpy==1.20 due to numba compatibility)
           - python: 3.9
             display_name: "2021"
-            deps: "numpy==1.20.* scipy==1.7.* matplotlib==3.5.* pandas==1.3.* tables==3.6.* scikit-learn==1.0.* pyyaml numba==0.54.* llvmlite==0.37.*"
+            deps: "numpy==1.20.* scipy==1.7.* matplotlib==3.5.* pandas==1.3.* tables==3.6.* scikit-learn==1.0.* pyyaml numba==0.54.* llvmlite==0.37.* looseversion>=1.0.1"
           # most recent
           - python: '3.x'
             display_name: "latest, no optional deps"
-            deps: "numpy scipy matplotlib pandas pyyaml"
+            deps: "numpy scipy matplotlib pandas pyyaml looseversion"
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ soft-matter-docs-deploy
 
 # VS Code
 .vscode
+.venv

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -128,6 +128,7 @@ Essential Dependencies:
 * `matplotlib <http://matplotlib.org/>`__
 * `pandas <http://pandas.pydata.org/pandas-docs/stable/overview.html>`__
 * `pyyaml <http://pyyaml.org/>`__
+* `looseversion <https://pypi.org/project/looseversion/>`__
 
 You will also want to install the `pims <http://soft-matter.github.io/pims/>`_
 package that simplifies image-reading, and that is used in the trackpy tutorials.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup_parameters = dict(
     author = "Trackpy Contributors",
     author_email = "daniel.b.allan@gmail.com",
     url = "https://github.com/soft-matter/trackpy",
-    install_requires = ['numpy>=1.14', 'scipy>=1.1', 'pandas>=0.22', 'pyyaml', 'matplotlib'],
+    install_requires = ['numpy>=1.14', 'scipy>=1.1', 'pandas>=0.22', 'pyyaml', 'matplotlib', "looseversion>=1.0.1"],
     python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/trackpy/preprocessing.py
+++ b/trackpy/preprocessing.py
@@ -1,8 +1,7 @@
 import logging
 
 import numpy as np
-from scipy.ndimage.filters import uniform_filter1d, correlate1d
-from scipy.ndimage.fourier import fourier_gaussian
+from scipy.ndimage import uniform_filter1d, correlate1d, fourier_gaussian
 
 from .utils import validate_tuple
 from .masks import gaussian_kernel

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Hashable
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from multiprocessing.pool import Pool
 
 import pandas as pd


### PR DESCRIPTION
[Scipy 1.8 introduced depraction warnings](https://docs.scipy.org/doc/scipy-1.8.1/release.1.8.0.html#clear-split-between-public-and-private-api) for importing the submodules of `ndimage`. The solution is to import the functions directly from the `ndimage` module itself and not through one of the sub-modules that it is (accidentally) exposed through. Furthermore [distutils has been slated for deprecation for quite a while now and will be removed in python 3.12](https://docs.python.org/3/library/distutils.html). The `utils.py` file uses functionality from it to handle various versions of pandas. The distutils `LooseVersion` functionality is re-exposed through the looseversion package and is supposed to be a drop-in replacement for version the distutils counterpart.