### PR TITLE
FIX: Fix prediction bugs

### DIFF
--- a/doc/releases/v0.6.txt
+++ b/doc/releases/v0.6.txt
@@ -1,0 +1,29 @@
+v0.6
+----
+
+This release focuses on fixing bugs and some inconsistencies in the prediction
+capabilities. Some existing code that used prediction may now fail to run until
+a (minor) update is made.
+
+Enhancements
+~~~~~~~~~~~~
+
+
+API Changes
+~~~~~~~~~~~
+
+- When supplying an initial velocity guess to NearestVelocityPredict or
+  DriftPredict, you must also supply the pos_columns argument to identify
+  the names of the columns in your array. (For example,
+  "pos_columns = ['y', 'x']".) Otherwise, creating the predictor will
+  raise an exception that explains this change. If you provide pos_columns
+  when creating the predictor, you do not have to supply it when subsequently
+  using the link_df() or link_df_iter() methods to link your features.
+
+Bug Fixes
+~~~~~~~~~
+
+- When linking with prediction, the predictor now correctly uses the same
+  position columns as the linker, and correctly handles the pos_columns
+  argument if specified.
+- The link_df() method of predictor objects now works correctly.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,8 @@ What's new in the package
 
 A catalog of new features, improvements, and bug-fixes in each release. Follow links to the relevant GitHub issue or pull request for specific code changes and any related discussion.
 
+.. include:: releases/v0.6.txt
+
 .. include:: releases/v0.5.txt
 
 .. include:: releases/v0.4.txt

--- a/trackpy/linking/subnet.py
+++ b/trackpy/linking/subnet.py
@@ -52,14 +52,7 @@ class HashBase:
         """Predict and convert points to an array."""
         if self.predictor is None:
             return points_to_arr(points)
-        try:
-            for p in points:
-                p.pos = p.pos[::-1]
-            result = np.array(list(self.predictor(self.t, points)))
-        finally:
-            for p in points:  # swap axes order back
-                p.pos = p.pos[::-1]
-        return result[:, ::-1]
+        return np.array(list(self.predictor(self.t, points)))
 
     @property
     def coords(self):

--- a/trackpy/predict.py
+++ b/trackpy/predict.py
@@ -187,10 +187,13 @@ class NearestVelocityPredict(_RecentVelocityPredict):
     ----------
     initial_guess_positions : Nxd array, optional
         Columns should be in the same order used by the linking function.
-        (The linker's default is pos_columns=['y', 'x'] or ['z', 'y', 'x'])
     initial_guess_vels : Nxd array, optional
         If specified, these initialize the velocity field with velocity
         samples at the given points.
+    pos_columns : list of d strings, optional
+        Names of coordinate columns corresponding to the columns of
+        the initial_guess arrays, e.g. ['y', 'x']. Required if a guess
+        is specified.
     span : integer, default 1
         Compute velocity field from the most recent span+1 frames.
     """
@@ -247,7 +250,12 @@ class DriftPredict(_RecentVelocityPredict):
 
     Parameters
     ----------
-    initial_guess : Array of length d. Otherwise assumed to be zero velocity.
+    initial_guess : Array of length d, optional
+        Velocity vector initially used for prediction.
+        Default is to assume zero velocity.
+    pos_columns : list of d strings, optional
+        Names of coordinate columns corresponding to the elements of
+        initial_guess, e.g. ['y', 'x']. Required if a guess is specified.
     span : integer, default 1
         Compute velocity field from the most recent span+1 frames.
     """

--- a/trackpy/predict.py
+++ b/trackpy/predict.py
@@ -75,8 +75,9 @@ class NullPredict:
         features = args.pop(0)
         if kw.get('t_column') is None:
             kw['t_column'] = 'frame'
+        kw['predictor'] = self.predict
         features_iter = (frame for fnum, frame in features.groupby(kw['t_column']))
-        return pandas_concat(linking_fcn(*([features_iter, ] + args), **kw))
+        return pandas_concat(self.wrap(linking_fcn, features_iter, *args, **kw))
 
     def link_df_iter(self, *args, **kw):
         """Wrapper for linking.link_df_iter() that causes it to use this predictor."""

--- a/trackpy/predict.py
+++ b/trackpy/predict.py
@@ -198,8 +198,9 @@ class NearestVelocityPredict(_RecentVelocityPredict):
     def __init__(self, initial_guess_positions=None,
                  initial_guess_vels=None, pos_columns=None, span=1):
         if initial_guess_positions is not None and pos_columns is None:
-            warn('The order of the position columns in your initial guess is ambiguous. '
-                 'Consider specifying pos_columns here to avoid confusion.')
+            raise ValueError('The order of the position columns in your initial '
+                             "guess is ambiguous. Specify the coordinate names "
+                             "with your guess, using e.g. pos_columns=['y', 'x']")
         super().__init__(span=span, pos_columns=pos_columns)
         if initial_guess_positions is not None:
             self.use_initial_guess = True
@@ -252,8 +253,9 @@ class DriftPredict(_RecentVelocityPredict):
     """
     def __init__(self, initial_guess=None, pos_columns=None, span=1):
         if initial_guess is not None and pos_columns is None:
-            warn('The order of the position columns in your initial guess is ambiguous. '
-                 'Consider specifying pos_columns here to avoid confusion.')
+            raise ValueError('The order of the position columns in your initial '
+                             "guess is ambiguous. Specify the coordinate names "
+                             "with your guess, using e.g. pos_columns=['y', 'x']")
         super().__init__(pos_columns=pos_columns, span=span)
         self.initial_guess = initial_guess
 

--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -192,8 +192,8 @@ class NearestVelocityPredictTests(VelocityPredictTests):
         in the first pair of frames may be large."""
 
         # Initializing a guess without specifying pos_columns should
-        # raise a warning.
-        with self.assertWarns(Warning):
+        # raise an error
+        with self.assertRaises(ValueError):
             pred = self.predict_class(
                 initial_guess_positions=[(0., 0.)],
                 initial_guess_vels=[(1, -1)])
@@ -287,8 +287,8 @@ class DriftPredictTests(VelocityPredictTests):
         in the first pair of frames may be large."""
 
         # Initializing a guess without specifying pos_columns should
-        # raise a warning.
-        with self.assertWarns(Warning):
+        # raise an error
+        with self.assertRaises(ValueError):
             pred = self.predict_class(initial_guess=(1, -1))
 
         # A bad initial guess will fail.

--- a/trackpy/tests/test_predict.py
+++ b/trackpy/tests/test_predict.py
@@ -455,8 +455,6 @@ class FindLinkIterWithPrediction(FindLinkWithPrediction):
         # Takes an iterable of frames, and outputs a single linked DataFrame.
         defaults = {}
         defaults.update(kw)
-        if 'pos_columns' in defaults:
-            del defaults['pos_columns']
         link_df_iter = self.get_linker_iter(pred)
         return pandas.concat(link_df_iter(frames, *args, **defaults),
                              ignore_index=True)
@@ -477,6 +475,8 @@ class FindLinkIterWithPrediction(FindLinkWithPrediction):
                 int)
             reader = CoordinateReader(f, shape, size, t=indices)
 
+            # FIXME: pos_columns is not supported by find_link_iter---
+            # so why are we setting it for the predictor?
             pred.pos_columns = kw.get('pos_columns', ['x', 'y'])
             pred.t_column = kw.get('t_column', 'frame')
 


### PR DESCRIPTION
This PR closes #699 . It tests for and (hopefully) fixes both the `link_df` issue and the coordinate switching issue. It makes the order of `pos_columns` used by the linker match the order used by the predictor, whereas before trackpy tried to keep them in reverse order (for backward compatibility, perhaps?). The PR includes some safeguards (tested) against prediction with ambiguous or conflicting `pos_columns`.

There is (unfortunately) a breaking API change when supplying an initial velocity guess to a predictor. Since these guesses are supplied as arrays (not DataFrames), the order of the coordinates has always been ambiguous. In recent versions including v0.5.1, the order has implicitly been the *reverse* of the order in the subsequent linking step, so that the columns in the velocity guess typically corresponded to e.g. `['x', 'y', 'z']`. I hope you'll agree that this is confusing at best. With this new PR, the predictor uses the same `pos_columns` as the linker, which is typically e.g. `['z', 'y', 'x']`.

Because of this change, `NearestVelocityPredict` and `DriftPredict` now require `pos_columns` to be specified along with any initial velocity guess. There is additional logic to make sure this is the same `pos_columns` subsequently used by the linking step (the user doesn't need to specify `pos_columns` a second time). Requiring `pos_columns` is good for users who are currently supplying initial velocity guesses, since their code will stop working until they resolve this ambiguity, instead of trackpy silently misinterpreting their velocity guess.

Finally, prediction when using `find_link()` etc. is still barely supported. Even though we test it extensively, using it requires a few things to be done manually that would ordinarily be handled automatically by the predictor instance. The best "documentation" is the code near the end of `test_predict.py`, which is not a good situation.

Still to do in this PR:
- [x] Update the prediction tutorial

Suggested future enhancements:
- Provide wrapper functions to make it easier to use `find_link` with a predictor.
- Accept initial velocity guesses as DataFrames, eliminating the need to specify `pos_columns`.

I think this API change suggests that we should include these fixes in v0.6. That is inconvenient, but all of the prediction features *were* usable with enough luck and/or workarounds, and the more correct handling of `pos_columns` will surely break some existing scripts. I have drafted release notes accordingly.
