### PR TITLE
BLD: Switch docs to PyData theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,6 @@
 
 import sys
 import os
-import sphinx_bootstrap_theme
 import matplotlib as mpl
 mpl.use("Agg")
 
@@ -40,7 +39,7 @@ extensions = ['sphinx.ext.autodoc',
              ]
 
 extlinks = {'issue': ('https://github.com/soft-matter/trackpy/issues/%s',
-                      'GH')}
+                      'GH #%s')}
 
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js'
 
@@ -118,27 +117,30 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'bootstrap'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-                      'source_link_position': "footer",
-                      'bootswatch_theme': "spacelab",
-                      'navbar_sidebarrel': False,
-                      'bootstrap_version': "3",
-                      'navbar_links': [("Tutorial", "tutorial")],
+                      "header_links_before_dropdown": 2,
+                      "navbar_align": "right",
+                      "secondary_sidebar_items": ["page-toc"],
                      }
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = "trackpy " + release
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+html_short_title = "trackpy " + release
+
+# Only show left sidebar in API reference
+html_sidebars = {
+    "[!generated]**": [],
+    "api": ["sidebar-nav-bs"],
+    "generated/trackpy.*": ["sidebar-nav-bs"],
+}
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,7 +125,11 @@ html_theme = 'pydata_sphinx_theme'
 html_theme_options = {
                       "header_links_before_dropdown": 2,
                       "navbar_align": "right",
-                      "secondary_sidebar_items": ["page-toc"],
+                      "secondary_sidebar_items": {
+                        "*": ["page-toc"],
+                        "generated/trackpy.*": [],
+
+                      }
                      }
 
 # The name for this set of Sphinx documents.  If None, it defaults to
@@ -137,7 +141,8 @@ html_short_title = "trackpy " + release
 
 # Only show left sidebar in API reference
 html_sidebars = {
-    "[!generated]**": [],
+    "*": [],
+    "tutorial/*": [],
     "api": ["sidebar-nav-bs"],
     "generated/trackpy.*": ["sidebar-nav-bs"],
 }


### PR DESCRIPTION
The sphinx-bootstrap theme for the docs was last updated in 2022, and it had accumulated some formatting glitches. This PR switches to the [PyData Theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html). That is also based on bootstrap, so the thumbnails on the index page still look OK. I did some basic work to clean up the navigation elements and only show the sidebars when appropriate.

If there are no objections, I'll merge this and update the "dev" docs, and we can live with this for a bit before the v0.7 release.