### PR TITLE
MNT: numpy v2.0 compatibility

### DIFF
--- a/doc/releases/v0.6.txt
+++ b/doc/releases/v0.6.txt
@@ -1,3 +1,16 @@
+v0.6.4
+------
+
+trackpy v0.6.4 is a minor compatibility update for numpy v2.0
+
+Dependencies
+~~~~~~~~~~~~
+- Adds support for numpy 2.0 (@nkeim, #770). Note that as of this writing,
+  pytables (an optional dependency for trackpy) does not yet support
+  numpy 2.0 (see https://github.com/PyTables/PyTables/issues/1172 and 
+  #768).
+
+
 v0.6.3
 ------
 

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -33,7 +33,7 @@ class SubnetLinker:
         self.max_links = min(self.MAX, dest_size)
         self.best_pairs = None
         self.cur_pairs = deque([])
-        self.best_sum = np.Inf
+        self.best_sum = np.inf
         self.d_taken = set()
         self.cur_sum = 0
 


### PR DESCRIPTION
This is a partial fix for #768 within the trackpy source, by replacing a reference to the deprecated `np.Inf`.