### PR TITLE
FIX: Stable degeneracy

### DIFF
--- a/trackpy/linking/utils.py
+++ b/trackpy/linking/utils.py
@@ -166,6 +166,10 @@ class Point:
     def track(self):
         """Returns the track that this :class:`Point` is in.  May be `None` """
         return self._track
+    
+    def __hash__(self):
+        """Returns a deterministic value so that set() order is more stable."""
+        return self.uuid
 
 
 class TrackUnstored:

--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -16,6 +16,7 @@ from trackpy.tests.test_linking import SubnetNeededTests, _skip_if_no_sklearn
 class FindLinkTests(SubnetNeededTests):
     def setUp(self):
         super().setUp()
+        self.coordinates_exact = False  # b/c we roundtrip to images
         self.linker_opts['separation'] = 10
         self.linker_opts['diameter'] = 15
         self.linker_opts['preprocess'] = False

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -499,6 +499,53 @@ class SubnetNeededTests(CommonTrackingTests):
         pandas_sort(actual, ['x'], inplace=True)
         assert_equal(actual['particle'].values.astype(int),
                      case2['particle'].values.astype(int))
+        
+    def test_degeneracy_forward(self):
+        """Check that a trivial degenerate subnet is resolved stably.
+
+        Also checks that the result matches a known value. This is likely
+        but NOT guaranteed. It may be wise to remove this check in the future.
+        """
+        if not getattr(self, 'coordinates_exact', True): 
+            return  # Test will not be meaningful
+        result_counts = {0: 0, 1: 0}
+        for i in range(100):
+            # degen_df = pd.DataFrame({
+            #     'y':     [-1, 1, 0],
+            #     'x':     [-1, 1, 0],
+            #     'frame': [ 0, 0, 1]
+            # })
+            degen_df = pd.DataFrame({
+                'y':     [0, -1, 1],
+                'x':     [0, -1, 1],
+                'frame': [0,  1, 1]
+            })
+            out = self.link(degen_df, search_range=1.8, t_column="frame")
+            result_counts[out.particle.iloc[-1]] += 1
+        # There are two degenerate forward candidates for the last frame.
+        assert any((c == 100 for c in result_counts.values()))  # Stable
+        assert result_counts[1] == 100  # Deterministic
+
+    def test_degeneracy_source(self):
+        """Check that a trivial degenerate subnet is resolved stably.
+
+        Also checks that the result matches a known value. This is likely
+        but NOT guaranteed. It may be wise to remove this check in the future.
+        """
+        if not getattr(self, 'coordinates_exact', True):  
+            return  # Test will not be meaningful
+        result_counts = {0: 0, 1: 0}
+        for i in range(100):
+            degen_df = pd.DataFrame({
+                'y':     [-1, 1, 0],
+                'x':     [-1, 1, 0],
+                'frame': [ 0, 0, 1]
+            })
+            out = self.link(degen_df, search_range=1.8, t_column="frame")
+            result_counts[out.particle.iloc[-1]] += 1
+        # There are two degenerate source candidates for the last frame.
+        assert any((c == 100 for c in result_counts.values()))  # Stable
+        assert result_counts[0] == 100  # Deterministic
 
     def test_memory(self):
         """A unit-stepping trajectory and a random walk are observed
@@ -564,6 +611,27 @@ class SubnetNeededTests(CommonTrackingTests):
         f1.reindex(np.random.permutation(f1.index))
         actual = self.link(f1, 5, memory=1)
         assert_traj_equal(actual, expected)
+
+    def test_memory_degeneracy(self):
+        """Check that with memory, degeneracies are resolved stably.
+
+        Also checks that the result matches a known value. This is likely
+        but NOT guaranteed. It may be wise to remove this check in the future.
+        """
+        if not getattr(self, 'coordinates_exact', True): 
+            return  # Test will not be meaningful
+        result_counts = {0: 0, 1: 0}
+        for i in range(100):
+            mem_df = pd.DataFrame({
+                'y':     [-1, 1, 100, 0],
+                'x':     [-1, 1, 100, 0],
+                'frame': [ 0, 0,   1, 2]
+            })
+            out = self.link(mem_df, search_range=1.8, memory=1, t_column="frame")
+            result_counts[out.particle.iloc[-1]] += 1
+        # With memory > 0, there are two degenerate candidates for the last frame.
+        assert any((c == 100 for c in result_counts.values()))  # Stable
+        assert result_counts[0] == 100  # Deterministic
 
     def test_pathological_tracking(self):
         level_count = 5

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -501,11 +501,7 @@ class SubnetNeededTests(CommonTrackingTests):
                      case2['particle'].values.astype(int))
         
     def test_degeneracy_forward(self):
-        """Check that a trivial degenerate subnet is resolved stably.
-
-        Also checks that the result matches a known value. This is likely
-        but NOT guaranteed. It may be wise to remove this check in the future.
-        """
+        """Check that a trivial degenerate subnet is resolved stably."""
         if not getattr(self, 'coordinates_exact', True): 
             return  # Test will not be meaningful
         result_counts = {0: 0, 1: 0}
@@ -524,14 +520,9 @@ class SubnetNeededTests(CommonTrackingTests):
             result_counts[out.particle.iloc[-1]] += 1
         # There are two degenerate forward candidates for the last frame.
         assert any((c == 100 for c in result_counts.values()))  # Stable
-        assert result_counts[1] == 100  # Deterministic
 
     def test_degeneracy_source(self):
-        """Check that a trivial degenerate subnet is resolved stably.
-
-        Also checks that the result matches a known value. This is likely
-        but NOT guaranteed. It may be wise to remove this check in the future.
-        """
+        """Check that a trivial degenerate subnet is resolved stably."""
         if not getattr(self, 'coordinates_exact', True):  
             return  # Test will not be meaningful
         result_counts = {0: 0, 1: 0}
@@ -545,7 +536,6 @@ class SubnetNeededTests(CommonTrackingTests):
             result_counts[out.particle.iloc[-1]] += 1
         # There are two degenerate source candidates for the last frame.
         assert any((c == 100 for c in result_counts.values()))  # Stable
-        assert result_counts[0] == 100  # Deterministic
 
     def test_memory(self):
         """A unit-stepping trajectory and a random walk are observed
@@ -613,11 +603,7 @@ class SubnetNeededTests(CommonTrackingTests):
         assert_traj_equal(actual, expected)
 
     def test_memory_degeneracy(self):
-        """Check that with memory, degeneracies are resolved stably.
-
-        Also checks that the result matches a known value. This is likely
-        but NOT guaranteed. It may be wise to remove this check in the future.
-        """
+        """Check that with memory, degeneracies are resolved stably."""
         if not getattr(self, 'coordinates_exact', True): 
             return  # Test will not be meaningful
         result_counts = {0: 0, 1: 0}
@@ -631,7 +617,6 @@ class SubnetNeededTests(CommonTrackingTests):
             result_counts[out.particle.iloc[-1]] += 1
         # With memory > 0, there are two degenerate candidates for the last frame.
         assert any((c == 100 for c in result_counts.values()))  # Stable
-        assert result_counts[0] == 100  # Deterministic
 
     def test_pathological_tracking(self):
         level_count = 5


### PR DESCRIPTION
This resolves #776 in most if not all cases, by making the order of a `set` of `Point` objects non-random. 

While the order of a set is never guaranteed, it is based on the objects' `hash` values. Starting with Python 3.3 [these hashes were randomized](https://docs.python.org/3/reference/datamodel.html#object.__hash__) as a security measure. This issue was causing repeated linking runs to resolve degenerate cases randomly, even within the same session. This PR makes Python use the Point's `uuid` attribute (basically, its serial number) instead.

This PR adds tests to make sure that degenerate linking cases (with and without memory) always resolve the same way within the same session. It does *not* ensure that results are consistent across linkers or across sessions. (It turns out this requires a change to the linking algorithm itself, so it will be a separate PR.)