### PR TITLE
Update motion.py to fix TypeError: mean() got an unexpected keyword argument 'level' on emsd function

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -232,8 +232,8 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
         msds.append(msd(ptraj, mpp, fps, max_lagtime, True, pos_columns))
         ids.append(pid)
     msds = pandas_concat(msds, keys=ids, names=['particle', 'frame'])
-    results = msds.mul(msds['N'], axis=0).mean(level=1)  # weighted average
-    results = results.div(msds['N'].mean(level=1), axis=0)  # weights normalized
+    results = msds.mul(msds['N'], axis=0).groupby(level=1).mean()  # weighted average
+    results = results.div(msds['N'].groupby(level=1).mean(), axis=0)  # weights normalized
     # Above, lagt is lumped in with the rest for simplicity and speed.
     # Here, rebuild it from the frame index.
     if not detail:


### PR DESCRIPTION
Running the walkthrough with pandas 1.5.3 I was getting this futurewarning when calculating the average mean square displacement with emsd function in the motion.py module

```
/usr/local/lib/python3.10/dist-packages/trackpy/motion.py:235: FutureWarning: Using the level keyword in DataFrame and Series aggregations is deprecated and will be removed in a future version. Use groupby instead. df.median(level=1) should use df.groupby(level=1).median().
  results = msds.mul(msds['N'], axis=0).mean(level=1)  # weighted average
/usr/local/lib/python3.10/dist-packages/trackpy/motion.py:236: FutureWarning: Using the level keyword in DataFrame and Series aggregations is deprecated and will be removed in a future version. Use groupby instead. df.median(level=1) should use df.groupby(level=1).median().
  results = results.div(msds['N'].mean(level=1), axis=0)  # weights normalized
```

Running with pandas 2.0.3 I get this error:

![image](https://github.com/soft-matter/trackpy/assets/5448255/bfe5a539-7452-4310-972b-77666b918021)


After modification I can reproduce the same results as in the walkthrough

![image](https://github.com/soft-matter/trackpy/assets/5448255/9ec56d88-7ea5-443a-91ad-d6b5564f08f0)

Sending back in case you want to include, I tested this modified version works fine back to pandas 1.5.3
Thanks for this great library!

