### PR TITLE
Fix issue #772, Incorrect zeros included in emsd average when particles are dropped 

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -108,11 +108,15 @@ def _msd_gaps(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
 
     result = pd.DataFrame(_msd_iter(pos.values, lagtimes),
                           columns=result_columns, index=lagtimes)
-    result['msd'] = result[result_columns[-len(pos_columns):]].sum(1)
+    result['msd'] = result[result_columns[-len(pos_columns):]].sum(1, skipna=False)
     if detail:
         # effective number of measurements
         # approximately corrected with number of gaps
         result['N'] = _msd_N(len(pos), lagtimes) * len(traj) / len(pos)
+        # If MSD is nan that's because there were zero datapoints. Reset N to 0.
+        result['N'] = np.where(result['msd'].isna(), 0, result['N'])
+        # An alternative option at this point would be to scale up N for the rest of the column
+        
     result['lagt'] = result.index.values/float(fps)
     result.index.name = 'lagt'
     return result
@@ -232,6 +236,10 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
         msds.append(msd(ptraj, mpp, fps, max_lagtime, True, pos_columns))
         ids.append(pid)
     msds = pandas_concat(msds, keys=ids, names=['particle', 'frame'])
+    
+    # remove np.nan because it would make the rest of the calculation break
+    msds['msd'] = np.where(msds['msd'].isna(), 0, msds['msd'])
+
     results = msds.mul(msds['N'], axis=0).groupby(level=1).mean()  # weighted average
     results = results.div(msds['N'].groupby(level=1).mean(), axis=0)  # weights normalized
     # Above, lagt is lumped in with the rest for simplicity and speed.


### PR DESCRIPTION
I've tested this code with imsd() and emsd() on test data and it works, and on actual movie data and it is more accurate but it doesn't make as big a difference as I feared it would. So Issue #772 isn't so bad unless there are a lot of gaps in the data.

Pros of accepting my pull-request: Slightly more accurate emsd data! If there are a lot of gaps, then it's MUCH MUCH more accurate.

Cons: It takes slightly more time to run. With timit, I see 30.6 ms ± 1.55 ms per loop before my edits versus 32.1 ms ± 1.43 ms per loop after my edits.


Issue #772 occurs when there are gaps in the data, so the problem shows up in _msd_gaps().

Here are the edits:
I updated _msd_gaps() with "skipna=False" on the sum() function. This way values based on a lack of data will show up as NaN (instead of showing up as zero).

I also added some code to reset the estimated number of datapoints N to be 0 if there is no data.
    result['N'] = np.where(result['msd'].isna(), 0, result['N'])
 
I was hoping this would be enough but it created another problem that I had to take care of: When the emsd is calculated, there's a problem because we are averaging in a NaN (albeit weighted as N=0), and it turns out NaN * 0 = NaN. I wanted it to come out to zero. So I had to reset the NaN to zero again. Awkward, but it works. Then it's 0*0 = 0, which is the weight I wanted, and it calculates the emsd correctly.

    # remove np.nan because it would make the rest of the calculation break
    msds['msd'] = np.where(msds['msd'].isna(), 0, msds['msd'])

So this update does provide a more accurate emsd() calculation, and it removes the weird DROPS that show up in the imsd data (see Walkthrough output 31).

I plan to use this version going forward because I can't stand inaccuracies!