### PR TITLE
Bump versions in CI/CD (and minor test fixes)

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.8, 3.9, "3.10", "3.11"]
+        python: ["3.9", "3.11", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -10,9 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python: "3.8"
-            display_name: "2019"
-            deps: "numpy==1.18.* scipy==1.4.* matplotlib==3.1.* pandas==1.0.* tables==3.6.* scikit-learn==0.22.* numba==0.47.* llvmlite==0.31.*"
           - python: "3.9"
             display_name: "2020"
             deps: "numpy==1.19.* scipy==1.5.* matplotlib==3.3.* pandas==1.1.* tables==3.6.* scikit-learn==0.24.* numba==0.53.* llvmlite==0.36.*"
@@ -23,8 +20,15 @@ jobs:
             display_name: "2022"
             deps: "numpy==1.24.* scipy==1.9.* matplotlib==3.6.* pandas==2.0.* tables==3.8.* scikit-learn==1.1.* numba==0.57.* llvmlite==0.40.*"
           - python: "3.12"
-            display_name: "2023, no numba"  # no numba support yet
-            deps: "numpy==1.26.* scipy==1.11.* matplotlib==3.8.* pandas==2.1.* tables==3.9.* scikit-learn==1.3.*"
+            display_name: "2023"
+            deps: "numpy==1.26.* scipy==1.11.* matplotlib==3.8.* pandas==2.1.* tables==3.9.* scikit-learn==1.3.* numba==0.59.* llvmlite==0.42.*"
+          - python: "3.13"
+            display_name: "2024"
+            deps: "numpy==2.1.* scipy==1.14.* matplotlib==3.9.* pandas==2.2.* tables==3.10.* scikit-learn==1.5.* numba==0.61.* llvmlite==0.44.*"
+          - python: "3.13"
+            display_name: "latest (no numba)"
+            deps: "numpy scipy matplotlib pandas tables scikit-learn"
+
 
     steps:
       - uses: actions/checkout@v4

--- a/trackpy/linking/legacy.py
+++ b/trackpy/linking/legacy.py
@@ -549,7 +549,7 @@ def link_df(features, search_range, memory=0,
                 raise UnknownLinkingError("There are more labels than "
                                           "particles to be labeled in Frame "
                                           "{}.".format(frame_no))
-        features['particle'].update(labels)
+        features.loc[labels.index, 'particle'] = labels
         if diagnostics:
             _add_diagnostic_columns(features, level)
 
@@ -689,7 +689,7 @@ def link_df_iter(features, search_range, memory=0,
                 raise UnknownLinkingError("There are more labels than "
                                           "particles to be labeled in Frame "
                                            "{}.".format(frame_no))
-        features['particle'].update(labels)
+        features.loc[labels.index, 'particle'] = labels
         if diagnostics:
             _add_diagnostic_columns(features, labeled_level)
 

--- a/trackpy/linking/legacy.py
+++ b/trackpy/linking/legacy.py
@@ -764,7 +764,7 @@ def _gen_levels_df(df, pos_columns, t_column, diagnostics=False):
 def _add_diagnostic_columns(features, level):
     """Copy the diagnostic information stored in each particle to the
     corresponding columns in 'features'. Create columns as needed."""
-    diag = pd.DataFrame({x.id: x.diag for x in level}, dtype=object).T
+    diag = pd.DataFrame({x.id: x.diag for x in level}, dtype=float).T
     diag.columns = ['diag_' + cn for cn in diag.columns]
     for cn in diag.columns:
         if cn not in features.columns:

--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -353,7 +353,7 @@ def plot_traj(traj, colorby='particle', mpp=None, label=False,
     if label:
         unstacked = traj.set_index([t_column, 'particle'])[pos_columns].unstack()
         first_frame = int(traj[t_column].min())
-        coords = unstacked.fillna(method='backfill').stack().loc[first_frame]
+        coords = unstacked.bfill().stack().loc[first_frame]
         for particle_id, coord in coords.iterrows():
             ax.text(*coord.tolist(), s="%d" % particle_id,
                     horizontalalignment='center',

--- a/trackpy/tests/common.py
+++ b/trackpy/tests/common.py
@@ -75,13 +75,13 @@ class TrackpyFrame(np.ndarray):
             return
         self.frame_no = getattr(obj, 'frame_no', None)
 
-    def __array_wrap__(self, out_arr, context=None):
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
         # Handle scalars so as not to break ndimage.
         # See http://stackoverflow.com/a/794812/1221924
         if out_arr.ndim == 0:
             return out_arr[()]
 
-        return np.ndarray.__array_wrap__(self, out_arr, context)
+        return np.ndarray.__array_wrap__(self, out_arr, context, return_scalar)
 
 
 class TrackpyImageSequence:

--- a/trackpy/tests/test_feature_saving.py
+++ b/trackpy/tests/test_feature_saving.py
@@ -45,7 +45,7 @@ class FeatureSavingTester:
         v = TrackpyImageSequence(os.path.join(directory, '*.png'))
         self.v = [tp.invert_image(v[i]) for i in range(2)]
         # mass depends on pixel dtype, which differs per reader
-        minmass = self.v[0].max() * 2
+        minmass = self.v[0].max().item() * 2
         self.PARAMS = {'diameter': 11, 'minmass': minmass}
         if batch_params is not None:
             self.PARAMS.update(batch_params)

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -9,7 +9,7 @@ from pandas.testing import (
 from numpy.testing import assert_almost_equal
 
 import trackpy as tp
-from trackpy.utils import pandas_sort, pandas_concat
+from trackpy.utils import pandas_sort, pandas_concat, is_pandas_since_220
 from trackpy.tests.common import StrictTestCase
 
 
@@ -228,7 +228,10 @@ class TestSpecial(StrictTestCase):
     def test_theta_entropy(self):
         # just a smoke test
         theta_entropy = lambda x: tp.motion.theta_entropy(x, plot=False)
-        self.steppers.groupby('particle').apply(theta_entropy, include_groups=False)
+        self.steppers.groupby('particle').apply(
+            theta_entropy,
+            **({"include_groups": False} if is_pandas_since_220 else {}),
+        )
 
     def test_relate_frames(self):
         # Check completeness of output

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -228,7 +228,7 @@ class TestSpecial(StrictTestCase):
     def test_theta_entropy(self):
         # just a smoke test
         theta_entropy = lambda x: tp.motion.theta_entropy(x, plot=False)
-        self.steppers.groupby('particle').apply(theta_entropy)
+        self.steppers.groupby('particle').apply(theta_entropy, include_groups=False)
 
     def test_relate_frames(self):
         # Check completeness of output

--- a/trackpy/utils.py
+++ b/trackpy/utils.py
@@ -23,6 +23,14 @@ try:
 except ValueError:  # Probably a development version
     is_pandas_since_023 = True
 
+
+try:
+    is_pandas_since_220 = (LooseVersion(pd.__version__) >=
+                           LooseVersion('2.2.0'))
+except ValueError:  # Probably a development version
+    is_pandas_since_220 = True
+
+
 # Emit warnings in refine.least_squares for scipy 1.5
 try:
     is_scipy_15 = LooseVersion("1.5.0") <= LooseVersion(scipy.__version__) < LooseVersion('1.6.0')


### PR DESCRIPTION
Hi @nkeim ,

Seemed good to have a look at the trackpy testing against recent versions. Last time was already some months ago.
There wasn't much to fix, actually, the only real errors originated from deprecated usage of pandas/numpy in tests themselves. 

I did tackle a bunch of pandas FutureWarnings, I think I got the most important ones, but there are still some pending.

Don't think a release is necessary right away.

