### PR TITLE
FIX: Stable linking with degeneracy, via sorting

### DIFF
--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -27,7 +27,7 @@ class SubnetLinker:
         self.search_range = search_range
         self.max_size = max_size
         self.s_lst = [s for s in s_sn]
-        self.s_lst.sort(key=lambda x: len(x.forward_cands))
+        self.s_lst.sort(key=lambda p: (len(p.forward_cands), p.uuid))
         self.MAX = len(self.s_lst)
 
         self.max_links = min(self.MAX, dest_size)
@@ -85,7 +85,7 @@ class SubnetLinker:
 
 def nonrecursive_link(source_list, dest_size, search_range, max_size=30, diag=False):
     source_list = list(source_list)
-    source_list.sort(key=lambda x: len(x.forward_cands))
+    source_list.sort(key=lambda p: (len(p.forward_cands), p.uuid))
     MAX = len(source_list)
 
     if MAX > max_size:
@@ -183,7 +183,7 @@ def numba_link(s_sn, dest_size, search_range, max_size=30, diag=False):
     # Then the hard part runs quickly because it is just operating on arrays.
     # We can compile it with numba for outstanding performance.
     max_candidates = 9  # Max forward candidates we expect for any particle
-    src_net = list(s_sn)
+    src_net = sorted(s_sn, key=lambda p: p.uuid)
     nj = len(src_net) # j will index the source particles
     if nj > max_size:
         raise SubnetOversizeException('search_range (aka maxdisp) too large for reasonable performance '

--- a/trackpy/linking/subnetlinker.py
+++ b/trackpy/linking/subnetlinker.py
@@ -183,7 +183,7 @@ def numba_link(s_sn, dest_size, search_range, max_size=30, diag=False):
     # Then the hard part runs quickly because it is just operating on arrays.
     # We can compile it with numba for outstanding performance.
     max_candidates = 9  # Max forward candidates we expect for any particle
-    src_net = sorted(s_sn, key=lambda p: p.uuid)
+    src_net = sorted(s_sn, key=lambda p: (len(p.forward_cands), p.uuid))
     nj = len(src_net) # j will index the source particles
     if nj > max_size:
         raise SubnetOversizeException('search_range (aka maxdisp) too large for reasonable performance '
@@ -427,15 +427,12 @@ def subnet_linker_numba(source_set, dest_set, search_range,
                         hybrid=True, **kwargs):
     """Link a subnet using a numba-accelerated algorithm.
 
-    Since this is meant to be the highest-performance option, it
-    has some special behaviors:
-
-    - Each source particle's forward_cands must be sorted by distance.
-    - If the 'hybrid' option is true, subnets with only 1 source or
-      destination particle, or with at most 4 source particles and
-      4 destination particles, are solved using the recursive
-      pure-Python algorithm, which has much less overhead since
-      it does not convert to a numpy representation.
+    Since this is meant to be the highest-performance option, if the 
+    'hybrid' option is true, subnets with only 1 source or
+    destination particle, or with at most 4 source particles and
+    4 destination particles, are solved using the recursive
+    pure-Python algorithm, which has much less overhead since
+    it does not convert to a numpy representation.
     """
     lss = len(source_set)
     lds = len(dest_set)

--- a/trackpy/tests/test_find_link.py
+++ b/trackpy/tests/test_find_link.py
@@ -16,6 +16,7 @@ from trackpy.tests.test_linking import SubnetNeededTests, _skip_if_no_sklearn
 class FindLinkTests(SubnetNeededTests):
     def setUp(self):
         super().setUp()
+        self.coordinates_exact = False  # b/c we roundtrip to images
         self.linker_opts['separation'] = 10
         self.linker_opts['diameter'] = 15
         self.linker_opts['preprocess'] = False

--- a/trackpy/tests/test_linking.py
+++ b/trackpy/tests/test_linking.py
@@ -499,6 +499,43 @@ class SubnetNeededTests(CommonTrackingTests):
         pandas_sort(actual, ['x'], inplace=True)
         assert_equal(actual['particle'].values.astype(int),
                      case2['particle'].values.astype(int))
+        
+    def test_degeneracy_forward(self):
+        """Check that a trivial degenerate subnet is resolved stably."""
+        if not getattr(self, 'coordinates_exact', True): 
+            return  # Test will not be meaningful
+        result_counts = {0: 0, 1: 0}
+        for i in range(100):
+            # degen_df = pd.DataFrame({
+            #     'y':     [-1, 1, 0],
+            #     'x':     [-1, 1, 0],
+            #     'frame': [ 0, 0, 1]
+            # })
+            degen_df = pd.DataFrame({
+                'y':     [0, -1, 1],
+                'x':     [0, -1, 1],
+                'frame': [0,  1, 1]
+            })
+            out = self.link(degen_df, search_range=1.8, t_column="frame")
+            result_counts[out.particle.iloc[-1]] += 1
+        # There are two degenerate forward candidates for the last frame.
+        assert any((c == 100 for c in result_counts.values()))  # Stable
+
+    def test_degeneracy_source(self):
+        """Check that a trivial degenerate subnet is resolved stably."""
+        if not getattr(self, 'coordinates_exact', True):  
+            return  # Test will not be meaningful
+        result_counts = {0: 0, 1: 0}
+        for i in range(100):
+            degen_df = pd.DataFrame({
+                'y':     [-1, 1, 0],
+                'x':     [-1, 1, 0],
+                'frame': [ 0, 0, 1]
+            })
+            out = self.link(degen_df, search_range=1.8, t_column="frame")
+            result_counts[out.particle.iloc[-1]] += 1
+        # There are two degenerate source candidates for the last frame.
+        assert any((c == 100 for c in result_counts.values()))  # Stable
 
     def test_memory(self):
         """A unit-stepping trajectory and a random walk are observed
@@ -564,6 +601,22 @@ class SubnetNeededTests(CommonTrackingTests):
         f1.reindex(np.random.permutation(f1.index))
         actual = self.link(f1, 5, memory=1)
         assert_traj_equal(actual, expected)
+
+    def test_memory_degeneracy(self):
+        """Check that with memory, degeneracies are resolved stably."""
+        if not getattr(self, 'coordinates_exact', True): 
+            return  # Test will not be meaningful
+        result_counts = {0: 0, 1: 0}
+        for i in range(100):
+            mem_df = pd.DataFrame({
+                'y':     [-1, 1, 100, 0],
+                'x':     [-1, 1, 100, 0],
+                'frame': [ 0, 0,   1, 2]
+            })
+            out = self.link(mem_df, search_range=1.8, memory=1, t_column="frame")
+            result_counts[out.particle.iloc[-1]] += 1
+        # With memory > 0, there are two degenerate candidates for the last frame.
+        assert any((c == 100 for c in result_counts.values()))  # Stable
 
     def test_pathological_tracking(self):
         level_count = 5


### PR DESCRIPTION
This fixes #776 by making sure candidates are considered in order during subnet linking. It supersedes #801 because that fix's performance regression was much worse (and, it did not actually guarantee ordering).

Each subnet linker implementation now sorts source candidates by the number of forward candidates first, and then by their uuid. The performance penalty appears to be within 1%, too small to measure easily.

Previously, the numba linker did not sort by the number of forward candidates, which is a helpful optimization for this depth-first algorithm. Because the core linking algorithm was so fast, this optimization was not always worthwhile in practice. However, introducing sorting by uuid in the numba linker caused a serious performance regression for large subnets, much worse than for the other linker implementations. I found that when the numba linker also sorts by forward candidates, the regression seems to go away. So I include that optimization in this PR.