### PR TITLE
FIX: Zero cosmask at its center

### DIFF
--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -81,7 +81,9 @@ def sinmask(radius):
 @memo
 def cosmask(radius):
     "Sin of theta_mask"
-    return np.cos(2*theta_mask(radius))
+    result = np.cos(2 * theta_mask(radius))
+    result[validate_tuple(radius, 2)] = 0
+    return result
 
 
 @memo

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -36,6 +36,18 @@ def compare(shape, count, radius, noise_level, **kwargs):
     return actual, expected
 
 
+class TestCosmask(StrictTestCase):
+    def test_center_is_zero(self):
+        radius = (2, 3)
+        expected = np.cos(2 * tp.masks.theta_mask(radius))
+        expected[radius] = 0
+
+        actual = tp.masks.cosmask(radius)
+
+        assert_allclose(actual, expected)
+        assert actual[radius] == 0
+
+
 class OldMinmass(StrictTestCase):
     def check_skip(self):
         pass
@@ -643,6 +655,17 @@ class CommonFeatureIdentificationTests:
                            engine=self.engine)['ecc']
         expected = ECC
         assert_allclose(actual, expected, atol=0.1)
+
+    def test_single_pixel_eccentricity(self):
+        self.check_skip()
+        image = np.zeros((7, 7), dtype='uint8')
+        image[3, 3] = 1
+
+        result = refine_com_arr(image, image, 2, np.array([[3, 3]]),
+                                engine=self.engine)
+
+        assert np.isfinite(result[0, 4])
+        assert_allclose(result[0, 4], 0)
 
     def test_ep(self):
         # Test whether the estimated static error equals the rms deviation from


### PR DESCRIPTION
## Summary

- set the geometric center of `cosmask` to zero
- add a direct mask regression test
- add a single-pixel eccentricity regression for both Python and numba engines

## Root cause

At the geometric center, `theta_mask` evaluates `arctan2(0, 0)` as zero. The previous `cos(2 * theta)` calculation therefore contributed `1` at the center, even though the eccentricity calculation expects that undefined angular contribution to be zero. For a center-only feature, this produced an eccentricity of `1000000.0` instead of `0.0`.

Fixes #728.

## Validation

Fresh publication checks on upstream commit `186fa02f048ef0902b6f9804874b701345a22398`:

- reproduced the center value as `1.0` before the patch
- verified the center is `0.0` after the patch and every non-center mask value is unchanged
- syntax compilation and `git diff --check` passed

Archived test evidence from the same upstream commit, with its manifest reverified before publication:

- focused regression tests: 5 passed
- adjacent mask tests: 8 passed
- adjacent feature/refine tests: 64 passed
- broader non-slow suite: 958 passed and 95 skipped, with one known failure because the historical `reproducibility_v0.4.npz` fixture retains 14 previous eccentricity values

## Automation disclosure

This pull request was prepared and submitted by an OpenAI Codex agent operating on behalf of @sapunyangkut. The agent reproduced the bug, applied the minimal patch, verified the test evidence, and checked the repository's public contribution rules before submission.
