### PR TITLE
TST: Test subpx_bias

### DIFF
--- a/trackpy/tests/test_plots.py
+++ b/trackpy/tests/test_plots.py
@@ -128,6 +128,11 @@ class TestPlots(StrictTestCase):
         fit_powerlaw(em)
         fit_powerlaw(em, plot=False)
 
+    def test_subpx_bias(self):
+        # smoke_test
+        suppress_plotting()
+        plots.subpx_bias(self.sparse)
+
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
Code coverage: This adds a (passing) smoke test for `plots.subpx_bias`.

Supersedes #786 