### PR TITLE
MNT: Avoid deprecated DataFrame.applymap

### DIFF
--- a/trackpy/plots.py
+++ b/trackpy/plots.py
@@ -640,7 +640,7 @@ def subpx_bias(f, pos_columns=None):
             pos_columns = ['x', 'y', 'z']
         else:
             pos_columns = ['x', 'y']
-    axlist = f[pos_columns].applymap(lambda x: x % 1).hist()
+    axlist = f[pos_columns].map(lambda x: x % 1).hist()
     return axlist
 
 @make_axes

--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -128,6 +128,11 @@ class TestPlots(StrictTestCase):
         fit_powerlaw(em)
         fit_powerlaw(em, plot=False)
 
+    def test_subpx_bias(self):
+        # smoke_test
+        suppress_plotting()
+        plots.subpx_bias(self.sparse)
+
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
When running the walkthrough with recent Pandas, this avoids the warning `FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.`