### PR TITLE
BUG in utils.py (default_pos_columns)

### DIFF
--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -315,7 +315,7 @@ def default_pos_columns(ndim):
     if ndim < 4:
         return ['z', 'y', 'x'][-ndim:]
     else:
-        return map(lambda i: 'x' + str(i), range(ndim))
+        return list(map(lambda i: 'x' + str(i), range(ndim)))
 
 
 def default_size_columns(ndim, isotropic):


### PR DESCRIPTION
solution for error "unsupported operand type(s) for +: 'map' and 'list'" when locating features in 4D image sequence: default_pos_columns should return a list.