### PR TITLE
BLD: Remove "affiliation" field that Zenodo now rejects

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,27 +4,22 @@
     "creators": [
         {
             "orcid": "0000-0002-5947-6017", 
-            "affiliation": "Brookhaven National Lab", 
             "name": "Allan, Daniel B."
         }, 
         {
             "orcid": "0000-0003-4692-608X", 
-            "affiliation": "Brookhaven National Lab", 
             "name": "Caswell, Thomas"
         }, 
         {
             "orcid": "0000-0003-0746-0547", 
-            "affiliation": "Pennsylvania State University", 
             "name": "Keim, Nathan C."
         }, 
         {
             "orcid": "0000-0002-0488-2237", 
-            "affiliation": "Leiden University", 
             "name": "van der Wel, Casper M."
         },
         {
             "orcid": "0000-0003-3925-5732",
-            "affliation": "Leiden University",
             "name": "Verweij, Ruben W."
         }
     ], 


### PR DESCRIPTION
Delightfully, Zenodo now raises an error for the "affiliation" field, meaning that trackpy v0.6.0 has no DOI. This removes the field (which should be redundant anyway since Zenodo has each author's ORCID). My plan is to update the GitHub release only and hope that Zenodo tries again. The incorrect JSON will still be on PyPI. If this plan does not work, I will release v0.6.1.

I have also updated the release checklist in the wiki so that from now on, we will check that Zenodo has properly processed each release candidate.