### PR TITLE
BLD: Allow CI workflows to be re-run manually

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -1,6 +1,6 @@
 name: Conda
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   TestConda:

--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -1,6 +1,6 @@
 name: Pip
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   TestLinux:


### PR DESCRIPTION
This allows the two GitHub Actions workflows we use for CI to be re-triggered manually, to help troubleshoot failures.