### PR TITLE
MNT: Don't test py3.9 on macos due to conda issues

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -11,6 +11,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.9", "3.11", "3.13"]
+        # Exclude macOS with Python 3.9 due to compatibility issues with conda
+        exclude:
+          - os: macos-latest
+            python: "3.9"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
For the past several weeks (at least), the conda environment with Python 3.9 on macOS has a binary packaging issue, apparently with numpy. Because 3.10 was released in 2021, and we are testing on other platforms, there's no need to keep running this failing check.